### PR TITLE
fix(architecture): signal-processing.md + ai-analysis.md — Issue #84

### DIFF
--- a/docs/architecture/ai-analysis.md
+++ b/docs/architecture/ai-analysis.md
@@ -49,7 +49,7 @@ sequenceDiagram
     Note over AA: Phase: Analyzing
 ```
 
-This pattern avoids long HTTP timeouts and allows the controller to use Kubernetes-native requeue mechanisms (`RequeueAfter`) while the LLM investigation runs. The controller polls at a **constant 15-second interval** (configurable from 1s to 5m via `--session-poll-interval` flag or `WithSessionPollInterval` option).
+This pattern avoids long HTTP timeouts and allows the controller to use Kubernetes-native requeue mechanisms (`RequeueAfter`) while the LLM investigation runs. The controller polls at a **constant 15-second interval** (configurable from 1s to 5m via the `holmesgpt.sessionPollInterval` YAML config field).
 
 ### Session Recovery
 
@@ -105,19 +105,26 @@ When HolmesGPT reports `investigation_outcome=resolved`, it appends a "Problem s
 
 Without this bypass, a resolved incident with a detailed RCA would be incorrectly escalated to human review (because `hasSubstantiveRCA` would return `true`, preventing the `WorkflowNotNeeded` completion path). The fix ensures that HAPI's authoritative "resolved" signal takes priority over the RCA content check.
 
-### Approval Gate (Rego policy, user-replaceable)
+### Approval Gate (Rego policy, operator-provided)
 
-The Analyzing handler evaluates a **user-replaceable Rego policy** (`approval.rego`) to determine whether the remediation requires human approval. The policy receives the full analysis context as input and returns `require_approval` (boolean) and `reason` (string).
+The Analyzing handler evaluates a Rego policy to determine whether the remediation requires human approval:
 
-The **default shipped policy** gates on environment and remediation target presence:
+- **Query**: `data.aianalysis.approval`
+- **Input**: Full analysis context (see below)
+- **Output**: `require_approval` (boolean) and `reason` (string)
+
+**When no policy is mounted**, the controller auto-approves all remediations. Operators provide their own `approval.rego` to enforce custom gates.
+
+The **default shipped policy** (bundled for reference) gates on:
 
 - **Production** — always requires approval
 - **Non-production** — auto-approved when `remediation_target` is present
 - **Missing `remediation_target`** — always requires approval (default-deny per ADR-055)
+- **Sensitive resource kinds** — requires approval for Deployments, StatefulSets, DaemonSets in production
 
-The policy also receives `confidence`, `confidence_threshold`, `detected_labels` (snake_case keys: `"stateful"`, `"pdb_protected"`, `"hpa_enabled"`), `failed_detections`, `custom_labels`, and `business_classification`. Operators can write custom policies that use any combination of these inputs -- for example, confidence-gated approval for production.
+The policy receives `confidence`, `confidence_threshold`, `detected_labels` (snake_case keys: `"stateful"`, `"pdb_protected"`, `"hpa_enabled"`), `failed_detections`, `custom_labels`, and `business_classification`. Operators can write custom policies that use any combination of these inputs — for example, confidence-gated approval for production.
 
-The confidence threshold is configurable via Helm (`aianalysis.rego.confidenceThreshold`, default 0.8) and passed as `input.confidence_threshold`. The default policy defines `is_high_confidence` but does not use it in approval rules.
+The confidence threshold is configurable via Helm (`aianalysis.rego.confidenceThreshold`, default 0.8) and passed as `input.confidence_threshold`.
 
 See [Human Approval](../user-guide/approval.md) for the full approval flow and policy customization details.
 

--- a/docs/architecture/signal-processing.md
+++ b/docs/architecture/signal-processing.md
@@ -38,7 +38,7 @@ stateDiagram-v2
 | **Pending** | CRD just created, set `StartTime` | 100ms |
 | **Enriching** | Gather Kubernetes context and custom labels | 100ms |
 | **Classifying** | Evaluate Rego policies for environment, priority, severity, signal mode | 100ms |
-| **Categorizing** | Business classification from namespace labels and Rego | None |
+| **Categorizing** | Business classification from namespace labels + environment mapping | None |
 | **Completed** | All results stored in status, `Ready=True` | None |
 | **Failed** | Terminal -- severity policy error or unrecoverable failure | None |
 
@@ -50,7 +50,7 @@ The enrichment phase gathers Kubernetes context about the target resource.
 
 ### Owner Chain Resolution
 
-The `OwnerChainBuilder` follows `controller: true` owner references up to a depth of **5** to find the top-level controlling resource:
+The owner chain builder (`ownerchain.NewBuilder`) follows `controller: true` owner references up to a depth of **5** to find the top-level controlling resource:
 
 ```
 Pod → ReplicaSet → Deployment
