### PR TITLE
fix: correct Vertex AI credential key name and SDK config requirements

### DIFF
--- a/docs/api-reference/holmesgpt-api.md
+++ b/docs/api-reference/holmesgpt-api.md
@@ -145,7 +145,7 @@ HolmesGPT uses **LiteLLM** under the hood, supporting any compatible provider:
 | Provider | Configuration |
 |---|---|
 | OpenAI | `provider: openai`, `model: gpt-4o` |
-| Vertex AI | `provider: vertex_ai`, `model: gemini-2.5-pro`, `gcpProjectId`, `gcpRegion` |
+| Vertex AI | `provider: vertex_ai`, `model: gemini-2.5-pro`, `gcp_project_id`, `gcp_region` |
 | Azure OpenAI | `provider: azure`, `model: gpt-4o`, `endpoint` |
 | Any LiteLLM provider | See [LiteLLM documentation](https://docs.litellm.ai/docs/providers) |
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -172,16 +172,19 @@ The chart **auto-generates** credentials for PostgreSQL, DataStorage, and Valkey
 
     ```bash
     kubectl create secret generic llm-credentials \
-      --from-file=GOOGLE_APPLICATION_CREDENTIALS=path/to/service-account-key.json \
+      --from-file=application_default_credentials.json=path/to/service-account-key.json \
       -n kubernaut-system
     ```
 
-    The chart mounts this file and sets `GOOGLE_APPLICATION_CREDENTIALS` automatically.
+    HAPI auto-detects `application_default_credentials.json` in the mounted secret and sets `GOOGLE_APPLICATION_CREDENTIALS` to the mount path at runtime.
     With GCP Workload Identity the secret can be omitted.
+
+    !!! note "Vertex AI requires an SDK config file"
+        The quickstart `--set holmesgptApi.llm.provider=...` path only supports OpenAI and Anthropic. Vertex AI requires `gcp_project_id` and `gcp_region`, which must be provided via `sdkConfigContent` or `existingSdkConfigMap`. See [Advanced Configuration](#advanced-configuration) and the [Vertex AI SDK config example](../user-guide/configmap-holmesgpt.md#google-vertex-ai).
 
 | Chart Value | Secret Name | Required Keys |
 |---|---|---|
-| `holmesgptApi.llm.credentialsSecretName` | `llm-credentials` (default) | Provider-specific: `OPENAI_API_KEY`, `AZURE_API_KEY`, or `GOOGLE_APPLICATION_CREDENTIALS` (file) |
+| `holmesgptApi.llm.credentialsSecretName` | `llm-credentials` (default) | Provider-specific: `OPENAI_API_KEY`, `AZURE_API_KEY`, or `application_default_credentials.json` (file) |
 
 The LLM credentials secret **must** exist before installing the chart. Without valid credentials, AI analysis cannot function.
 

--- a/docs/user-guide/configmap-holmesgpt.md
+++ b/docs/user-guide/configmap-holmesgpt.md
@@ -136,7 +136,9 @@ llm:
   timeout_seconds: 180
 ```
 
-Secret: `kubectl create secret generic llm-credentials --from-file=GOOGLE_APPLICATION_CREDENTIALS=service-account-key.json`
+Secret: `kubectl create secret generic llm-credentials --from-file=application_default_credentials.json=service-account-key.json -n kubernaut-system`
+
+HAPI auto-detects `application_default_credentials.json` in the mounted secret and sets `GOOGLE_APPLICATION_CREDENTIALS` to the mount path at runtime. The `gcp_project_id` and `gcp_region` fields from the SDK config are used to set `VERTEXAI_PROJECT` and `VERTEXAI_LOCATION`.
 
 GCP Workload Identity is also supported -- the secret can be omitted when authentication is handled by the node metadata service.
 


### PR DESCRIPTION
## Summary

- Vertex AI `llm-credentials` secret instructions used wrong key name (`GOOGLE_APPLICATION_CREDENTIALS` instead of `application_default_credentials.json`), causing `VertexAIException InternalServerError` because LiteLLM receives raw JSON content where it expects a file path
- Replaced misleading "chart sets GOOGLE_APPLICATION_CREDENTIALS" with accurate description of HAPI's `_inject_runtime_env()` auto-detect mechanism
- Added note that Vertex AI **cannot** use the quickstart `--set provider/model` path (requires `sdkConfigContent` with `gcp_project_id`/`gcp_region`)
- Fixed camelCase field names (`gcpProjectId`/`gcpRegion`) in HAPI API reference to match SDK config snake_case (`gcp_project_id`/`gcp_region`)

### Files changed

| File | Change |
|---|---|
| `docs/getting-started/installation.md` | Fix secret command, explanation, required keys table, add SDK config requirement note |
| `docs/user-guide/configmap-holmesgpt.md` | Fix secret command, add runtime auto-detect explanation |
| `docs/api-reference/holmesgpt-api.md` | Fix field names to snake_case |

### Verified against

- `holmesgpt-api/src/main.py` at `v1.1.0` tag: `_inject_runtime_env()` looks for `application_default_credentials.json` (line 285)
- `charts/kubernaut/values.yaml` at `v1.1.0` tag: quickstart only supports `openai`/`anthropic`
- `charts/kubernaut/examples/sdk-config.yaml`: documents `gcp_project_id`/`gcp_region`

Closes #31

Made with [Cursor](https://cursor.com)