### PR TITLE
fix(docs): align scenario catalog with upstream kubernaut-demo-scenarios

### DIFF
--- a/docs/use-cases/index.md
+++ b/docs/use-cases/index.md
@@ -32,9 +32,9 @@ All scenarios are available in the [kubernaut-demo-scenarios](https://github.com
 | [crashloop](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/crashloop) | `KubePodCrashLooping` | `RollbackDeployment` | Bad ConfigMap causes CrashLoopBackOff, rollback restores previous revision |
 | [crashloop-helm](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/crashloop-helm) | `KubePodCrashLooping` | `HelmRollback` | Helm-managed workload crash, Helm rollback to last known-good release |
 | [stuck-rollout](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/stuck-rollout) | `KubeDeploymentRolloutStuck` | `RollbackDeployment` | Bad image tag stalls rollout, rollback restores healthy revision |
-| [memory-leak](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/memory-leak) | `PredictedMemoryExhaustion` | `GracefulRestart` | Proactive: `predict_linear()` detects memory growth before OOM |
-| [memory-escalation](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/memory-escalation) | `KubePodOOMKilled` | `IncreaseMemoryLimits` | OOM kills trigger memory limit increase; escalates to human if limits are already high |
-| [slo-burn](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/slo-burn) | `SLOErrorBudgetBurn` | `RollbackDeployment` | Error budget burn rate exceeds threshold, proactive rollback |
+| [memory-leak](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/memory-leak) | `ContainerMemoryExhaustionPredicted` | `GracefulRestart` | Proactive: `predict_linear()` detects memory growth before OOM |
+| [memory-escalation](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/memory-escalation) | `ContainerMemoryHigh` | `IncreaseMemoryLimits` | Memory usage exceeds threshold; escalates to human if limits are already high |
+| [slo-burn](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/slo-burn) | `ErrorBudgetBurn` | `RollbackDeployment` | Error budget burn rate exceeds threshold, proactive rollback |
 
 ### GitOps
 
@@ -42,25 +42,26 @@ All scenarios are available in the [kubernaut-demo-scenarios](https://github.com
 |----------|--------|-------------|-------------|
 | [gitops-drift](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/gitops-drift) | `KubePodCrashLooping` | `GitRevertCommit` | Bad ConfigMap commit in Gitea, LLM selects git revert over kubectl rollback |
 | [cert-failure-gitops](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/cert-failure-gitops) | `CertManagerCertNotReady` | `GitRevertCommit` / `FixCertificate` | Broken ClusterIssuer via git; LLM may choose git revert or direct fix ([details](multi-path-remediation.md)) |
+| [disk-pressure-emptydir](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/disk-pressure-emptydir) | `PredictedDiskPressure` | `AnsiblePVCMigration` | PostgreSQL on emptyDir fills disk; Ansible/AWX runs pg\_dump, commits PVC migration to Git, ArgoCD syncs, pg\_restore completes migration |
 
 ### Infrastructure
 
 | Scenario | Signal | Remediation | Description |
 |----------|--------|-------------|-------------|
 | [cert-failure](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/cert-failure) | `CertManagerCertNotReady` | `FixCertificate` | CA Secret deleted, workflow recreates it to restore certificate issuance |
-| [hpa-maxed](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/hpa-maxed) | `HPAMaxedOut` | `ScaleHPA` | HPA at max replicas under sustained load |
-| [resource-contention](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/resource-contention) | `KubePodOOMKilled` | `IncreaseMemoryLimits` | Memory contention causes OOM kills across competing workloads |
+| [hpa-maxed](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/hpa-maxed) | `KubeHpaMaxedOut` | `ScaleHPA` | HPA at max replicas under sustained load |
+| [resource-contention](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/resource-contention) | `OOMKilled` | `IncreaseMemoryLimits` | Memory contention causes OOM kills across competing workloads |
 | [resource-quota-exhaustion](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/resource-quota-exhaustion) | `KubeResourceQuotaExhausted` | `AdjustResourceQuota` | Namespace quota prevents scaling ([details](remediation-history-feedback.md)) |
-| [network-policy-block](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/network-policy-block) | `KubeDeploymentReplicasMismatch` | `FixNetworkPolicy` | Deny-all NetworkPolicy blocks traffic; readiness-based signal self-resolves after remediation |
-| [statefulset-pvc-failure](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/statefulset-pvc-failure) | `StatefulSetPVCFailure` | `FixStatefulSetPVC` | PVC binding failure prevents StatefulSet pod scheduling |
+| [network-policy-block](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/network-policy-block) | `KubePodCrashLooping` / `KubeDeploymentReplicasMismatch` | `FixNetworkPolicy` | Deny-all NetworkPolicy blocks traffic; readiness-based signal self-resolves after remediation |
+| [statefulset-pvc-failure](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/statefulset-pvc-failure) | `KubeStatefulSetReplicasMismatch` | `FixStatefulSetPVC` | PVC binding failure prevents StatefulSet pod scheduling |
 
 ### Multi-Node
 
 | Scenario | Signal | Remediation | Description |
 |----------|--------|-------------|-------------|
-| [autoscale](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/autoscale) | `ClusterCapacityExhausted` | `AddNode` | Cluster autoscaling via kubeadm join |
-| [pending-taint](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/pending-taint) | `KubePodPending` | `RemoveTaint` | Node taint prevents pod scheduling |
-| [pdb-deadlock](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/pdb-deadlock) | `PDBDeadlock` | `ResolvePDBDeadlock` | PodDisruptionBudget prevents necessary evictions |
+| [autoscale](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/autoscale) | `KubePodSchedulingFailed` | `AddNode` | Cluster autoscaling via kubeadm join |
+| [pending-taint](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/pending-taint) | `KubePodNotScheduled` | `RemoveTaint` | Node taint prevents pod scheduling |
+| [pdb-deadlock](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/pdb-deadlock) | `KubePodDisruptionBudgetAtLimit` | `ResolvePDBDeadlock` | PodDisruptionBudget prevents necessary evictions |
 | [node-notready](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/node-notready) | `KubeNodeNotReady` | `CordonDrain` | Node health failure triggers cordon and workload migration |
 
 ### Advanced Pipeline
@@ -69,10 +70,18 @@ All scenarios are available in the [kubernaut-demo-scenarios](https://github.com
 |----------|--------|-------------|-------------|
 | [duplicate-alert-suppression](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/duplicate-alert-suppression) | `KubePodCrashLooping` | `RollbackDeployment` | Validates that duplicate alerts for the same incident are suppressed |
 | [concurrent-cross-namespace](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/concurrent-cross-namespace) | `KubePodCrashLooping` | Per-team workflow | Two teams hit the same fault; LLM selects different workflows based on risk labels |
-| [orphaned-pvc-no-action](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/orphaned-pvc-no-action) | `DiskPressure` | None (NoActionRequired) | LLM correctly identifies no remediation is needed |
+| [orphaned-pvc-no-action](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/orphaned-pvc-no-action) | `KubePersistentVolumeClaimOrphaned` | None (NoActionRequired) | LLM correctly identifies no remediation is needed |
 
 ### Service Mesh
 
 | Scenario | Signal | Remediation | Description |
 |----------|--------|-------------|-------------|
-| [mesh-routing-failure](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/mesh-routing-failure) | `LinkerdRoutingFailure` | `FixServiceMeshRouting` | Linkerd service mesh routing misconfiguration |
+| [mesh-routing-failure](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/mesh-routing-failure) | `IstioHighDenyRate` / `IstioRequestsUnauthorized` | `FixServiceMeshRouting` | Istio service mesh AuthorizationPolicy misconfiguration |
+
+### Unvalidated
+
+These scenarios have scaffolding (manifests, run.sh, workflow) but have **not been validated end-to-end** on any platform. Do not rely on them until they are promoted to a category above.
+
+| Scenario | Signal | Remediation | Description | Blocker |
+|----------|--------|-------------|-------------|---------|
+| [memory-limits-gitops-ansible](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/memory-limits-gitops-ansible) | `ContainerOOMKilling` | `AnsibleMemoryLimitsUpdate` | OOMKill on GitOps-managed deployment; Ansible/AWX updates limits in Git, ArgoCD syncs | Requires ArgoCD + AWX; not tested on Kind or OCP |


### PR DESCRIPTION
## Summary

- **Add 2 missing scenarios**: `disk-pressure-emptydir` (GitOps/Ansible+AWX PVC migration) and `memory-limits-gitops-ansible` (new Unvalidated section)
- **Fix 12 signal name mismatches** to match the authoritative alert names in [kubernaut-demo-scenarios/docs/scenarios.md](https://github.com/jordigilh/kubernaut-demo-scenarios/blob/main/docs/scenarios.md)
- **Correct `mesh-routing-failure`** from Linkerd to Istio (upstream uses Istio AuthorizationPolicy)

### Signal names corrected

| Scenario | Before | After |
|----------|--------|-------|
| memory-leak | `PredictedMemoryExhaustion` | `ContainerMemoryExhaustionPredicted` |
| memory-escalation | `KubePodOOMKilled` | `ContainerMemoryHigh` |
| slo-burn | `SLOErrorBudgetBurn` | `ErrorBudgetBurn` |
| hpa-maxed | `HPAMaxedOut` | `KubeHpaMaxedOut` |
| resource-contention | `KubePodOOMKilled` | `OOMKilled` |
| network-policy-block | `KubeDeploymentReplicasMismatch` | `KubePodCrashLooping` / `KubeDeploymentReplicasMismatch` |
| statefulset-pvc-failure | `StatefulSetPVCFailure` | `KubeStatefulSetReplicasMismatch` |
| autoscale | `ClusterCapacityExhausted` | `KubePodSchedulingFailed` |
| pending-taint | `KubePodPending` | `KubePodNotScheduled` |
| pdb-deadlock | `PDBDeadlock` | `KubePodDisruptionBudgetAtLimit` |
| orphaned-pvc-no-action | `DiskPressure` | `KubePersistentVolumeClaimOrphaned` |
| mesh-routing-failure | `LinkerdRoutingFailure` | `IstioHighDenyRate` / `IstioRequestsUnauthorized` |

## Test plan

- [ ] Verify rendered page at `/use-cases/` lists 24 scenarios (22 validated + 1 disk-pressure-emptydir + 1 unvalidated)
- [ ] Confirm all scenario links resolve to the correct kubernaut-demo-scenarios directories
- [ ] Cross-check signal names against scenario READMEs in kubernaut-demo-scenarios


Made with [Cursor](https://cursor.com)