### PR TITLE
docs: fix Rego input paths, priority values, source links, and approval defaults

### DIFF
--- a/docs/user-guide/approval.md
+++ b/docs/user-guide/approval.md
@@ -7,15 +7,16 @@ Kubernaut supports human-in-the-loop approval gates to ensure that remediations 
 
 ## When Approval Is Required
 
-Approval is determined by a **user-replaceable Rego policy** evaluated during the AI Analysis phase. Operators control approval behavior by editing the Rego policy in the `aianalysis-rego` ConfigMap -- the policy is not hardcoded.
+Approval is determined by a **user-replaceable Rego policy** evaluated during the AI Analysis phase. Operators control approval behavior by editing the Rego policy in the `aianalysis-policies` ConfigMap -- the policy is not hardcoded.
 
 ### Default Policy Behavior
 
-The shipped `approval.rego` makes decisions based on **environment** and **affected resource presence**:
+The shipped `approval.rego` makes decisions based on **environment**, **remediation target presence**, and **sensitive resource kinds**:
 
 - **Production namespaces** (`kubernaut.ai/environment=production`) — always require approval, regardless of confidence
-- **Non-production namespaces** (`staging`, `development`, `qa`, `test`) — auto-approved when `remediation_target` is present
-- **Missing affected resource** — always requires approval (default-deny safety per ADR-055)
+- **Sensitive resource kinds** (Node, StatefulSet) — always require approval, regardless of environment
+- **Non-production namespaces** (`staging`, `development`, `qa`, `test`) — auto-approved when `remediation_target` is present and the resource kind is not sensitive
+- **Missing remediation target** — always requires approval (default-deny safety per ADR-055)
 
 When approval is required, a `RemediationApprovalRequest` CRD is created and the remediation enters the `AwaitingApproval` phase.
 
@@ -266,7 +267,7 @@ The built-in policy behavior:
 - **Non-production namespaces**: Auto-approved unless critical safety conditions (missing `remediation_target`)
 - **Missing affected resource**: Always requires approval (default-deny safety)
 
-Operators can customize approval behavior by modifying the Rego policy in the `aianalysis-rego` ConfigMap.
+Operators can customize approval behavior by modifying the Rego policy in the `aianalysis-policies` ConfigMap.
 
 ## Approval Context
 

--- a/docs/user-guide/configmap-approval.md
+++ b/docs/user-guide/configmap-approval.md
@@ -44,7 +44,7 @@ The approval policy receives this input from the AIAnalysis controller:
 | `confidence_threshold` | float | Configurable threshold (default 0.8, via `aianalysis.rego.confidenceThreshold`) |
 | `remediation_target` | object | LLM-identified remediation target (`kind`, `name`, `namespace`) |
 | `target_resource` | object | Original alert target resource |
-| `detected_labels` | map | Detected workload labels (`stateful`, `gitOpsManaged`, `pdbProtected`) |
+| `detected_labels` | map | Detected workload labels (snake_case keys: `stateful`, `git_ops_managed`, `pdb_protected`, `hpa_enabled`, `helm_managed`, `network_isolated`, `service_mesh`) |
 | `failed_detections` | array | Detection fields that failed (e.g., `["gitOpsManaged"]`) |
 | `warnings` | array | Investigation warnings |
 

--- a/docs/user-guide/configmap-notification.md
+++ b/docs/user-guide/configmap-notification.md
@@ -95,7 +95,7 @@ receivers:
 |---|---|---|
 | `type` | Notification type | `escalation`, `approval_required`, `failed`, `manual-review`, `completion` |
 | `severity` | Signal severity | `critical`, `high`, `medium`, `low` |
-| `priority` | Signal priority | `critical`, `high`, `medium`, `low` |
+| `priority` | Signal priority | `P0`, `P1`, `P2`, `P3` (also accepts `critical`, `high`, `medium`, `low`) |
 | `phase` | Remediation phase | `signal-processing`, `ai-analysis`, `executing` |
 | `environment` | Namespace environment | `production`, `staging`, `development` |
 

