### PR TITLE
feat(docs): centralize Helm version refs with mkdocs-macros-plugin

### DIFF
--- a/docs/design-decisions/index.md
+++ b/docs/design-decisions/index.md
@@ -1,6 +1,6 @@
 # Design Decisions
 
-This section documents the key architectural decisions made during Kubernaut's development. Decisions marked **(v1.1)** are new in v1.1.0-rc0.
+This section documents the key architectural decisions made during Kubernaut's development. Decisions marked **(v1.1)** are new in {{ image_tag }}.
 
 ## Architecture
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -275,7 +275,7 @@ helm install kubernaut charts/kubernaut/ \
 
 ```bash
 helm install kubernaut oci://quay.io/kubernaut-ai/charts/kubernaut \
-  --version 1.1.0-rc0 \
+  --version {{ chart_version }} \
   --namespace kubernaut-system \
   -f my-values.yaml
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -136,6 +136,7 @@ spec:
 
 And the Prometheus alerting rule detects crash loops:
 
+{% raw %}
 ```yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -162,6 +163,7 @@ spec:
           Container {{ $labels.container }} in pod {{ $labels.pod }} is in
           CrashLoopBackOff with {{ $value | humanize }} restarts in the last 3 minutes.
 ```
+{% endraw %}
 
 ## Step 2: Verify the Healthy State
 

--- a/docs/operations/disconnected-install.md
+++ b/docs/operations/disconnected-install.md
@@ -44,7 +44,7 @@ All published under `quay.io/kubernaut-ai/` with a tag matching the chart versio
 | `registry.redhat.io/rhel10/postgresql-16` | PostgreSQL 16 (Red Hat RHEL10) |
 | `registry.redhat.io/rhel10/valkey-8` | Valkey 8 (Red Hat RHEL10) |
 | `registry.redhat.io/openshift4/ose-cli-rhel9:v4.17` | OCP CLI for TLS certificate hook Jobs |
-| `quay.io/kubernaut-ai/db-migrate:v1.1.0-rc0` | Database migrations (goose + psql on UBI9) |
+| `quay.io/kubernaut-ai/db-migrate:{{ image_tag }}` | Database migrations (goose + psql on UBI9) |
 
 !!! note
     The Kubernetes Event Exporter is disabled on OCP (`eventExporter.enabled=false` in `values-ocp.yaml`) and is excluded from the mirror list.
@@ -55,7 +55,7 @@ Use the included script to extract the exact images from the chart templates:
 
 ```bash
 ./hack/airgap/generate-image-list.sh \
-  --set global.image.tag=v1.1.0-rc0 \
+  --set global.image.tag={{ image_tag }} \
   -f charts/kubernaut/values-ocp.yaml
 ```
 
@@ -71,7 +71,7 @@ Copy the template and replace the version placeholder:
 
 ```bash
 cp hack/airgap/imageset-config.yaml.tmpl imageset-config.yaml
-sed -i 's/<VERSION>/v1.1.0-rc0/g' imageset-config.yaml
+sed -i 's/<VERSION>/{{ image_tag }}/g' imageset-config.yaml
 ```
 
 The resulting file lists every image under `mirror.additionalImages`:
@@ -84,10 +84,10 @@ storageConfig:
     path: ./kubernaut-mirror
 mirror:
   additionalImages:
-    - name: quay.io/kubernaut-ai/gateway:v1.1.0-rc0
-    - name: quay.io/kubernaut-ai/datastorage:v1.1.0-rc0
+    - name: quay.io/kubernaut-ai/gateway:{{ image_tag }}
+    - name: quay.io/kubernaut-ai/datastorage:{{ image_tag }}
     # ... all 10 Kubernaut services ...
-    - name: quay.io/kubernaut-ai/db-migrate:v1.1.0-rc0
+    - name: quay.io/kubernaut-ai/db-migrate:{{ image_tag }}
     - name: registry.redhat.io/rhel10/postgresql-16
     - name: registry.redhat.io/rhel10/valkey-8
     - name: registry.redhat.io/openshift4/ose-cli-rhel9:v4.17
@@ -109,16 +109,16 @@ Replace `<mirror-registry>` with your private registry hostname (e.g., `mirror.c
 
     ```bash
     skopeo copy \
-      docker://quay.io/kubernaut-ai/gateway:v1.1.0-rc0 \
-      docker://harbor.corp/kubernaut-ai/gateway:v1.1.0-rc0
+      docker://quay.io/kubernaut-ai/gateway:{{ image_tag }} \
+      docker://harbor.corp/kubernaut-ai/gateway:{{ image_tag }}
     ```
 
     For flat registries (quay.io, Docker Hub) use dash-joined names:
 
     ```bash
     skopeo copy \
-      docker://quay.io/kubernaut-ai/gateway:v1.1.0-rc0 \
-      docker://quay.io/myorg/kubernaut-ai-gateway:v1.1.0-rc0
+      docker://quay.io/kubernaut-ai/gateway:{{ image_tag }} \
+      docker://quay.io/myorg/kubernaut-ai-gateway:{{ image_tag }}
     ```
 
     `oc mirror` is preferred because it processes all images in one pass and preserves multi-arch manifests.