@@ -122,24 +122,24 @@ The classification phase evaluates four classifiers in sequence. A failure in se
 
 ### 1. Environment Classifier (Rego)
 
-- **Query**: `data.signalprocessing.environment.result`
-- **Input**: `{namespace: {name, labels}, signal: {labels}}`
+- **Query**: `data.signalprocessing.environment`
+- **Input**: `{namespace: {name, labels}, signal: {severity, type, source, labels}, workload: {kind, name, labels}}`
 - **Output**: `{environment, source}`
 - **Values**: `production`, `staging`, `development`, `test`
 - **Source tracking**: `namespace-labels`, `rego-inference`, or `default`
 
 ### 2. Priority Engine (Rego)
 
-- **Query**: `data.signalprocessing.priority.result`
-- **Input**: `{signal: {severity, source}, environment, namespace_labels, workload_labels}`
+- **Query**: `data.signalprocessing.priority`
+- **Input**: `{namespace: {name, labels}, signal: {severity, type, source, labels}, workload: {kind, name, labels}}`
 - **Output**: `{priority, policy_name}`
 - **Values**: `P0`, `P1`, `P2`, `P3`
 - **Timeout**: 100ms
 
 ### 3. Severity Classifier (Rego)
 
-- **Query**: `data.signalprocessing.severity.determine_severity`
-- **Input**: `{signal: {severity, type, source}}`
+- **Query**: `data.signalprocessing.severity`
+- **Input**: `{namespace: {name, labels}, signal: {severity, type, source, labels}, workload: {kind, name, labels}}`
 - **Output**: Normalized severity string
 - **Values**: `critical`, `high`, `medium`, `low`, `unknown`
 - **Fatal on failure**: A severity policy error transitions the CRD to `Failed` with `RegoEvaluationError`
@@ -171,31 +171,30 @@ On success, the status is updated with:
 
 ## Phase 3: Categorizing
 
-The categorization phase assigns business classification using a tiered resolution strategy:
+The categorization phase assigns business classification using pure Go logic — no Rego evaluation.
 
-### Resolution Priority
+### `classifyBusiness`
 
-1. **Namespace labels** (highest confidence: 1.0):
-    - `kubernaut.ai/business-unit` → BusinessUnit
-    - `kubernaut.ai/team` → BusinessUnit fallback
-    - `kubernaut.ai/service-owner` → ServiceOwner
+The function reads namespace labels directly:
 
-2. **Pattern matching** (confidence: 0.8): Splits namespace name by `-`, uses the first segment as business unit
+| Namespace Label | Field |
+|---|---|
+| `kubernaut.ai/business-unit` | `BusinessUnit` |
+| `kubernaut.ai/team` | `BusinessUnit` (fallback when `business-unit` is absent) |
+| `kubernaut.ai/service-owner` | `ServiceOwner` |
 
-3. **Rego policy** (confidence: 0.6):
-    - **Query**: `data.signalprocessing.business.result`
-    - **Input**: `{namespace, workload, environment}`
-    - **Timeout**: 200ms
+If a label is absent, the corresponding field is left as an **empty string** (not `"unknown"`).
 
-4. **Environment-based defaults** (confidence: 0.4):
+### Environment-to-Criticality/SLA Mapping
 
-    | Environment | Criticality | SLA |
-    |---|---|---|
-    | `production`, `prod` | high | gold |
-    | `staging`, `stage` | medium | silver |
-    | `development`, `dev` | low | bronze |
+After label extraction, the classifier maps the environment (determined in Phase 2) to criticality and SLA:
 