--- a/docs/user-guide/notifications.md
+++ b/docs/user-guide/notifications.md
@@ -49,7 +49,7 @@ Routes match on notification attributes:
 |---|---|---|
 | `type` | Notification type | `escalation`, `approval_required`, `failed`, `manual-review`, `completion` |
 | `severity` | Signal severity | `critical`, `high`, `medium`, `low` |
-| `priority` | Signal priority | `critical`, `high`, `medium`, `low` |
+| `priority` | Signal priority | `P0`, `P1`, `P2`, `P3` (also accepts `critical`, `high`, `medium`, `low`) |
 | `phase` | Remediation phase | `signal-processing`, `ai-analysis`, `executing` |
 | `environment` | Namespace environment | `production`, `staging`, `development` |
 | `review-source` | Why review was triggered | `WorkflowResolutionFailed`, `ExhaustedRetries` |

--- a/docs/user-guide/policies.md
+++ b/docs/user-guide/policies.md
@@ -181,13 +181,15 @@ The approval policy runs after HAPI returns a successful workflow selection. It 
 
 ### Approval Rules
 
-Two mandatory triggers:
+Three mandatory triggers:
 
 1. **Missing remediation target** -- If `remediation_target` is absent or has an empty `kind`, approval is always required. Safety net for incomplete RCA.
 
 2. **Production environment** -- All production remediations require human approval, regardless of confidence. Controlled by setting `kubernaut.ai/environment=production` on the namespace.
 
-Non-production environments (development, staging, qa, test) auto-approve when `remediation_target` is present.
+3. **Sensitive resource kinds** -- Remediations targeting `Node` or `StatefulSet` resources always require approval, regardless of environment. These are high-impact resources where automated remediation carries elevated risk.
+
+Non-production environments (development, staging, qa, test) auto-approve when `remediation_target` is present and the resource kind is not sensitive.
 
 ### Confidence Threshold
 

--- a/docs/user-guide/rego-reference.md
+++ b/docs/user-guide/rego-reference.md
@@ -536,9 +536,9 @@ reason := f.reason if { some f in risk_factors; f.score == max_risk_score }
 |---|---|---|
 | **Severity** | `input.signal.*` | `severity`, `type`, `source` |
 | **Environment** | `input.namespace.*`, `input.signal.*` | `namespace.name`, `namespace.labels`, `signal.labels` |
-| **Priority** | `input.signal.*`, `input.*` | `signal.severity`, `signal.source`, `environment`, `namespace_labels`, `workload_labels` |
+| **Priority** | `input.signal.*`, `input.namespace.*`, `input.workload.*` | `signal.severity`, `signal.source`, `namespace.labels`, `workload.labels` |
 | **Business** | `input.namespace.*`, `input.workload.*`, `input.*` | `namespace.name/labels/annotations`, `workload.kind/name/labels/annotations`, `environment` |
-| **Custom Labels** | `input.kubernetes.*`, `input.signal.*` | `kubernetes.namespace.name/labels/annotations`, `kubernetes.workload.kind/name/labels/annotations`, `kubernetes.ownerChain`, `signal.type/severity/source` |
+| **Custom Labels** | `input.namespace.*`, `input.workload.*`, `input.signal.*` | `namespace.name/labels/annotations`, `workload.kind/name/labels/annotations`, `workload.ownerChain`, `signal.type/severity/source` |
 
 ### AI Analysis Approval
 
@@ -557,12 +557,11 @@ reason := f.reason if { some f in risk_factors; f.score == max_risk_score }
 
 | Component | Source File |
 |---|---|
