### PR TITLE
docs: update notification routing to catch-all pattern (#571)

### DIFF
--- a/docs/user-guide/configmap-notification.md
+++ b/docs/user-guide/configmap-notification.md
@@ -35,7 +35,9 @@ helm install kubernaut charts/kubernaut/ \
 
 ### Default (no config provided)
 
-When neither option is set and `notification.slack.secretName` is empty, the chart generates a console-only routing config:
+When `routing.existingConfigMap` is set, the chart skips ConfigMap creation entirely and uses the pre-existing ConfigMap as-is. The defaults below only apply when **neither** `routing.content` **nor** `routing.existingConfigMap` is set.
+
+When `notification.slack.secretName` is empty, the chart generates a console-only routing config:
 
 ```yaml
 route:

--- a/docs/user-guide/notifications.md
+++ b/docs/user-guide/notifications.md
@@ -36,7 +36,7 @@ receivers:
         credentialRef: slack-webhook
 ```
 
-The catch-all receiver routes **all** notification types (escalation, approval_required, failed, manual-review, completion) to both Slack and console. Avoid matching specific types unless you intentionally want to suppress certain notifications from a channel.
+The catch-all receiver routes **all** notification types to both Slack and console. New types added in future releases are automatically covered. Avoid matching specific types unless you intentionally want to suppress certain notifications from a channel.
 
 ### Match Fields
 


### PR DESCRIPTION
## Summary

- Replace outdated type-specific routing example in `notifications.md` with the catch-all `slack-and-console` receiver that routes all notification types to both channels
- Document the Slack shortcut behavior in `configmap-notification.md` — when `slack.secretName` is set, the chart generates a catch-all config instead of console-only

The old pattern matched specific notification types individually (`escalation`, `approval_required`, `failed`), which caused other types (`manual-review`, `completion`) to fall through to console-only. kubernaut#571 fixed this by using a single catch-all receiver.

## Test plan

- [ ] Verify the routing examples match the chart template output

Closes #52

Made with [Cursor](https://cursor.com)