### PR TITLE
docs: align with BR-496 v2 (HAPI-owned target resource) and K8s credential injection

### DIFF
--- a/docs/api-reference/crds.md
+++ b/docs/api-reference/crds.md
@@ -69,8 +69,8 @@ _Appears in:_
 | `approvalRequired`| _boolean_| True if approval is required (confidence < 80% or policy requires)|
 | `approvalReason`| _string_| Reason why approval is required (when ApprovalRequired=true)|
 | `approvalContext`| _[ApprovalContext](#approvalcontext)_| Rich context for approval notification|
-| `needsHumanReview`| _boolean_| Set by HAPI when AI cannot produce reliable result<br />True if human review required (HAPI decision: RCA incomplete/unreliable)<br /> Triggers NotificationRequest creation in RO<br /> Set when workflow selected but affectedResource missing|
-| `humanReviewReason`| _string_| Reason why human review needed (when NeedsHumanReview=true)<br /> Maps to HAPI's human_review_reason enum values<br /> Includes "rca_incomplete" for missing affectedResource|
+| `needsHumanReview`| _boolean_| Set by HAPI when AI cannot produce reliable result<br />True if human review required (HAPI decision: RCA incomplete/unreliable)<br /> Triggers NotificationRequest creation in RO<br />BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.|
+| `humanReviewReason`| _string_| Reason why human review needed (when NeedsHumanReview=true)<br /> Maps to HAPI's human_review_reason enum values|
 | `actionability`| _string_| #388: LLM's assessment of whether the alert warrants action.<br />Empty when not yet assessed (pre-investigation or error paths).<br />"Actionable" when the LLM determines the alert warrants action (default for all processed alerts).<br />"NotActionable" when the LLM determines the alert is benign (e.g., orphaned PVCs).|
 | `investigationId`| _string_| HolmesGPT investigation ID for correlation|
 | `investigationTime`| _integer_| Investigation duration in seconds|

--- a/docs/architecture/hapi-investigation.md
+++ b/docs/architecture/hapi-investigation.md
@@ -424,7 +424,7 @@ flowchart TD
 
 ### Outcome 1: Success (Workflow Selected)
 
-The LLM returns a `selected_workflow` with `workflow_id`, `confidence`, `parameters`, and `affectedResource`. This is the only outcome that proceeds to Rego evaluation.
+The LLM returns a `selected_workflow` with `workflow_id`, `confidence`, and `parameters`. HAPI then injects the three canonical `TARGET_RESOURCE_*` parameters and constructs `affectedResource` from the K8s-verified `root_owner` (resolved via `get_resource_context`). This is the only outcome that proceeds to Rego evaluation.
 
 **Fields:** `needs_human_review=false`, `selected_workflow` present, `confidence >= 0.7`
 **Next:** AA transitions to `Analyzing` phase → Rego evaluation
@@ -457,7 +457,7 @@ The LLM identified the root cause but no workflow in the catalog matches the req
 
 ### Outcome 5: RCA Incomplete
 
-The LLM selected a workflow but did not identify the `affectedResource`. This is a defense-in-depth check (BR-HAPI-212) -- a workflow without a confirmed target resource is unsafe.
+HAPI could not determine the target resource identity because `root_owner` is missing from `session_state` -- either `get_resource_context` was never called during the investigation or it returned no owner chain. Without a verified target, HAPI cannot inject the canonical `TARGET_RESOURCE_*` parameters and the investigation is unsafe to proceed.
 
 **Fields:** `needs_human_review=true`, `human_review_reason=rca_incomplete`
 **Next:** Routed to human review.

--- a/docs/architecture/workflow-execution.md
+++ b/docs/architecture/workflow-execution.md
@@ -187,9 +187,10 @@ The Ansible executor:
 
 3. **Injects dependency ConfigMaps** as `extra_vars` with a `KUBERNAUT_CONFIGMAP_{NAME}_{KEY}` prefix (non-sensitive data)
 4. **Injects dependency Secrets** as ephemeral AWX credentials with `KUBERNAUT_SECRET_{NAME}_{KEY}` environment variables (sensitive data, never in `extra_vars`)
-5. **Launches the AWX Job** with the combined `extra_vars` and credential IDs. When ephemeral credentials are present, the executor also fetches the job template's pre-configured credentials and merges them (deduplicated, template-first ordering) so AWX receives the full union.
-6. **Polls job status** via `GET /api/v2/jobs/{id}/` mapping AWX states (`pending`, `waiting`, `running`, `successful`, `failed`, `error`, `canceled`) to WFE phases
-7. **Cleans up** ephemeral credentials after execution completes (credential IDs are persisted in `status.ephemeralCredentialIDs` via the status subresource)
+5. **Injects K8s API credentials** -- reads the controller's in-cluster ServiceAccount token and creates an ephemeral AWX credential that injects `K8S_AUTH_HOST`, `K8S_AUTH_API_KEY`, and `K8S_AUTH_SSL_CA_CERT` into the Execution Environment. Playbooks using `kubernetes.core` modules authenticate automatically. If the in-cluster environment is unavailable, the job proceeds without K8s credentials.
+6. **Launches the AWX Job** with the combined `extra_vars` and credential IDs. When ephemeral credentials are present, the executor also fetches the job template's pre-configured credentials and merges them (deduplicated, template-first ordering) so AWX receives the full union.
+7. **Polls job status** via `GET /api/v2/jobs/{id}/` mapping AWX states (`pending`, `waiting`, `running`, `successful`, `failed`, `error`, `canceled`) to WFE phases
+8. **Cleans up** ephemeral credentials (including K8s credentials) after execution completes (credential IDs are persisted in `status.ephemeralCredentialIDs` via the status subresource)
 
 The credential lifecycle ensures Kubernetes Secret data is never persisted in AWX `extra_vars` (which are logged). Instead, each Secret gets a dynamic AWX credential type with `env` injectors, and an ephemeral credential is created per execution and deleted on cleanup.
 
@@ -231,8 +232,11 @@ The executor injects system variables and passes through all parameters from the
 
 | Variable | Source |
 |---|---|
-| `TARGET_RESOURCE` | `wfe.Spec.TargetResource` (system-injected) |
-| Custom parameters | All entries from `wfe.Spec.Parameters` (from LLM selection) |
+| `TARGET_RESOURCE` | `wfe.Spec.TargetResource` (system-injected by WFE controller) |
+| `TARGET_RESOURCE_NAME` | `wfe.Spec.Parameters` (HAPI-injected from K8s root_owner) |
+| `TARGET_RESOURCE_KIND` | `wfe.Spec.Parameters` (HAPI-injected from K8s root_owner) |
+| `TARGET_RESOURCE_NAMESPACE` | `wfe.Spec.Parameters` (HAPI-injected from K8s root_owner) |
+| Custom parameters | All remaining entries from `wfe.Spec.Parameters` (LLM-populated) |
 
 Custom parameters use `UPPER_SNAKE_CASE` names and are injected as environment variables (Jobs) or Tekton params (PipelineRuns).
 
@@ -240,13 +244,19 @@ Custom parameters use `UPPER_SNAKE_CASE` names and are injected as environment v
 
 | Variable | Source |
 |---|---|
+| `TARGET_RESOURCE_NAME` | `wfe.Spec.Parameters` (HAPI-injected from K8s root_owner) |
+| `TARGET_RESOURCE_KIND` | `wfe.Spec.Parameters` (HAPI-injected from K8s root_owner) |
+| `TARGET_RESOURCE_NAMESPACE` | `wfe.Spec.Parameters` (HAPI-injected from K8s root_owner) |
 | `WFE_NAME` | `wfe.Name` (auto-injected) |
 | `WFE_NAMESPACE` | `wfe.Namespace` (auto-injected) |
 | `RR_NAME` | `wfe.Spec.RemediationRequestRef.Name` (auto-injected) |
 | `RR_NAMESPACE` | `wfe.Spec.RemediationRequestRef.Namespace` (auto-injected) |
 | `KUBERNAUT_CONFIGMAP_{NAME}_{KEY}` | Dependency ConfigMap data (auto-injected) |
 | `KUBERNAUT_SECRET_{NAME}_{KEY}` | Dependency Secret data (via ephemeral AWX credentials) |
-| Custom parameters | All entries from `wfe.Spec.Parameters` (type-coerced into `extra_vars`) |
+| `K8S_AUTH_HOST` | WE controller in-cluster SA (ephemeral AWX credential) |
+| `K8S_AUTH_API_KEY` | WE controller in-cluster SA (ephemeral AWX credential) |
+| `K8S_AUTH_SSL_CA_CERT` | WE controller in-cluster SA (ephemeral AWX credential) |
+| Custom parameters | All remaining entries from `wfe.Spec.Parameters` (type-coerced into `extra_vars`) |
 
 ## Handoff
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -416,6 +416,9 @@ Expected output:
 "Executor registry initialized" "engines"=["tekton","job","ansible"]
 ```
 
+!!! note "Automatic K8s API credentials for playbooks"
+    The ansible executor automatically injects the WE controller's in-cluster ServiceAccount token as an ephemeral AWX credential on every job launch. Playbooks using `kubernetes.core` modules receive `K8S_AUTH_HOST`, `K8S_AUTH_API_KEY`, and `K8S_AUTH_SSL_CA_CERT` without manual credential configuration. If the in-cluster environment is unavailable, the job proceeds without K8s credentials.
+
 For authoring ansible workflows, see [Ansible (AWX/AAP) in Remediation Workflows](workflows.md#ansible-awxaap) and [Workflow Execution Architecture](../architecture/workflow-execution.md#ansible-awxaap).
 
 ## TLS and Certificate Management

--- a/docs/user-guide/workflow-authoring.md
+++ b/docs/user-guide/workflow-authoring.md
@@ -286,10 +286,18 @@ spec:
     engine: job
     bundle: registry.example.com/workflows/restart-pods@sha256:abc123...
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
-      description: "Namespace of the deployment"
+      description: "Name of the root managing resource (HAPI-injected)"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the root managing resource (HAPI-injected)"
+    - name: TARGET_RESOURCE_NAMESPACE
+      type: string
+      required: true
+      description: "Namespace of the root managing resource (HAPI-injected)"
     - name: TARGET_DEPLOYMENT
       type: string
       required: true
@@ -322,10 +330,18 @@ spec:
     engine: job
     bundle: registry.example.com/workflows/crashloop-rollback@sha256:def456...
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
-      description: "Namespace of the deployment"
+      description: "Name of the root managing resource (HAPI-injected)"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the root managing resource (HAPI-injected)"
+    - name: TARGET_RESOURCE_NAMESPACE
+      type: string
+      required: true
+      description: "Namespace of the root managing resource (HAPI-injected)"
     - name: TARGET_DEPLOYMENT
       type: string
       required: true

--- a/docs/user-guide/workflows.md
+++ b/docs/user-guide/workflows.md
@@ -63,10 +63,18 @@ spec:
     bundle: registry.example.com/workflows/restart-deployment@sha256:abc123...
 
   parameters:
-    - name: TARGET_NAMESPACE
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
-      description: "Namespace of the deployment to restart"
+      description: "Name of the root managing resource (HAPI-injected)"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the root managing resource (HAPI-injected)"
+    - name: TARGET_RESOURCE_NAMESPACE
+      type: string
+      required: true
+      description: "Namespace of the root managing resource (HAPI-injected)"
     - name: TARGET_DEPLOYMENT
       type: string
       required: true
@@ -86,20 +94,20 @@ Create `remediate.sh`:
 set -euo pipefail
 
 echo "Validating deployment exists..."
-kubectl get deployment "$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" || {
+kubectl get deployment "$TARGET_DEPLOYMENT" -n "$TARGET_RESOURCE_NAMESPACE" || {
   echo "ERROR: Deployment not found"
   exit 1
 }
 
 echo "Performing rolling restart..."
-kubectl rollout restart deployment/"$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE"
+kubectl rollout restart deployment/"$TARGET_DEPLOYMENT" -n "$TARGET_RESOURCE_NAMESPACE"
 
 echo "Waiting for rollout to complete..."
-kubectl rollout status deployment/"$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" --timeout=120s
+kubectl rollout status deployment/"$TARGET_DEPLOYMENT" -n "$TARGET_RESOURCE_NAMESPACE" --timeout=120s
 
 echo "Verifying deployment health..."
-READY=$(kubectl get deployment "$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" -o jsonpath='{.status.readyReplicas}')
-DESIRED=$(kubectl get deployment "$TARGET_DEPLOYMENT" -n "$TARGET_NAMESPACE" -o jsonpath='{.spec.replicas}')
+READY=$(kubectl get deployment "$TARGET_DEPLOYMENT" -n "$TARGET_RESOURCE_NAMESPACE" -o jsonpath='{.status.readyReplicas}')
+DESIRED=$(kubectl get deployment "$TARGET_DEPLOYMENT" -n "$TARGET_RESOURCE_NAMESPACE" -o jsonpath='{.spec.replicas}')
 
 if [ "$READY" = "$DESIRED" ]; then
   echo "SUCCESS: All $READY/$DESIRED replicas ready"
@@ -294,7 +302,25 @@ Parameters use `UPPER_SNAKE_CASE` names and are injected as environment variable
 
 The `description` field is shown to the LLM during `get_workflow`, so it should be clear enough for the LLM to populate the parameter from its investigation findings.
 
-`TARGET_RESOURCE` is always injected automatically from the `RemediationRequest` target.
+#### Canonical target resource parameters
+
+Every workflow schema **must** declare these three parameters as `required: true`:
+
+| Parameter | Description |
+|---|---|
+| `TARGET_RESOURCE_NAME` | Name of the root managing resource |
+| `TARGET_RESOURCE_KIND` | Kind of the root managing resource (e.g., `Deployment`) |
+| `TARGET_RESOURCE_NAMESPACE` | Namespace of the root managing resource |
+
+These are **HAPI-injected** -- HAPI derives them from the K8s-verified `root_owner` (resolved via the Pod → ReplicaSet → Deployment owner chain) and injects them into `selected_workflow.parameters` before the AIAnalysis completes. The LLM never sees or populates these fields (they are stripped from the schema before the LLM receives it).
+
+If HAPI cannot determine the `root_owner` (e.g., `get_resource_context` was never called), the investigation is flagged `rca_incomplete` with `needs_human_review=true`.
+
+Additionally, the WFE controller injects `TARGET_RESOURCE` (composite format `namespace/kind/name`) from `wfe.Spec.TargetResource` into every Job and Tekton PipelineRun as a system variable.
+
+Workflows may also declare additional **operational parameters** (e.g., `TARGET_DEPLOYMENT`, `GRACE_PERIOD_SECONDS`) that the LLM populates from its investigation findings.
+
+#### Ansible auto-injected variables
 
 For `ansible` executions, the executor also auto-injects remediation context variables into AWX `extra_vars` (BR-WE-015 TR-6):
 
@@ -321,7 +347,7 @@ execution:
 
 The Workflow Execution controller creates a Job with:
 
-- **Environment variables** -- All parameters injected as env vars, plus `TARGET_RESOURCE`
+- **Environment variables** -- All parameters (including the three canonical `TARGET_RESOURCE_*` params) injected as env vars, plus the system-injected `TARGET_RESOURCE`
 - **Dependency mounts** -- Secrets at `/run/kubernaut/secrets/<name>`, ConfigMaps at `/run/kubernaut/configmaps/<name>`
 - **ServiceAccount** -- `kubernaut-workflow-runner` (pre-configured RBAC)
 
@@ -338,7 +364,7 @@ execution:
 The bundle must contain a Tekton Pipeline named `workflow`. The controller creates a PipelineRun with:
 
 - **Tekton bundle resolver** -- The bundle is referenced via `resolver: bundles` with the digest-pinned image
-- **Parameters** -- All parameters injected as Tekton params, plus `TARGET_RESOURCE`
+- **Parameters** -- All parameters (including the three canonical `TARGET_RESOURCE_*` params) injected as Tekton params, plus the system-injected `TARGET_RESOURCE`
 - **Dependency workspaces** -- Secrets as `secret-<name>` workspace bindings, ConfigMaps as `configmap-<name>` workspace bindings
 
 Tekton provides step ordering, retries, and artifact passing between steps.
@@ -371,10 +397,18 @@ spec:
       playbookPath: "playbooks/fix-config.yml"
       jobTemplateName: "kubernaut-fix-config"
   parameters:
-    - name: target_kind
+    - name: TARGET_RESOURCE_NAME
       type: string
       required: true
-      description: "Kind of the target resource"
+      description: "Name of the root managing resource (HAPI-injected)"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the root managing resource (HAPI-injected)"
+    - name: TARGET_RESOURCE_NAMESPACE
+      type: string
+      required: true
+      description: "Namespace of the root managing resource (HAPI-injected)"
 ```
 
 The `engineConfig` fields for Ansible:
@@ -391,6 +425,10 @@ The Workflow Execution controller launches the AWX job template, passes paramete
 
 - **Secrets** (`dependencies.secrets`): Injected as environment variables via ephemeral AWX credentials (`KUBERNAUT_SECRET_{NAME}_{KEY}`). Use `lookup('env', ...)` in your playbook.
 - **ConfigMaps** (`dependencies.configMaps`): Merged into AWX extra_vars (`KUBERNAUT_CONFIGMAP_{NAME}_{KEY}`). Access as standard Ansible variables.
+
+**Automatic K8s API credentials:**
+
+The executor automatically injects the WE controller's in-cluster ServiceAccount token as an ephemeral AWX credential on every job launch. Playbooks using `kubernetes.core` modules receive `K8S_AUTH_HOST`, `K8S_AUTH_API_KEY`, and `K8S_AUTH_SSL_CA_CERT` environment variables without manual credential configuration. The credential is ephemeral and deleted after the job completes. If the in-cluster environment is unavailable, the job proceeds without K8s credentials.
 
 ## The Validate-Action-Verify Pattern
 


### PR DESCRIPTION
## Summary

Aligns kubernaut-docs with two merged PRs on kubernaut main:

- **[PR #504](https://github.com/jordigilh/kubernaut/pull/504) -- BR-496 v2: HAPI-owned target resource identity**
  - Every workflow schema must now declare `TARGET_RESOURCE_NAME`, `TARGET_RESOURCE_KIND`, `TARGET_RESOURCE_NAMESPACE` as `required: true`
  - HAPI injects these from K8s-verified `root_owner` (owner chain resolution); the LLM never sees them
  - `affectedResource` is constructed by HAPI, not the LLM
  - `rca_incomplete` is the sole failure mode when `root_owner` is missing
  - Removed: `affectedResource_mismatch`, `unverified_target_resource`, 4-layer defense model

- **[PR #499](https://github.com/jordigilh/kubernaut/pull/499) issue #500 -- K8s SA token injection**
  - Ansible executor auto-injects WE controller SA token as ephemeral AWX credential
  - Playbooks using `kubernetes.core` get `K8S_AUTH_HOST`, `K8S_AUTH_API_KEY`, `K8S_AUTH_SSL_CA_CERT` automatically

### Files changed (6)

| File | Changes |
|---|---|
| `workflows.md` | Canonical params in example schema and script, rewritten Parameters section with two injection layers, updated engine descriptions, K8s auth in Ansible section |
| `workflow-authoring.md` | Canonical params replace `TARGET_NAMESPACE` in both example workflows |
| `workflow-execution.md` | Canonical params in parameter injection tables, K8s credential step in Ansible architecture, K8s auth vars in Ansible variable table |
| `hapi-investigation.md` | Outcome 1 and Outcome 5 rewritten for HAPI-owned target identity |
| `crds.md` | Regenerated from kubernaut main (`RcaIncomplete` SubReason, BR-496 v2 descriptions) |
| `configuration.md` | K8s credential auto-injection note in Ansible Engine section |

## Test plan

- [ ] Verify canonical `TARGET_RESOURCE_*` params appear in all workflow examples
- [ ] Verify `remediate.sh` script uses `$TARGET_RESOURCE_NAMESPACE` (not `$TARGET_NAMESPACE`)
- [ ] Verify Parameters section explains both HAPI-injected and WFE-injected layers
- [ ] Verify hapi-investigation.md Outcome 1 no longer claims LLM returns `affectedResource`
- [ ] Verify hapi-investigation.md Outcome 5 references `root_owner` missing, not LLM
- [ ] Verify crds.md no longer contains `affectedResource_mismatch` or `unverified_target_resource`
- [ ] Verify K8s credential injection is documented in workflows.md, workflow-execution.md, and configuration.md

Made with [Cursor](https://cursor.com)