### PR TITLE
docs: add data sovereignty row to AIOps landscape comparison

### DIFF
--- a/docs/getting-started/aiops-landscape.md
+++ b/docs/getting-started/aiops-landscape.md
@@ -154,7 +154,8 @@ The LLM decides when and whether to query the predictive AI based on the investi
 | High-confidence RCA with cross-validation | Generative AI + Predictive AI |
 | Topology-dependent incidents across microservices | Predictive AI as knowledge agent for Generative AI |
 | Environments requiring closed-loop verification | Generative AI (Kubernaut) |
-| Air-gapped / disconnected clusters | Generative AI (Kubernaut) with a [locally hosted LLM](../operations/disconnected-install.md) -- predictive AI platforms typically require cloud connectivity |
+| On-premises with data sovereignty requirements | Generative AI (Kubernaut) -- fully self-hosted; LLM prompts, telemetry, and remediation data never leave the network boundary. Predictive AI platforms typically require cloud-hosted SaaS |
+| Air-gapped / disconnected clusters | Generative AI (Kubernaut) with a [locally hosted LLM](../operations/disconnected-install.md) -- no external network dependencies |
 | Full lifecycle: detect, investigate, remediate, verify, learn | Combined: Predictive AI for detection and context, Generative AI for reasoning and execution |
 
 The strongest architecture uses predictive AI for what it does best -- high-fidelity anomaly detection, topology mapping, and correlation of known patterns -- and generative AI for what statistical models cannot do: reason about novel situations, select context-appropriate remediations, and verify outcomes in a closed loop.


### PR DESCRIPTION
## Summary

- Adds an "On-premises with data sovereignty requirements" row to the "When to Use Each Approach" table in the AIOps Remediation Landscape page.
- Kubernaut is fully self-hosted — LLM prompts, telemetry, and remediation data never leave the network boundary. Predictive AI platforms (Dynatrace SaaS, Datadog) typically require cloud-hosted SaaS.
- Distinct from the air-gapped row (merged in #14): data sovereignty applies when the cluster has internet access but the organization requires data to stay on-premises.

## Test plan

- [ ] Verify the new table row renders correctly on the AIOps Landscape page


Made with [Cursor](https://cursor.com)