### PR TITLE
docs: add toolset optimization guidance (pre-v1.2)

### DIFF
--- a/docs/architecture/hapi-investigation.md
+++ b/docs/architecture/hapi-investigation.md
@@ -32,6 +32,9 @@ toolsets:
       prometheus_url: "http://kube-prometheus-stack-prometheus.monitoring.svc:9090"
 ```
 
+!!! tip "Token overhead from unused toolsets"
+    Each enabled toolset adds its full tool schema to every LLM context turn, even if none of its tools are called. This can add ~30% token overhead and bias the LLM toward irrelevant investigation paths. Enable only the toolsets your workload needs. See [Toolset Optimization](../user-guide/configmap-holmesgpt.md#toolset-optimization-pre-v12) for guidance and an incident-type mapping table.
+
 The Helm chart supports three tiers for providing the SDK config -- see [Configuration Reference: HolmesGPT API](../user-guide/configuration.md#holmesgpt-api-llm-integration).
 
 ## Pipeline Overview

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -36,6 +36,8 @@ LLM tokens are consumed only during the investigation phase (root cause analysis
 
 Cost depends on the LLM provider and model. A typical investigation with Gemini 1.5 Pro costs a fraction of a cent. For cost-sensitive environments, you can use smaller models or locally hosted LLMs via LiteLLM.
 
+Enabled-but-unused toolsets also contribute to token consumption — each toolset injects its full schema into every LLM turn, even when none of its tools are called. Starting with `toolsets: {}` and enabling additional toolsets only for workloads that need them can reduce token usage by ~30%. See [Toolset Optimization](user-guide/configmap-holmesgpt.md#toolset-optimization-pre-v12) for recommended configurations by incident type.
+
 ## Can I run it air-gapped?
 
 Yes. Point the HolmesGPT API service at a locally hosted LLM endpoint (via LiteLLM or any OpenAI-compatible server). All other components — the CRD controllers, DataStorage, workflow execution — run entirely within the cluster with no external network dependencies.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -300,6 +300,13 @@ kubectl create secret generic kubernaut-valkey-credentials \
 # 2. Copy and customize the SDK config (fill in your LLM provider + API key)
 cp charts/kubernaut/examples/sdk-config.yaml my-sdk-config.yaml
 # Edit my-sdk-config.yaml: set llm.provider, llm.model
+# Leave toolsets: {} empty unless you need Prometheus or other data sources
+```
+
+!!! tip "Start with minimal toolsets"
+    The default SDK config ships with `toolsets: {}` (no optional toolsets). This is the recommended starting point — the Kubernetes core toolset is always available and handles most incident types (CrashLoopBackOff, config errors, OOMKilled). Enable additional toolsets like `prometheus/metrics` only for workloads that require metric-driven investigation (SLO burn-rate alerts, latency spikes). Unused toolsets add ~30% token overhead per investigation. See [Toolset Optimization](../user-guide/configmap-holmesgpt.md#toolset-optimization-pre-v12) for details.
+
+```bash
 
 kubectl create secret generic llm-credentials \
   --from-literal=OPENAI_API_KEY=sk-... \

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -299,3 +299,4 @@ The full audit trail of every step is stored in PostgreSQL for compliance and po
 - [Remediation Workflows](../user-guide/workflows.md) — Write your own workflow schemas
 - [Human Approval](../user-guide/approval.md) — Configure approval gates and confidence thresholds
 - [Architecture Overview](architecture-overview.md) — Dive deeper into the system design
+- [HolmesGPT SDK Config](../user-guide/configmap-holmesgpt.md) — Configure LLM providers, toolsets, and token optimization

--- a/docs/user-guide/configmap-holmesgpt.md
+++ b/docs/user-guide/configmap-holmesgpt.md
@@ -59,6 +59,46 @@ toolsets: {}             # Optional: HolmesGPT data source toolsets
 mcp_servers: {}          # Optional: Model Context Protocol servers
 ```
 
+## Toolset Optimization (pre-v1.2)
+
+Each enabled toolset injects its full tool schema into every LLM context turn. When a toolset is enabled but never called during an investigation, those schema tokens are pure overhead — they consume budget and can bias the LLM toward irrelevant investigation paths.
+
+Empirical testing shows that loading a single unused toolset (Prometheus, 123 tools) can add ~30% token overhead and increase LLM latency by ~15%, with no benefit to the investigation outcome. See the [two-phase toolkit selection discussion](https://github.com/jordigilh/kubernaut/issues/434) for detailed measurements.
+
+**Recommendation:** Enable only the toolsets needed for your workload. The Kubernetes core toolset (`kubectl` commands and logs) is always available — it cannot be disabled.
+
+### Incident-Type to Toolset Mapping
+
+| Incident Type | Recommended Toolsets | Notes |
+|---|---|---|
+| Config errors, CrashLoopBackOff, OOMKilled | *(core only — no extra toolsets)* | `kubectl` access to pods, events, and logs is sufficient |
+| SLO burn-rate alerts, latency spikes | `prometheus/metrics` | Requires Prometheus for metric queries |
+| Cloud resource issues | Relevant cloud provider toolset | Add only the provider you use |
+
+### Example: Minimal SDK Config (No Optional Toolsets)
+
+```yaml
+llm:
+  provider: openai
+  model: gpt-4o
+  temperature: 0.5
+
+toolsets: {}
+```
+
+Enable Prometheus only when investigating metric-driven alerts:
+
+```yaml
+toolsets:
+  prometheus/metrics:
+    enabled: true
+    config:
+      prometheus_url: "http://kube-prometheus-stack-prometheus.monitoring.svc:9090"
+```
+
+!!! note "v1.2: Automatic toolset selection"
+    v1.2 will introduce [two-phase toolkit selection](https://github.com/jordigilh/kubernaut/issues/434) that automatically loads only the toolsets relevant to each investigation. This section will be updated when that feature ships.
+
 ## Provider Examples
 
 ### OpenAI


### PR DESCRIPTION
## Summary

- Adds toolset optimization guidance across 5 existing docs pages to address [kubernaut#474](https://github.com/jordigilh/kubernaut/issues/474)
- Documents that unused-but-enabled HolmesGPT toolsets inject full tool schemas into every LLM context turn, adding ~30% token overhead and potentially biasing investigation paths
- Primary content lives in the HolmesGPT SDK Config page (`configmap-holmesgpt.md`) with cross-references from Installation, Investigation Pipeline, FAQ, and Quickstart

## Changes

| File | Change |
|------|--------|
| `docs/user-guide/configmap-holmesgpt.md` | New "Toolset Optimization (pre-v1.2)" section with incident-type mapping table, minimal config examples, and v1.2 note |
| `docs/getting-started/installation.md` | Tip admonition in Quickstart section recommending minimal toolsets |
| `docs/architecture/hapi-investigation.md` | Tip admonition near SDK config YAML block |
| `docs/faq.md` | Expanded "What about token cost?" answer |
| `docs/getting-started/quickstart.md` | Added SDK Config link to Next Steps |

## References

- [kubernaut#474](https://github.com/jordigilh/kubernaut/issues/474) — Docs: recommend disabling non-essential toolsets
- [kubernaut#434](https://github.com/jordigilh/kubernaut/issues/434) — Two-phase toolkit selection (v1.2)

## Test plan

- [ ] Verify `configmap-holmesgpt.md` renders correctly with new section, table, and YAML blocks
- [ ] Verify `installation.md` tip admonition renders between the split bash blocks
- [ ] Verify cross-reference anchor links resolve (`#toolset-optimization-pre-v12`)
- [ ] Verify FAQ link resolves from root-relative path


Made with [Cursor](https://cursor.com)