@@ -128,8 +128,8 @@ Replace `<mirror-registry>` with your private registry hostname (e.g., `mirror.c
 
     ```bash
     skopeo copy --override-arch=amd64 --override-os=linux \
-      docker://quay.io/kubernaut-ai/gateway:v1.1.0-rc0 \
-      docker://<ocp-registry>/kubernaut-system/kubernaut-ai-gateway:v1.1.0-rc0
+      docker://quay.io/kubernaut-ai/gateway:{{ image_tag }} \
+      docker://<ocp-registry>/kubernaut-system/kubernaut-ai-gateway:{{ image_tag }}
     ```
 
     This limitation does not affect `oc mirror`, which handles the OCP registry natively.
@@ -221,7 +221,7 @@ valkey:
 
 hooks:
   migrations:
-    image: <mirror-registry>/kubernaut-ai/db-migrate:v1.1.0-rc0
+    image: <mirror-registry>/kubernaut-ai/db-migrate:{{ image_tag }}
   tlsCerts:
     image: <mirror-registry>/openshift4/ose-cli-rhel9:v4.17
 ```
@@ -405,11 +405,11 @@ If the PostgreSQL pod is in `ImagePullBackOff`, mirror `registry.redhat.io/rhel1
 ```bash
 # Nested registry (separator="/"):
 skopeo list-tags docker://<mirror-registry>/kubernaut-ai/gateway
-skopeo inspect docker://<mirror-registry>/kubernaut-ai/gateway:v1.1.0-rc0
+skopeo inspect docker://<mirror-registry>/kubernaut-ai/gateway:{{ image_tag }}
 
 # Flat registry (separator="-"):
 skopeo list-tags docker://<mirror-registry>/kubernaut-ai-gateway
-skopeo inspect docker://<mirror-registry>/kubernaut-ai-gateway:v1.1.0-rc0
+skopeo inspect docker://<mirror-registry>/kubernaut-ai-gateway:{{ image_tag }}
 ```
 
 ---

--- a/docs/operations/event-exporter.md
+++ b/docs/operations/event-exporter.md
@@ -31,6 +31,7 @@ Set `eventExporter.enabled=false` to skip deploying the Event Exporter. This is 
 
 The ConfigMap `event-exporter-config` controls which events are forwarded:
 
+{% raw %}
 ```yaml
 logLevel: debug
 logFormat: json
@@ -56,6 +57,7 @@ receivers:
       headers:
         Content-Type: application/json
 ```
+{% endraw %}
 
 ### Key Settings
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -69,7 +69,7 @@ All values are validated against `values.schema.json`. Run `helm lint` to check 
 | `global.nodeSelector` | Global node selector applied to all pods | `{}` |
 | `global.tolerations` | Global tolerations applied to all pods | `[]` |
 
-Image paths are constructed as `{registry}{separator}{namespace}{separator}{service}:{tag}`. For example, with the defaults: `quay.io/kubernaut-ai/gateway:v1.1.0-rc0`. For flat registries that don't support nested paths, set `separator: "-"` to produce `myregistry.example.com/kubernaut-ai-gateway:v1.1.0-rc0`.
+Image paths are constructed as `{registry}{separator}{namespace}{separator}{service}:{tag}`. For example, with the defaults: `quay.io/kubernaut-ai/gateway:{{ image_tag }}`. For flat registries that don't support nested paths, set `separator: "-"` to produce `myregistry.example.com/kubernaut-ai-gateway:{{ image_tag }}`.
 
 ### Gateway
 

--- a/docs/user-guide/workflows.md
+++ b/docs/user-guide/workflows.md
@@ -276,6 +276,7 @@ The Workflow Execution controller validates that these resources exist before cr
 !!! warning "Security: Use `no_log: true` for sensitive Ansible tasks"
     When writing Ansible playbooks that handle secrets (credentials, tokens, passwords), always set `no_log: true` on tasks that read or use sensitive values. This prevents AWX from recording secret data in job output logs:
 
+    {% raw %}
     ```yaml
     - name: Read Git credentials from AWX credential env vars
       ansible.builtin.set_fact:
@@ -283,6 +284,7 @@ The Workflow Execution controller validates that these resources exist before cr
         git_password: "{{ lookup('env', 'KUBERNAUT_SECRET_GITEA_REPO_CREDS_PASSWORD') }}"
       no_log: true
     ```
+    {% endraw %}
 
     Tasks to protect include: reading credentials from environment variables, building authenticated URLs, cloning repositories with embedded credentials, and any task that passes secrets as arguments.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,8 @@ theme:
     - toc.follow
 
 extra:
+  chart_version: "1.1.0-rc0"
+  image_tag: "v1.1.0-rc0"
   version:
     provider: mike
     default: latest
@@ -82,6 +84,7 @@ markdown_extensions:
 
 plugins:
   - search
+  - macros
 
 nav:
   - Home: index.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 mkdocs-material>=9.6
 mkdocs>=1.6,<2.0
+mkdocs-macros-plugin>=1.3
 mike>=2.1
 pymdown-extensions>=10.14


### PR DESCRIPTION
## Summary

- Adds `mkdocs-macros-plugin` so that `chart_version` and `image_tag` are defined once in `mkdocs.yml` and expanded automatically across all documentation pages.
- Replaces ~20 hardcoded `1.1.0-rc0` / `v1.1.0-rc0` version strings across 4 files with `{{ chart_version }}` / `{{ image_tag }}` template variables.
- Wraps 3 pre-existing `{{ }}` code blocks (Ansible lookups, Helm templates, Prometheus rules) with `{% raw %}` to prevent macro interpretation.

## Release workflow going forward

When cutting a new release (e.g., v1.2.0):

1. Update `chart_version` and `image_tag` in `mkdocs.yml`
2. Push to `main`
3. CI runs `mike deploy v1.2 latest --push`
4. All Helm commands automatically reference the new version
5. Previous version snapshots (v1.0, v1.1) retain their original values

## Test plan

- [x] `mkdocs build --strict` passes
- [x] Rendered HTML contains expanded version strings (not raw `{{ }}`)
- [x] Raw blocks preserve Ansible, Helm, and Prometheus template syntax literally

Made with [Cursor](https://cursor.com)