-5. **System defaults**: BusinessUnit=`unknown`, ServiceOwner=`unknown`, Criticality=`medium`, SLA=`bronze`
+| Environment | Criticality | SLA |
+|---|---|---|
+| `production`, `prod` | high | gold |
+| `staging`, `stage` | medium | silver |
+| `development`, `dev` | low | bronze |
+| (other) | medium | bronze |
 
 On completion, `Phase=Completed`, `CompletionTime` is set, `ObservedGeneration` is updated, and `Ready=True`.
 
@@ -203,9 +202,9 @@ On completion, `Phase=Completed`, `CompletionTime` is set, `ObservedGeneration` 
 
 ### Transient Errors
 
-Transient errors trigger exponential backoff with the DD-SHARED-001 pattern:
+Transient errors trigger exponential backoff with the DD-SHARED-001 pattern. Rego evaluation errors are **not** transient — they are treated as permanent failures.
 
-- **Detection**: `IsTimeout`, `IsServerTimeout`, `IsTooManyRequests`, `IsServiceUnavailable`, `context.DeadlineExceeded`, `context.Canceled`
+- **Detection**: `IsTimeout`, `IsServerTimeout`, `IsTooManyRequests`, `IsServiceUnavailable`, `context.DeadlineExceeded`, `context.Canceled` (Kubernetes API errors only)
 - **Backoff**: Base 30s, multiplier 2x, max 5m, ±10% jitter
 - **Formula**: `BasePeriod × (Multiplier ^ (failures - 1))` ± jitter
 - **Tracking**: `ConsecutiveFailures` incremented, `LastFailureTime` updated
@@ -220,7 +219,7 @@ Transient errors trigger exponential backoff with the DD-SHARED-001 pattern:
 
 All Rego policies support hot-reload via `FileWatcher` (DD-INFRA-001):
 
-- **Mechanism**: `fsnotify` watches the policy directory
+- **Mechanism**: `fsnotify` watches the policy file path
 - **Debounce**: 200ms to coalesce rapid ConfigMap mount updates
 - **Reload**: Recompile Rego, swap prepared query under a mutex
 - **Hash**: SHA256 of new policy stored for audit traceability
@@ -251,7 +250,7 @@ sequenceDiagram
     SP->>OPA: Severity policy
     SP->>SP: Signal mode (YAML lookup)
     Note over SP: Phase: Classifying → Categorizing
-    SP->>SP: Business classification (labels → pattern → Rego → defaults)
+    SP->>SP: Business classification (namespace labels + environment mapping)
     Note over SP: Phase: Categorizing → Completed
     SP->>DS: Audit events
     RO->>RO: Detect SP Completed → create AIAnalysis


### PR DESCRIPTION
## Summary

Fixes confirmed findings from Issue #84 (Signal Processing & AI Analysis triage):

**Signal Processing:**
- **H3**: Fix Rego query paths — remove `.result` suffix and `.determine_severity`
- **H4**: Rewrite Phase 3 (Categorizing) — pure Go logic reading namespace labels + environment-to-criticality mapping. No Rego call, no 200ms timeout, no confidence tiers, empty strings not "unknown"
- **M3**: Fix PolicyInput to show 3 fields (`namespace`, `signal`, `workload`) for all classifiers
- **M4**: Clarify Rego errors are NOT transient — only K8s API errors trigger backoff
- **L1**: Fix type name `OwnerChainBuilder` → `ownerchain.NewBuilder`
- **L2**: Fix hot-reload wording from "policy directory" to single file path

**AI Analysis:**
- **M5**: Fix `--session-poll-interval` CLI flag → `holmesgpt.sessionPollInterval` YAML config field
- **M6**: Rewrite approval gate — auto-approve when no policy mounted; operators provide their own `approval.rego`; add sensitive resource kinds trigger
- **L3**: Add `data.aianalysis.approval` Rego query path

## Test plan

- [ ] Verify Rego query paths match source code entrypoints
- [ ] Confirm Phase 3 description matches `classifyBusiness` implementation
- [ ] Verify PolicyInput fields match `buildPolicyInput` function
- [ ] Confirm session poll interval config mechanism matches YAML config pattern

Closes #84

Made with [Cursor](https://cursor.com)