-| Severity classifier | [`pkg/signalprocessing/classifier/severity.go`](https://github.com/jordigilh/kubernaut/blob/main/pkg/signalprocessing/classifier/severity.go) |
-| Priority classifier | [`pkg/signalprocessing/classifier/priority.go`](https://github.com/jordigilh/kubernaut/blob/main/pkg/signalprocessing/classifier/priority.go) |
-| Environment classifier | [`pkg/signalprocessing/classifier/environment.go`](https://github.com/jordigilh/kubernaut/blob/main/pkg/signalprocessing/classifier/environment.go) |
-| Business classifier | [`pkg/signalprocessing/classifier/business.go`](https://github.com/jordigilh/kubernaut/blob/main/pkg/signalprocessing/classifier/business.go) |
-| Custom labels engine | [`pkg/signalprocessing/rego/engine.go`](https://github.com/jordigilh/kubernaut/blob/main/pkg/signalprocessing/rego/engine.go) |
-| AA approval evaluator | [`pkg/aianalysis/rego/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/main/pkg/aianalysis/rego/evaluator.go) |
-| AA input builder | [`pkg/aianalysis/handlers/analyzing.go`](https://github.com/jordigilh/kubernaut/blob/main/pkg/aianalysis/handlers/analyzing.go) |
-| Default approval policy | [`config/rego/aianalysis/approval.rego`](https://github.com/jordigilh/kubernaut/blob/main/config/rego/aianalysis/approval.rego) |
-| Default SP policies | [`deploy/signalprocessing/policies/`](https://github.com/jordigilh/kubernaut/tree/main/deploy/signalprocessing/policies) |
+| SP unified evaluator | [`pkg/signalprocessing/evaluator/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.1.0/pkg/signalprocessing/evaluator/evaluator.go) |
+| SP policy input types | [`pkg/signalprocessing/evaluator/types.go`](https://github.com/jordigilh/kubernaut/blob/v1.1.0/pkg/signalprocessing/evaluator/types.go) |
+| SP signal mode classifier | [`pkg/signalprocessing/classifier/signalmode.go`](https://github.com/jordigilh/kubernaut/blob/v1.1.0/pkg/signalprocessing/classifier/signalmode.go) |
+| SP example policy | [`charts/kubernaut/examples/signalprocessing-policy.rego`](https://github.com/jordigilh/kubernaut/blob/v1.1.0/charts/kubernaut/examples/signalprocessing-policy.rego) |
+| SP deploy policies | [`deploy/signalprocessing/policies/`](https://github.com/jordigilh/kubernaut/tree/v1.1.0/deploy/signalprocessing/policies) |
+| AA approval evaluator | [`pkg/aianalysis/rego/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.1.0/pkg/aianalysis/rego/evaluator.go) |
+| AA input builder | [`pkg/aianalysis/handlers/analyzing.go`](https://github.com/jordigilh/kubernaut/blob/v1.1.0/pkg/aianalysis/handlers/analyzing.go) |
+| AA approval policy (test) | [`test/unit/aianalysis/testdata/policies/approval.rego`](https://github.com/jordigilh/kubernaut/blob/v1.1.0/test/unit/aianalysis/testdata/policies/approval.rego) |


### PR DESCRIPTION
## Summary

Fixes the Rego/SP/notification cluster from the v1.1.0 documentation review (#72) plus related approval issues from #73:

- **H2**: Fixes SP Quick Reference input paths — replaces `input.kubernetes.*` with the correct `input.namespace.*`, `input.workload.*`, `input.signal.*` paths matching the `PolicyInput` struct
- **H3**: Fixes `priority` match examples — uses `P0`-`P3` with a note that severity-style values are also accepted per `routing/attributes.go`
- **H10**: Replaces all stale source code links (404s) with v1.1.0 permanent links to the unified evaluator, deploy policies, and test approval policy
- **M10**: Fixes `detected_labels` keys in `configmap-approval.md` — uses snake_case (`git_ops_managed`, `pdb_protected`) matching Rego input
- **M4**: Fixes ConfigMap name `aianalysis-rego` → `aianalysis-policies` in `approval.md`
- **M9**: Adds sensitive resource kinds (Node, StatefulSet) as third mandatory approval trigger in `policies.md` and `approval.md`

## Test plan

- [ ] Verify source code links resolve (v1.1.0 tag)
- [ ] Cross-check SP input paths against `evaluator/types.go` PolicyInput struct
- [ ] Verify priority values align with `routing/attributes.go` L48

Closes #72
Partially addresses #73 (M4, M9, M10)

Made with [Cursor](https://cursor.com)