### PR TITLE
docs: deduplicate reconstruct endpoint (closes kubernaut#343)

### DIFF
--- a/docs/user-guide/data-lifecycle.md
+++ b/docs/user-guide/data-lifecycle.md
@@ -29,15 +29,7 @@ While CRDs are ephemeral, the audit trail in PostgreSQL is permanent. Every serv
 
 ## RemediationRequest Reconstruction
 
-Because audit events capture the full context of every stage, Kubernaut can **reconstruct a complete RemediationRequest** from audit data — even after the CRD has expired.
-
-The DataStorage service provides a reconstruction endpoint:
-
-```
-POST /api/v1/audit/remediation-requests/{correlation_id}/reconstruct
-```
-
-See [Architecture: Data Persistence](../architecture/data-persistence.md#remediationrequest-reconstruction) for the full reconstruction pipeline and source event mapping.
+Because audit events capture the full context of every stage, Kubernaut can **reconstruct a complete RemediationRequest** from audit data — even after the CRD has expired. The DataStorage service provides a reconstruction endpoint that rebuilds the full spec and status from typed audit payloads. See [Architecture: Data Persistence](../architecture/data-persistence.md#remediationrequest-reconstruction) for the endpoint, reconstruction pipeline, and source event mapping.
 
 ### Use Cases
 


### PR DESCRIPTION
## Summary

- Remove the duplicated `POST /api/v1/audit/.../reconstruct` endpoint from `data-lifecycle.md` (user guide), keeping the architecture page (`data-persistence.md`) as the single source of truth
- Replace with prose description + link to the architecture page

## Context

Issue [kubernaut#343](https://github.com/jordigilh/kubernaut/issues/343) flagged 8 pairs of pages for content deduplication. Triage found that 7 of 8 were already resolved with cross-links. This PR fixes the one remaining item: the reconstruct endpoint duplicated across the user guide and architecture page.

## Test plan

- [ ] Verify the cross-link from `data-lifecycle.md` to `data-persistence.md#remediationrequest-reconstruction` resolves

Made with [Cursor](https://cursor.com)