### PR TITLE
docs: fix HAPI workflow selection, routing diagrams, and ManualReviewRequired paths

### DIFF
--- a/docs/architecture/ai-analysis.md
+++ b/docs/architecture/ai-analysis.md
@@ -83,7 +83,7 @@ HolmesGPT is a Python FastAPI service that orchestrates LLM-driven investigation
 1. **Reads the enriched signal** — Alert details, target resource, namespace context
 2. **Investigates using K8s tools** — Inspects pod logs, events, resource state, and live metrics via `kubectl`; optionally queries Prometheus, Grafana Loki/Tempo, and other configured toolsets
 3. **Produces a root cause analysis** — Structured explanation of what went wrong
-4. **Resolves the target resource** — Calls `get_resource_context` to resolve the owner chain, compute a spec hash, fetch **remediation history** (past outcomes and effectiveness scores from DataStorage), and detect **infrastructure labels** (GitOps, Helm, service mesh, HPA, PDB)
+4. **Resolves the target resource** — Calls `get_namespaced_resource_context` (or `get_cluster_resource_context` for cluster-scoped resources) to resolve the owner chain, compute a spec hash, fetch **remediation history** (past outcomes and effectiveness scores via internal DataStorage lookup), and detect **infrastructure labels** (GitOps, Helm, service mesh, HPA, PDB)
 5. **Discovers workflows via DataStorage** — The LLM uses a three-step protocol: `list_available_actions` → `list_workflows` → `get_workflow`. Signal context and detected labels are auto-injected as filters; DataStorage orders results by label-match scoring (scores not exposed to the LLM).
 6. **LLM selects a workflow** — Based on workflow descriptions (`what`, `whenToUse`, `whenNotToUse`), detected infrastructure context, and remediation history
 7. **Returns `actionable` flag** — Indicates whether the investigation identified a concrete remediation action. Propagated to the `AIAnalysis` CRD status and used downstream for audit and decision filtering.
@@ -109,7 +109,7 @@ Without this bypass, a resolved incident with a detailed RCA would be incorrectl
 
 The Analyzing handler evaluates a **user-replaceable Rego policy** (`approval.rego`) to determine whether the remediation requires human approval. The policy receives the full analysis context as input and returns `require_approval` (boolean) and `reason` (string).
 
-The **default shipped policy** gates on environment and affected resource presence:
+The **default shipped policy** gates on environment and remediation target presence:
 
 - **Production** — always requires approval
 - **Non-production** — auto-approved when `remediation_target` is present

