### PR TITLE
chore: add CODEOWNERS, CONTRIBUTORS, PR and issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Kubernaut Docs Code Owners
+# All changes require review from a code owner before merging.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything
+* @jordigilh

--- a/.github/CONTRIBUTORS
+++ b/.github/CONTRIBUTORS
@@ -1,0 +1,6 @@
+# Kubernaut Docs — Authorized Contributors
+#
+# This file lists individuals authorized to contribute to this repository.
+# All pull requests require code-owner approval before merging (see CODEOWNERS).
+
+jordigilh (Jordi Gil) — maintainer, code owner

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug Report
+about: Report an issue with Kubernaut documentation
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of the documentation issue.
+
+## Location
+
+- **Page URL or path**: (e.g., `docs/getting-started/quickstart.md`)
+- **Section**: (e.g., "Installation")
+
+## Problem
+
+What is incorrect, misleading, or missing?
+
+## Suggested Fix
+
+If applicable, describe the correction.
+
+## Additional Context
+
+Any other context (screenshots, related issues, etc.).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest new or improved documentation
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+
+A clear description of what documentation is missing or could be improved.
+
+## Proposed Solution
+
+Describe the documentation you'd like to see.
+
+## Alternatives Considered
+
+Any alternative approaches to documenting this.
+
+## Additional Context
+
+Any other context or references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+Brief description of what this PR does and why.
+
+## Changes
+
+- ...
+- ...
+
+## Test Plan
+
+- [ ] Ran `mkdocs serve` locally and verified rendering
+- [ ] No broken links or missing images
+- [ ] Navigation structure is correct
+
+## Checklist
+
+- [ ] Spelling and grammar checked
+- [ ] Markdown linting passes (no warnings)
+- [ ] No secrets or credentials committed


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` requiring `@jordigilh` review on all changes
- Adds `.github/CONTRIBUTORS` listing authorized contributors
- Adds `.github/PULL_REQUEST_TEMPLATE.md` with docs-specific test plan
- Adds `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`

Part of securing the repository — branch protection and merge settings
are applied separately via the GitHub API.

## Test plan

- [ ] Verify CODEOWNERS auto-assigns reviewer on new PRs
- [ ] Verify PR template renders on new PR creation
- [ ] Verify issue templates appear in "New issue" picker

Made with [Cursor](https://cursor.com)