### PR TITLE
fix(architecture): workflow-selection.md + workflow-execution.md — Issue #86

### DIFF
--- a/docs/architecture/workflow-execution.md
+++ b/docs/architecture/workflow-execution.md
@@ -37,7 +37,7 @@ For the complete field specification, see [WorkflowExecution in the CRD Referenc
 ```mermaid
 stateDiagram-v2
     [*] --> Pending
-    Pending --> Running : Spec valid + cooldown clear + deps resolved + exec created
+    Pending --> Running : Spec valid + engine resolved + cooldown clear + deps resolved + exec created
     Pending --> Failed : Validation / dependency / cooldown failure
     Running --> Completed : Job/PipelineRun succeeded
     Running --> Failed : Job/PipelineRun failed
@@ -45,7 +45,7 @@ stateDiagram-v2
 
 | Phase | Terminal | Description |
 |---|---|---|
-| **Pending** | No | Spec validation, cooldown check, dependency resolution, execution creation |
+| **Pending** | No | Spec validation, engine resolution, cooldown check, dependency resolution, execution creation |
 | **Running** | No | Job or PipelineRun is active, polled every 10 seconds |
 | **Completed** | Yes | Execution succeeded |
 | **Failed** | Yes | Execution failed (pre-execution or runtime) |
@@ -63,7 +63,13 @@ Validates required fields:
 
 Failure → `MarkFailed` with `ConfigurationError`.
 
-### 2. Cooldown Check
+### 2. Engine Resolution
+
+`resolveExecutionEngine` queries the workflow catalog in DataStorage to determine the execution engine (`tekton`, `job`, or `ansible`). This runs immediately after validation, before cooldown check.
+
+Failure → `MarkFailed` with `ConfigurationError`.
+
+### 3. Cooldown Check
 
 Before creating a new execution, the controller checks for recently completed WFEs on the same target resource:
 
@@ -73,7 +79,11 @@ Before creating a new execution, the controller checks for recently completed WF
 
 **Default cooldown**: 1 minute (configurable via `workflowexecution.config.execution.cooldownPeriod`). Prevents rapid re-execution of the same workflow on the same target.
 
-### 3. Dependency Resolution
+### Audit: `workflowexecution.selection.completed`
+
+Emitted after validation + engine resolution + cooldown check pass, **before** dependency resolution and execution creation.
+
+### 4. Dependency Resolution
 
 Fetches workflow dependencies from DataStorage and validates them in the execution namespace:
 
@@ -83,17 +93,16 @@ Fetches workflow dependencies from DataStorage and validates them in the executi
     - DataStorage fetch failure → non-fatal, continue without dependency data
     - Dependency validation failure → `MarkFailed` with `ConfigurationError`
 
-### 4. Execution Creation
+### 5. Execution Creation
 
-Resolves the execution engine from the DS workflow catalog and creates a Kubernetes Job, Tekton PipelineRun, or AWX Job accordingly:
+Creates a Kubernetes Job, Tekton PipelineRun, or AWX Job using the engine resolved in Step 2:
 
-- The executor registry dispatches to the appropriate engine (`tekton`, `job`, or `ansible`)
+- The executor registry dispatches to the appropriate engine
 - **AlreadyExists handling** (Job/Tekton only): If the resource already exists and belongs to this WFE, adopt it (idempotent). If it belongs to another WFE, mark as `Failed` (race condition).
 
-### Audit Events
+### Audit: `workflowexecution.execution.started`
 
-- `workflowexecution.selection.completed` -- Emitted after spec validation
-- `workflowexecution.execution.started` -- Emitted after execution resource creation
+Emitted after execution resource creation succeeds.
 
 ## Running Phase
 
@@ -109,7 +118,9 @@ The Running phase polls the executor status every **10 seconds**:
 After reaching `Completed` or `Failed`, the controller does not immediately clean up:
 
 1. **Wait for cooldown** (default 1m) after `CompletionTime`
-2. **Cleanup** -- `exec.Cleanup(ctx, wfe, namespace)` deletes the Job or PipelineRun
+2. **Cleanup** -- `exec.Cleanup(ctx, wfe, namespace)`:
+    - **Job/Tekton**: Deletes the Job or PipelineRun
+    - **Ansible**: Deletes ephemeral AWX credentials via `cleanupEphemeralCredentials` and cancels the AWX job if still running
 3. **Emit** `LockReleased` Kubernetes event
 
 The cooldown period serves two purposes:

--- a/docs/architecture/workflow-selection.md
+++ b/docs/architecture/workflow-selection.md
@@ -107,7 +107,7 @@ Business classification labels (`businessUnit`, `serviceOwner`, `criticality`, `
 4. **Rego policy connection** -- Signal Processing Rego policies determine severity, environment, and priority, which directly feed into Layer 1. Business classification feeds into Layer 2 scoring as a refinement signal, not a hard gate.
 
 !!! note "`signalName` is not a matching label"
-    `signalName` is optional metadata in the workflow schema (DD-WORKFLOW-016). It is **not** used for filtering or matching. The LLM selects workflows by `actionType`, not by `signalName`.
+    `signalName` is optional metadata in the workflow schema (DD-WORKFLOW-016). It is **not** used for filtering or matching — only for the final result ordering tiebreaker (`ORDER BY final_score DESC, workflow_id ASC`). The LLM selects workflows by `actionType`, not by `signalName`.
 
 ## Layer 2: Semantic Scoring
 
@@ -147,7 +147,7 @@ final_score = LEAST((5.0 + detected_label_boost + custom_label_boost - label_pen
 
 ### Custom Label Boost
 
-Custom labels from Signal Processing's Rego policy output contribute additional scoring (DD-WORKFLOW-004 v2.1):
+Custom labels from Signal Processing's Rego policy output contribute additional scoring (DD-WORKFLOW-004 v1.5):
 
 - **Exact match**: +0.15 per key
 - **Wildcard match**: +0.075 per key


### PR DESCRIPTION
## Summary

Fixes confirmed findings from Issue #86 (Workflow Selection & Execution triage):

**Workflow Selection:**
- **M12**: Fix DD-WORKFLOW-004 version reference from v2.1 to **v1.5** for custom label scoring
- **L8**: Add DD-WORKFLOW-016 reference to `signalName` ordering note

**Workflow Execution:**
- **M13**: Fix `workflowexecution.selection.completed` timing — emitted after validation + engine resolution + cooldown check, before `resolveDependencies` and `exec.Create`
- **M14**: Fix engine resolution ordering — `resolveExecutionEngine` runs at Step 2 (after validation, before cooldown check), not at "Step 4: Execution Creation"
- **M15**: Fix Ansible `Cleanup` description — deletes ephemeral AWX credentials via `cleanupEphemeralCredentials` and cancels AWX job, not K8s Jobs/PipelineRuns

## Test plan

- [ ] Confirm DD-WORKFLOW-004 v1.5 matches source code comment reference
- [ ] Verify Pending phase step ordering matches reconcile function call order
- [ ] Confirm audit event emission timing matches source code
- [ ] Verify Ansible cleanup matches `cleanupEphemeralCredentials` implementation

Closes #86

Made with [Cursor](https://cursor.com)