--- a/docs/architecture/hapi-investigation.md
+++ b/docs/architecture/hapi-investigation.md
@@ -413,7 +413,9 @@ The LLM investigation can produce 8 distinct outcomes, each handled differently 
 ```mermaid
 flowchart TD
     HAPI["HAPI Response"] --> NHR{"needs_human_review?"}
-    NHR -->|true| HumanReview["Human Review<br/><small>Phase: Failed</small>"]
+    NHR -->|true| HasWFReview{"selected_workflow?"}
+    HasWFReview -->|present| HRFailed["Human Review + Workflow<br/><small>Phase: Failed</small>"]
+    HasWFReview -->|null| HRCompleted["Manual Review Required<br/><small>Phase: Completed</small>"]
     NHR -->|false| HasWF{"selected_workflow?"}
     HasWF -->|null| Resolved{"Problem resolved?"}
     HasWF -->|present| Confidence{"confidence >= 0.7?"}
@@ -475,7 +477,7 @@ The LLM selected a workflow that fails catalog validation (wrong ID, image misma
 The LLM returns a workflow with `confidence` below the investigation threshold (0.7). HAPI does not enforce this threshold -- it passes the confidence through. The AA controller's response processor detects the low confidence.
 
 **Fields:** `selected_workflow` present, `confidence < 0.7`
-**Next:** AA routes to human review via `handleLowConfidenceFailure`. Rego is never evaluated.
+**Next:** AA response processor rejects the low-confidence selection and routes to human review. Rego is never evaluated.
 
 ### Outcome 8: LLM Explicitly Requests Human Review
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -43,7 +43,7 @@ Each service has a single responsibility:
 | **Gateway** | Signal ingestion, authentication, scope checking, deduplication, RR creation | [Gateway](gateway.md) |
 | **Signal Processing** | Kubernetes context enrichment, Rego-based classification (environment, severity, priority, signal mode), business categorization | [Signal Processing](signal-processing.md) |
 | **AI Analysis** | Orchestrates HolmesGPT investigation session, evaluates Rego approval policy | [AI Analysis](ai-analysis.md) |
-| **HolmesGPT API** | LLM-driven investigation with K8s tools, infrastructure label detection, remediation history, three-step workflow discovery | [Investigation Pipeline](hapi-investigation.md) |
+| **HolmesGPT API** | LLM-driven investigation with K8s tools, infrastructure label detection, tiered remediation history (via DataStorage), three-step LLM-driven workflow discovery | [Investigation Pipeline](hapi-investigation.md) |
 | **Remediation Orchestrator** | Lifecycle coordination, routing engine, timeout enforcement, child CRD management | [Remediation Routing](remediation-routing.md) |
 | **Workflow Execution** | Dependency resolution, Job/Tekton execution, cooldown, deterministic locking | [Workflow Execution](workflow-execution.md) |
 | **Notification** | Multi-channel delivery with routing, retry, circuit breaker | [Notification Pipeline](notification.md) |
@@ -150,7 +150,7 @@ An internal admission webhook validates and audits:
 - **DataStorage** -- Kubernetes TokenReview + SubjectAccessReview middleware (DD-AUTH-014)
 - **Gateway** -- Kubernetes TokenReview + SubjectAccessReview middleware for signal ingestion (see [Security & RBAC](security-rbac.md#signal-ingestion))
 - **NetworkPolicies** -- Not included in Helm chart ([GitHub #285](https://github.com/jordigilh/kubernaut/issues/285)); recommended for production deployments
-- **TLS** -- Not configured for internal service-to-service traffic in v1.0
+- **TLS** -- Not configured for internal service-to-service traffic in v1.1
 
 ## Error Handling Patterns
 

--- a/docs/architecture/remediation-routing.md
+++ b/docs/architecture/remediation-routing.md
@@ -25,10 +25,10 @@ stateDiagram-v2
     Processing --> Analyzing : SP completed → Create AIAnalysis
     Processing --> Failed : SP failed
     Processing --> TimedOut : Phase timeout
-    Analyzing --> AwaitingApproval : Low confidence → Create RAR
+    Analyzing --> AwaitingApproval : Rego approval required → Create RAR
     Analyzing --> Executing : Auto-approved + post-analysis passes → Create WFE
     Analyzing --> Blocked : Post-analysis check fails
-    Analyzing --> Completed : No workflow needed / ManualReviewRequired
+    Analyzing --> Completed : NoActionRequired / ManualReviewRequired
     Analyzing --> Failed : AI analysis failed
     Analyzing --> TimedOut : Phase timeout
     AwaitingApproval --> Executing : Approved → Create WFE
@@ -97,14 +97,15 @@ Failed      → Blocked
 
 ### Analyzing → (multiple outcomes)
 
-The AI Analysis produces one of five outcomes:
+The AI Analysis produces one of six outcomes:
 
 | AA Outcome | RR Action |
 |---|---|
 | **Normal** (workflow selected, auto-approved) | Run post-analysis checks → create **WFE** → **Executing** |
-| **ApprovalRequired** (low confidence) | Create **RemediationApprovalRequest** → **AwaitingApproval** |
+| **ApprovalRequired** (Rego policy mandate) | Create **RemediationApprovalRequest** → **AwaitingApproval** |
 | **WorkflowNotNeeded** (issue already resolved) | Transition to **Completed** with `Outcome: NoActionRequired` |
-| **ManualReviewRequired** (no workflow, human review needed) | Transition to **Completed** with `Outcome: ManualReviewRequired` |
+| **ManualReviewRequired** (no workflow, HAPI flagged human review) | Transition to **Completed** with `Outcome: ManualReviewRequired` |
+| **HumanReviewWithWorkflow** (HAPI flagged review + workflow present) | Transition to **Failed** (see [ManualReviewRequired Outcome](#manualreviewrequired-outcome)) |
 | **Failed** (AI analysis error) | Transition to **Failed** |
 
 For the normal path, the Orchestrator runs **post-analysis routing checks** before creating the WFE. If blocked, the RR enters **Blocked** (returning to Analyzing when the block clears).
@@ -272,7 +273,8 @@ When a RR reaches a terminal phase:
 
 | Trigger | Escalation | Mechanism |
 |---|---|---|
-| Low AI confidence | Human approval | RemediationApprovalRequest CRD |
+| Rego policy requires approval (environment, sensitive kind, confidence) | Human approval | RemediationApprovalRequest CRD |
+| HAPI flags human review with selected workflow | Notification + Failed | NotificationRequest with rejected recommendation |
 | Failure at any stage | Team notification | NotificationRequest with error context |
 | No matching workflow | Team notification with RCA | NotificationRequest |
 | Consecutive ineffective remediations | Manual review | `IneffectiveChain` block + `RequiresManualReview` |

--- a/docs/getting-started/aiops-landscape.md
+++ b/docs/getting-started/aiops-landscape.md
@@ -36,7 +36,7 @@ Platforms like Dynatrace Davis and Datadog Watchdog build their intelligence fro
 
 Kubernaut's LLM investigates each incident as an open-ended question rather than a pattern match:
 
-1. The LLM receives the alert context, affected resource metadata, namespace labels, and remediation history.
+1. The LLM receives the alert context, remediation target metadata, namespace labels, and remediation history.
 2. It queries live cluster state via tool calls -- `kubectl get`, `kubectl describe`, `kubectl logs`, Prometheus queries.
 3. It reasons about the root cause, considering that the signal resource (e.g., a crashing Pod) may differ from the actual cause (e.g., a broken ConfigMap or an exhausted ResourceQuota).
 4. It selects a remediation workflow from the catalog based on the diagnosed cause, environmental context (GitOps-managed? production? stateful?), and confidence level.
@@ -54,7 +54,7 @@ Kubernaut's LLM investigates each incident as an open-ended question rather than
 - **Non-deterministic**: The same input may produce different reasoning paths. This complicates auditing, though Kubernaut mitigates this with full investigation transcripts and structured output.
 - **Latency**: LLM investigation adds 10-30 seconds. For incidents where millisecond response matters, this overhead is unavoidable in the current architecture.
 - **Hallucination risk**: The LLM may confidently diagnose the wrong root cause. Kubernaut addresses this through approval gates, Rego policies, effectiveness verification, and the cross-validation architecture described below.
-- **Per-token cost**: Each investigation consumes LLM API tokens. Workflow selection from the catalog is label-based (no LLM call), so cost scales with investigations, not catalog size. For cost-sensitive environments, use smaller models or locally hosted LLMs via LiteLLM.
+- **Per-token cost**: Each investigation consumes LLM API tokens. Investigation, enrichment, and workflow selection run as a single LLM agent session; DataStorage applies label-based ranking to catalog queries but the LLM drives the final selection. Cost scales with investigations. For cost-sensitive environments, use smaller models or locally hosted LLMs via LiteLLM.
 
 ## Predictive AI as a Knowledge-Based Agent
 

--- a/docs/getting-started/why-kubernaut.md
+++ b/docs/getting-started/why-kubernaut.md
@@ -39,11 +39,11 @@ The AIOps remediation landscape has three distinct approaches. Kubernaut uses ge
 | **Learning from failure** | None — repeats the same action | Adjusts baselines over time | Effectiveness scores feed into future investigations |
 | **Cold start** | None — works immediately | Weeks/months of baseline data required | None — useful from day one |
 | **Latency** | Milliseconds | Seconds (pre-computed models) | 10-30s (LLM investigation) |
-| **Token cost** | None | Vendor license | Per-investigation (workflow selection is label-based, no extra LLM call) |
+| **Token cost** | None | Vendor license | Per-investigation (includes LLM-driven workflow selection in the same session) |
 | **Auditability** | Deterministic, easy to trace | Deterministic, vendor-specific dashboards | Full audit trail with 7-year retention (SOC2-aligned); LLM reasoning is probabilistic |
 | **Vendor coupling** | Low | High — deep integration with vendor telemetry stack | Low — works with any monitoring stack |
 
-**Where rule-based tools win**: speed, zero token cost, deterministic auditability, and simplicity for well-understood single-action problems. Kubernaut's workflow catalog uses label-based scoring for selection (no LLM invocation) -- but the LLM investigation always runs first to diagnose the root cause.
+**Where rule-based tools win**: speed, zero token cost, deterministic auditability, and simplicity for well-understood single-action problems. Kubernaut's workflow catalog uses label-based scoring to rank candidates, but the LLM drives the final selection decision in a dedicated Phase 3 session -- investigation, enrichment, and workflow selection all happen in one agent session.
 
 **Where predictive AI fits**: anomaly detection and topology-aware correlation for known failure patterns. Rather than competing with generative AI, predictive AI platforms are most valuable as **knowledge-based agents** that the LLM can query during investigation — confirming hypotheses, providing dependency context, and boosting confidence. See [AIOps Remediation Landscape](aiops-landscape.md) for the full integration architecture.
 

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -45,11 +45,13 @@ Created after a RemediationRequest is accepted. The Signal Processing controller
 
 Created after signal enrichment completes. The AI Analysis controller:
 
-1. Submits the enriched signal to **HolmesGPT** (via the HolmesGPT API service) for live root cause investigation
-2. HolmesGPT investigates using Kubernetes inspection tools (pod logs, events, resource state, live metrics) and optionally Prometheus, Grafana Loki/Tempo, and other configured observability toolsets
-3. Resolves the target resource's owner chain, computes a spec hash, fetches **remediation history** (past outcomes and effectiveness scores), and detects **infrastructure labels** (GitOps, Helm, service mesh, HPA, PDB) — giving the LLM full context before workflow selection
-4. Searches the **workflow catalog** for a matching remediation based on enriched signal labels, detected infrastructure, and historical outcomes
-5. Evaluates whether auto-approval is safe via a **Rego policy** (configurable confidence threshold)
+1. Submits the enriched signal to **HolmesGPT** (via the HolmesGPT API service) for a three-phase LLM investigation:
+    - **Phase 1: Investigate** — Root cause analysis using live cluster data (logs, events, resource state, metrics)
+    - **Phase 2: Enrich** — Resolves the target resource's owner chain, computes a spec hash, fetches **remediation history** (past outcomes and effectiveness scores via DataStorage), and detects **infrastructure labels** (GitOps, Helm, service mesh, HPA, PDB)
+    - **Phase 3: Workflow Select** — The LLM discovers and selects a workflow from the catalog via a three-step protocol (`list_available_actions` → `list_workflows` → `get_workflow`); DataStorage applies label-based ranking but the LLM drives the final selection
+2. Evaluates whether auto-approval is safe via a **Rego policy** (configurable confidence threshold)
+
+See [Investigation Pipeline](../architecture/hapi-investigation.md) for the full three-phase architecture.
 
 ### RemediationApprovalRequest
 
@@ -94,8 +96,8 @@ A `RemediationRequest` progresses through these phases:
 | **Executing** | Workflow is running the remediation |
 | **Verifying** | Workflow succeeded; effectiveness assessment in progress |
 | **Blocked** | Routing engine prevents progress; automatically retried after cooldown (see below) |
-| **Completed** | Remediation finished successfully |
-| **Failed** | Remediation failed at any stage (including human rejection) |
+| **Completed** | Remediation finished successfully, or `NoActionRequired` / `ManualReviewRequired` outcome |
+| **Failed** | Remediation failed at any stage (including human rejection, or HAPI flagged human review with a selected workflow) |
 | **TimedOut** | Phase timeout expired |
 | **Skipped** | Remediation skipped (e.g., resource busy) |
 | **Cancelled** | Remediation cancelled |


### PR DESCRIPTION
## Summary

Fixes the highest-risk cluster from the v1.1.0 documentation review (#71):

- **H1**: Corrects "label-based, no LLM call" claims in `why-kubernaut.md` and `aiops-landscape.md` — Phase 3 is an explicit LLM session with workflow discovery tools; DataStorage applies label-based ranking but the LLM drives selection
- **H6**: Fixes `remediation-routing.md` diagram and outcomes table — `AwaitingApproval` is Rego policy-driven (not "low confidence"); adds the `NeedsHumanReview + SelectedWorkflow` → `Failed` path as a distinct outcome
- **H7**: Fixes `hapi-investigation.md` outcomes Mermaid — splits `needs_human_review` by `SelectedWorkflow` presence (nil → Completed/ManualReviewRequired, present → Failed)
- **M5/M6**: Adds HAPI 3-phase model to `concepts.md` and `ManualReviewRequired`/`NoActionRequired` to the phases table
- **M13**: Clarifies remediation history provenance in `overview.md` (via DataStorage, not standalone HAPI capability)
- Also fixes stale `get_resource_context` in `ai-analysis.md`, "affected resource" → "remediation target" terminology, and "v1.0" → "v1.1" TLS note

## Test plan

- [ ] Verify Mermaid diagrams render correctly in MkDocs
- [ ] Cross-reference routing diagram transitions against `phase/types.go` valid transitions
- [ ] Verify concepts.md 3-phase description aligns with `hapi-investigation.md`

Closes #71

Made with [Cursor](https://cursor.com)