### PR TITLE
docs: fix quickstart auth gap, disconnected overlay count, stale tool names, ops index

### DIFF
--- a/docs/architecture/data-persistence.md
+++ b/docs/architecture/data-persistence.md
@@ -147,7 +147,7 @@ The action type registry for workflow categorization.
 | `created_at` | `TIMESTAMPTZ` | Creation timestamp |
 | `updated_at` | `TIMESTAMPTZ` | Last update |
 
-The database deploys with a clean schema -- no pre-seeded rows. Action types are registered via `kubectl apply -f` on `ActionType` CRDs. The AuthWebhook intercepts the admission request and registers each action type in the DataStorage catalog via its REST API. See [Workflow Selection: Action Type Taxonomy](workflow-selection.md#action-type-taxonomy) and [Installation: Action Types](../getting-started/installation.md#action-types).
+The database deploys with a clean schema -- no pre-seeded rows. Action types are registered via `kubectl apply -f` on `ActionType` CRDs. The AuthWebhook intercepts the admission request and registers each action type in the DataStorage catalog via its REST API. See [Workflow Selection: Action Type Taxonomy](workflow-selection.md#action-type-taxonomy) and [Installation: Action Types](../getting-started/installation.md#action-types-and-workflows-demo-content).
 
 ### Other Tables
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -65,11 +65,41 @@ kubectl create secret generic llm-credentials \
   --from-literal=OPENAI_API_KEY=sk-... \
   -n kubernaut-system
 
-# 4. Install Kubernaut
+# 4. Configure AlertManager to forward alerts to the Gateway
+# The Gateway requires authenticated signal sources. Create a webhook receiver:
+kubectl apply -f - <<AMCFG
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: kubernaut-webhook
+  namespace: monitoring
+spec:
+  route:
+    receiver: kubernaut
+    matchers:
+      - name: kubernaut_managed
+        value: "true"
+  receivers:
+    - name: kubernaut
+      webhookConfigs:
+        - url: "http://gateway-service.kubernaut-system.svc.cluster.local:8080/api/v1/signals/prometheus"
+          httpConfig:
+            authorization:
+              type: Bearer
+              credentials:
+                name: alertmanager-kubernaut-token
+                key: token
+AMCFG
+
+# 5. Install Kubernaut with signal source authentication
 helm install kubernaut oci://quay.io/kubernaut-ai/charts/kubernaut \
   --namespace kubernaut-system \
+  --version {{ chart_version }} \
   --set holmesgptApi.llm.provider=openai \
   --set holmesgptApi.llm.model=gpt-4o \
+  --set gateway.auth.signalSources[0].name=alertmanager \
+  --set gateway.auth.signalSources[0].namespace=monitoring \
+  --set gateway.auth.signalSources[0].serviceAccount=alertmanager-kube-prometheus-stack-alertmanager \
   --wait --timeout 10m
 ```
 

--- a/docs/operations/disconnected-install.md
+++ b/docs/operations/disconnected-install.md
@@ -36,6 +36,8 @@ All published under `quay.io/kubernaut-ai/` with a tag matching the chart versio
 | `quay.io/kubernaut-ai/effectivenessmonitor` | Post-remediation effectiveness verification |
 | `quay.io/kubernaut-ai/holmesgpt-api` | LLM integration service |
 | `quay.io/kubernaut-ai/authwebhook` | Admission controller for CRD authorization |
+| `quay.io/kubernaut-ai/db-migrate` | Database schema migration (pre-upgrade hook) |
+| `quay.io/kubernaut-ai/must-gather` | Diagnostic data collection for support |
 
 ### Infrastructure images
 
@@ -235,7 +237,7 @@ The `separator` field controls how the namespace is joined to the service name:
 
 ### 4c. Install with layered overlays
 
-The three value files must be layered in this order:
+The two overlay files must be layered on top of the base `values.yaml` in this order:
 
 | Order | File | Purpose |
 |-------|------|---------|

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -4,5 +4,6 @@ Guides for running Kubernaut in production.
 
 - **[Monitoring](monitoring.md)** — Prometheus metrics, health checks, and dashboards. Documents available metrics, health endpoints, and recommended dashboards for production.
 - **[Troubleshooting](troubleshooting.md)** — Common issues and diagnostic procedures. Covers frequent failure modes and step-by-step diagnostic workflows.
-- **[Event Exporter](event-exporter.md)** — Kubernetes event forwarding to Gateway. Explains how to forward Kubernetes events to Kubernaut for remediation.
+- **[Event Exporter](event-exporter.md)** — Event Exporter (removed from chart). Deploy your own external forwarder to send Kubernetes events to the Gateway.
+- **[Upgrading](upgrading/index.md)** — Upgrade procedures, CRD handling, and secret migration notes.
 - **[Disconnected Install](disconnected-install.md)** — Mirror images and install Kubernaut on air-gapped OpenShift clusters.

--- a/docs/use-cases/multi-path-remediation.md
+++ b/docs/use-cases/multi-path-remediation.md
@@ -105,7 +105,7 @@ The `nonexistent-ca-secret` was then deleted to simulate the problem recurring. 
 
 ### History-Informed Decision Making
 
-When the LLM investigated the second incident, HAPI's `get_resource_context` tool
+When the LLM investigated the second incident, HAPI's resource context tools
 automatically queried DataStorage for the resource's remediation history. The HAPI logs
 confirmed:
 


### PR DESCRIPTION
## Summary

Fixes Operations and Getting Started gaps from #75:

- **M1**: Adds AlertManager webhook config + `gateway.auth.signalSources` to the quickstart manual setup — without this, the Gateway rejects unauthenticated alerts and the manual path won't deliver signals
- **M3**: Adds `--version {{ chart_version }}` to the quickstart Helm install command
- **H9**: Fixes "three value files" → "two overlay files on top of base values.yaml" in disconnected install
- **M20**: Adds `db-migrate` and `must-gather` to the disconnected image list (was 10, now 12)
- **M21**: Updates operations index — Event Exporter bullet reflects "(removed from chart)" status; adds missing Upgrading bullet
- **M22**: Fixes stale `get_resource_context` in `multi-path-remediation.md`
- **L12**: Fixes broken anchor `#action-types` → `#action-types-and-workflows-demo-content` in `data-persistence.md`

## Test plan

- [ ] Verify AlertmanagerConfig webhook config matches kube-prometheus-stack conventions
- [ ] Verify `gateway.auth.signalSources` Helm syntax
- [ ] Confirm db-migrate and must-gather images exist at v1.1.0
- [ ] Verify anchor resolves in built MkDocs site

Closes #75

Made with [Cursor](https://cursor.com)