### PR TITLE
fix(architecture): gateway.md + overview.md — Issue #83

### DIFF
--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -6,8 +6,8 @@ The Gateway is the entry point for all signals into Kubernaut. It accepts alerts
 
 ```mermaid
 flowchart LR
-    AM["AlertManager"] -->|POST /signals/prometheus| GW["Gateway"]
-    EE["Event Exporter"] -->|POST /signals/kubernetes-event| GW
+    AM["AlertManager"] -->|"POST /api/v1/signals/prometheus"| GW["Gateway"]
+    EE["Event Exporter"] -->|"POST /api/v1/signals/kubernetes-event"| GW
     GW -->|"Auth (SAR)"| K8s["Kubernetes API"]
     GW -->|"Scope check"| K8s
     GW -->|"Create RR"| K8s
@@ -32,7 +32,7 @@ Each signal source uses a dedicated **adapter** that parses the source-specific 
 
 Parses the AlertManager webhook format (`alerts[]`, `commonLabels`, `commonAnnotations`):
 
-1. **Parse** -- Takes the first alert from the `alerts[]` array. Extracts the target resource from labels using a priority list: HPA > PDB > PVC > Deployment > StatefulSet > DaemonSet > Node > Service > Job > CronJob > Pod. Before extraction, a **monitoring metadata filter** strips `service` and `pod` labels that refer to monitoring infrastructure (kube-state-metrics, prometheus-node-exporter, alertmanager, grafana, etc.) to prevent Kubernaut from targeting its own monitoring stack. Merges alert-level and common labels.
+1. **Parse** -- Takes the first alert from the `alerts[]` array. Extracts the target resource from labels using a priority list: HPA > PDB > PVC > Deployment > StatefulSet > DaemonSet > ReplicaSet > Node > Service > Job (`job_name`) > CronJob > Pod. Before extraction, a **monitoring metadata filter** strips `service` and `pod` labels that refer to monitoring infrastructure (kube-state-metrics, prometheus-node-exporter, alertmanager, grafana, etc.) to prevent Kubernaut from targeting its own monitoring stack. Merges alert-level and common labels.
 2. **Fingerprint** -- Resolves the owner chain (Pod -> ReplicaSet -> Deployment) and computes `SHA256(namespace:kind:name)` of the top-level owner. The alert name is excluded from the fingerprint (Issue #63) so that different alerts for the same resource deduplicate correctly.
 3. **Severity** -- Pass-through from `labels["severity"]`. Signal Processing normalizes it later via Rego policy.
 4. **Validate** -- Requires non-empty `Fingerprint`, `SignalName`, and `Severity`.
@@ -68,7 +68,8 @@ Both adapters produce a common `NormalizedSignal`:
 | `Annotations` | Source annotations |
 | `FiringTime` | When the alert started firing |
 | `ReceivedTime` | When the Gateway received it |
-| `SourceType` | `prometheus` or `kubernetes-event` |
+| `SourceType` | Always `"alert"` for all adapters |
+| `Source` | `"prometheus"` or `"kubernetes-events"` (identifies the adapter) |
 | `RawPayload` | Original payload for audit reconstruction |
 
 ## Authentication

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -144,6 +144,8 @@ An internal admission webhook validates and audits:
 - RemediationApprovalRequest mutations (approval/rejection)
 - RemediationRequest status mutations (timeout configuration)
 - NotificationRequest deletions (attribution)
+- RemediationWorkflow mutations (schema validation via `/validate-remediationworkflow`)
+- ActionType mutations (schema validation via `/validate-actiontype`)
 
 ### Authentication
 


### PR DESCRIPTION
## Summary

Fixes confirmed findings from Issue #83 (Gateway & System Overview triage):

- **H1**: Fix API endpoint paths in Mermaid diagram to use full `/api/v1/signals/...` paths
- **H2**: Fix `SourceType` — always `"alert"` for all adapters; add `Source` field (`"prometheus"` / `"kubernetes-events"`)
- **M1**: Add `RemediationWorkflow` and `ActionType` admission webhook validators to overview.md
- **M2**: Fix Prometheus resource priority list — add `ReplicaSet`, correct `Job` label to `job_name`

## Test plan

- [ ] Verify Mermaid diagram renders correctly with quoted edge labels
- [ ] Confirm SourceType/Source field documentation matches `pkg/gateway/adapters/` source code
- [ ] Confirm resource priority list matches `resourceCandidates` in Prometheus adapter
- [ ] Confirm webhook list matches registered handlers in admission webhook setup

Closes #83

Made with [Cursor](https://cursor.com)