### PR TITLE
fix(architecture): effectiveness.md + notification.md — Issue #87

### DIFF
--- a/docs/architecture/effectiveness.md
+++ b/docs/architecture/effectiveness.md
@@ -147,7 +147,7 @@ Compares the resource specification before and after remediation to detect drift
 
 1. **Pre-remediation hash**: From `EA.Spec.PreRemediationSpecHash` (captured by RO before execution) or queried from DataStorage
 2. **Post-remediation hash**: Computed live via `CanonicalSpecHash(target.Spec)`
-3. **Comparison**: `postHash == preHash` → `Match=true` (no drift, remediation didn't change the spec)
+3. **Comparison**: `postHash == preHash` → `Match=true` (spec unchanged). `postHash != preHash` can mean the remediation intentionally changed the spec (normal) or an external actor modified it during the assessment window (spec drift). The assessment distinguishes these by tracking whether the spec changed *after* the stabilization window began.
 
 #### Canonical Hash Algorithm
 
@@ -160,7 +160,7 @@ Compares the resource specification before and after remediation to detect drift
 
 When `HashComputeDelay` is set (async targets), the hash is not computed until the propagation delay elapses. The controller enters `WaitingForPropagation` and requeues with the remaining duration.
 
-If spec drift is detected (`postHash != preHash`), DataStorage short-circuits the weighted score to **0.0** regardless of other component results.
+If spec drift is detected (`assessment_status == "spec_drift"` — the spec changed *during* the assessment window, invalidating the evaluation), DataStorage short-circuits the weighted score to **0.0** regardless of other component results. Note: `postHash != preHash` alone is **normal** for a successful remediation (the workflow intentionally changed the spec). The score-0 override triggers only when the spec is modified by an external actor during the assessment window, making the effectiveness data inconclusive.
 
 ## Weighted Scoring
 
@@ -187,6 +187,10 @@ EA results feed back into the remediation pipeline through the [Investigation Pi
 5. **Decision influence** -- The LLM uses history to avoid repeating ineffective workflows and prefer historically successful ones
 
 See [Investigation Pipeline: Remediation History](hapi-investigation.md) for details on how the three-way hash comparison and formatted warnings work.
+
+## OCP Monitoring RBAC
+
+On OpenShift clusters with `effectivenessmonitor.external.ocpMonitoringRbac: true`, the Helm chart creates additional RBAC resources to allow the Effectiveness Monitor to query the cluster monitoring stack through `kube-rbac-proxy`. See [Security & RBAC: OCP Monitoring RBAC](security-rbac.md#ocp-monitoring-rbac) for details.
 
 ## Next Steps
 

--- a/docs/architecture/notification.md
+++ b/docs/architecture/notification.md
@@ -86,8 +86,8 @@ Attributes are extracted from the notification spec and used for route matching:
 | `priority` | `spec.Priority` |
 | `environment` | `spec.Metadata["environment"]` |
 | `namespace` | `spec.Metadata["namespace"]` |
-| `skipReason` | `spec.Metadata["skipReason"]` |
-| `investigationOutcome` | `spec.Metadata["investigationOutcome"]` |
+| `skip-reason` | `spec.Metadata["skip-reason"]` |
+| `investigation-outcome` | `spec.Metadata["investigation-outcome"]` |
 
 ### Route Matching
 
@@ -98,7 +98,6 @@ The routing configuration follows an AlertManager-style tree:
 3. Each route's `Match` map must match **all** specified attributes (AND logic)
 4. First matching route identifies the **receiver**
 5. The receiver declares which channels to use
-6. If `Continue: true`, matching continues for multi-channel fanout (BR-NOT-068)
 
 ### Fallback
 
@@ -241,7 +240,7 @@ Before delivery, the controller enriches notification bodies by resolving workfl
 
 ### Enrichment Flow
 
-1. Extract the workflow UUID from `spec.context.workflow` (checks `WorkflowContext.WorkflowID` for completion notifications, then `WorkflowContext.SelectedWorkflow` for approval notifications)
+1. Extract the workflow UUID from `spec.metadata["workflowId"]` with fallback to `spec.metadata["selectedWorkflow"]` (the former is set for completion notifications, the latter for approval notifications)
 2. Call the DataStorage catalog API (`GET /api/v1/workflows/{id}`) to resolve the UUID to a workflow name
 3. Replace every occurrence of the UUID in `spec.Body` with the resolved name
 4. Pass the enriched notification to the delivery orchestrator


### PR DESCRIPTION
## Summary

Fixes confirmed findings from Issue #87 (Effectiveness & Notification triage):

**Effectiveness:**
- **H6**: Fix score-0 override trigger — `assessment_status == "spec_drift"` (spec changed during assessment window by external actor), not `postHash != preHash` (which is normal post-remediation change)
- **E1**: Add OCP monitoring RBAC reference to effectiveness architecture page

**Notification:**
- **H7**: Fix enrichment field path — `spec.metadata["workflowId"]` with fallback to `spec.metadata["selectedWorkflow"]`, not `spec.context.workflow`
- **H8**: Remove `Continue` route fanout documentation (not implemented; tracked in [kubernaut#597](https://github.com/jordigilh/kubernaut/issues/597))
- **N1**: Fix routing metadata key casing from camelCase (`skipReason`, `investigationOutcome`) to kebab-case (`skip-reason`, `investigation-outcome`)

## Test plan

- [ ] Verify spec drift explanation matches `assessment_status` logic in DataStorage scorer
- [ ] Confirm enrichment field path matches `extractWorkflowUUID` function
- [ ] Verify `Continue` reference is removed and bug issue exists in kubernaut repo
- [ ] Confirm metadata key casing matches `buildRoutingAttributes` source

Closes #87

Made with [Cursor](https://cursor.com)