### PR TITLE
docs: update executionEngine location (spec → status) per #518

### DIFF
--- a/docs/api-reference/crds.md
+++ b/docs/api-reference/crds.md
@@ -1544,7 +1544,6 @@ _Appears in:_
 | `parameters`| _object (keys:string, values:string)_| Parameters from LLM selection <br />Keys are UPPER_SNAKE_CASE for Tekton PipelineRun params|
 | `confidence`| _float_| Confidence score from LLM (for audit trail)|
 | `rationale`| _string_| Rationale from LLM (for audit trail)|
-| `executionEngine`| _string_| ExecutionEngine specifies the backend engine for workflow execution.<br />"tekton" creates a Tekton PipelineRun; "job" creates a Kubernetes Job; "ansible" runs an AWX job.|
 | `executionConfig`| _[ExecutionConfig](#executionconfig)_| ExecutionConfig contains minimal execution settings|
 
 
@@ -1569,6 +1568,7 @@ _Appears in:_
 | `failureDetails`| _[FailureDetails](#failuredetails)_| FailureDetails contains structured failure information<br />Populated when Phase=Failed|
 | `blockClearance`| _[BlockClearanceDetails](#blockclearancedetails)_| BlockClearance tracks the clearing of PreviousExecutionFailed blocks<br />When set, allows new executions despite previous execution failure<br />Preserves audit trail of WHO cleared the block and WHY|
 | `ephemeralCredentialIDs`| _integer array_| EphemeralCredentialIDs stores AWX credential IDs created by the ansible<br />executor for cleanup after execution . Written via the status<br />subresource to avoid violating spec immutability .|
+| `executionEngine`| _string_| ExecutionEngine is the backend engine resolved from the DS workflow catalog<br />at runtime by the WE controller. Set once during Pending phase via<br />WorkflowQuerier.GetWorkflowExecutionEngine; immutable thereafter.<br />Values: "tekton", "job", "ansible".|
 | `conditions`| _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#condition-v1-meta) array_| Conditions provide detailed status information|
 
 

--- a/docs/architecture/workflow-execution.md
+++ b/docs/architecture/workflow-execution.md
@@ -85,7 +85,7 @@ Fetches workflow dependencies from DataStorage and validates them in the executi
 
 ### 4. Execution Creation
 
-Creates a Kubernetes Job, Tekton PipelineRun, or AWX Job based on `ExecutionEngine`:
+Resolves the execution engine from the DS workflow catalog and creates a Kubernetes Job, Tekton PipelineRun, or AWX Job accordingly:
 
 - The executor registry dispatches to the appropriate engine (`tekton`, `job`, or `ansible`)
 - **AlreadyExists handling** (Job/Tekton only): If the resource already exists and belongs to this WFE, adopt it (idempotent). If it belongs to another WFE, mark as `Failed` (race condition).


### PR DESCRIPTION
## Summary

- Regenerated `crds.md` from kubernaut main: `executionEngine` removed from `WorkflowExecutionSpec`, added to `WorkflowExecutionStatus` with description reflecting runtime resolution from DS catalog.
- Updated `workflow-execution.md` to clarify the WE controller resolves the execution engine from the DS workflow catalog at runtime.

Per [kubernaut PR #517](https://github.com/jordigilh/kubernaut/pull/517) issue #518.

## Test plan

- [ ] Verify `executionEngine` no longer appears in WorkflowExecutionSpec in crds.md
- [ ] Verify `executionEngine` appears in WorkflowExecutionStatus with runtime resolution description
- [ ] Verify workflow-execution.md step 4 mentions DS catalog resolution

Made with [Cursor](https://cursor.com)