### PR TITLE
fix(architecture): audit-pipeline.md + async-propagation.md + security-rbac.md — Issue #88

### DIFF
--- a/docs/architecture/async-propagation.md
+++ b/docs/architecture/async-propagation.md
@@ -19,8 +19,8 @@ The Remediation Orchestrator detects whether the remediation target requires pro
 
 | Characteristic | Detection Method | Source |
 |---|---|---|
-| **GitOps-managed** | `gitOpsManaged=true` detected label | HAPI `LabelDetector` during post-RCA analysis |
-| **Operator-managed CR** | Target resource is a custom resource (CR) with a controlling operator | Kubernetes API resource discovery |
+| **GitOps-managed** | `PostRCAContext.DetectedLabels.GitOpsManaged=true` (JSON field from HAPI response, not a Kubernetes object label) | HAPI `LabelDetector` during post-RCA analysis |
+| **Custom Resource (CRD)** | Target resource belongs to a non-built-in API group (detected via `IsBuiltInGroup(group)` allowlist — non-built-in groups are treated as CRDs) | API group check, no operator/controller detection |
 
 These flags are set during the AI Analysis phase and propagated to the EffectivenessAssessment CRD spec.
 
@@ -40,10 +40,10 @@ The propagation delay is computed from two independent flags (`isGitOps`, `isCRD
 
 | Target Type | Propagation Delay | Total Wait Before Assessment |
 |---|---|---|
-| **Sync target** (direct patch) | 0 | `stabilizationWindow` |
+| **Sync target** (direct patch, built-in API group) | 0 | `stabilizationWindow` |
 | **GitOps-managed** | `gitOpsSyncDelay` | `gitOpsSyncDelay` + `stabilizationWindow` |
-| **Operator-managed CR** | `operatorReconcileDelay` | `operatorReconcileDelay` + `stabilizationWindow` |
-| **GitOps + operator CR** (both) | `gitOpsSyncDelay` + `operatorReconcileDelay` | Both delays + `stabilizationWindow` |
+| **Custom Resource (non-built-in API group)** | `operatorReconcileDelay` | `operatorReconcileDelay` + `stabilizationWindow` |
+| **GitOps + CRD** (both) | `gitOpsSyncDelay` + `operatorReconcileDelay` | Both delays + `stabilizationWindow` |
 
 The delays are additive -- if a target is both GitOps-managed and an operator CR, both delays compound. Setting either delay to `0` disables that stage.
 

--- a/docs/architecture/audit-pipeline.md
+++ b/docs/architecture/audit-pipeline.md
@@ -49,8 +49,8 @@ Events are flushed in three scenarios:
 
 ### Retry Logic
 
-- **Max retries**: 3 per batch
-- **Backoff**: 1s, 4s, 9s (quadratic)
+- **Max retries**: 3 per batch (3 total attempts, 2 backoff waits)
+- **Backoff**: 1s, 4s (quadratic: `n²` seconds). A third backoff (9s) would only occur if `MaxRetries` is increased beyond 3.
 - **4xx errors**: No retry (permanent failure)
 - **5xx / network errors**: Retry with backoff
 
@@ -59,20 +59,19 @@ Events are flushed in three scenarios:
 | Parameter | Default | Recommendation |
 |---|---|---|
 | `BufferSize` | 10,000 | 10k--50k (DD-AUDIT-004) |
-| `BatchSize` | 1,000 | 1,000 |
+| `BatchSize` | 1,000 (library default; Gateway chart overrides to 100) | 100–1,000 |
 | `FlushInterval` | 1 second | 1s |
 | `MaxRetries` | 3 | 3 |
 
 ### Observability
 
-The buffered store exposes Prometheus metrics:
+The buffered store exposes one registered Prometheus metric:
 
-| Metric | Description |
-|---|---|
-| `buffered_count` | Events currently in the buffer |
-| `dropped_count` | Events dropped due to full buffer |
-| `written_count` | Events successfully written |
-| `failed_batch_count` | Batches that failed after all retries |
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `audit_events_dropped_total` | CounterVec | `service` | Events dropped due to full buffer |
+
+Additionally, internal atomic counters (`buffered_count`, `written_count`, `failed_batch_count`) are tracked for debug logging but are **not** registered as Prometheus metrics.
 
 ## Event Flow
 
@@ -80,7 +79,7 @@ The buffered store exposes Prometheus metrics:
 2. The buffered store enqueues the event into an in-memory channel (non-blocking)
 3. A background goroutine batches events and sends them via `POST /api/v1/audit/events/batch` to DataStorage
 4. DataStorage validates, converts, and inserts the batch into the `audit_events` PostgreSQL table within a transaction
-5. On PostgreSQL failure, the batch is enqueued to the Valkey DLQ for retry
+5. On PostgreSQL failure, the batch endpoint returns HTTP 500 — the caller's retry logic handles re-delivery. The batch handler does **not** use the Valkey DLQ (this is a known gap; see GAP-10 in the DataStorage source).
 6. On shutdown, `auditStore.Close()` flushes remaining events
 
 ## Event Structure
@@ -128,7 +127,7 @@ All audit events for a single remediation share a `correlation_id` set to the `R
 
 ## Emitting Services
 
-All 7 Go services, the auth webhook, and HolmesGPT API emit audit events:
+All 9 Go binaries (`cmd/*/main.go`: Gateway, Signal Processing, AI Analysis, Remediation Orchestrator, Workflow Execution, Effectiveness Monitor, Notification, Auth Webhook, DataStorage) and HolmesGPT API (Python) emit audit events:
 
 | Service | Event Prefix | Key Events |
 |---|---|---|

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -88,7 +88,7 @@ Four services (HolmesGPT API, WorkflowExecution, RemediationOrchestrator, Effect
 
 The RemediationOrchestrator and EffectivenessMonitor are additionally bound to the Kubernetes built-in `view` ClusterRole via `remediationorchestrator-view` and `effectivenessmonitor-view` ClusterRoleBindings. This provides broad read access to CRD types not individually enumerated in their dedicated ClusterRoles -- for example, cert-manager `Certificate` resources and Istio networking resources -- which is required for pre- and post-remediation hash capture (DD-EM-002).
 
-If the `view` ClusterRole lacks read permission for a particular resource type (e.g., a third-party CRD), hash capture emits a `HashCaptureDegraded` Kubernetes event and the EffectivenessAssessment proceeds in **degraded mode** rather than failing the pipeline. In degraded mode, the EA skips the hash comparison component and relies on the remaining health-check signals (alert state, metric thresholds, pod readiness) to determine effectiveness.
+If the `view` ClusterRole lacks read permission for a particular resource type (e.g., a third-party CRD), the **Remediation Orchestrator** emits a `HashCaptureDegraded` Kubernetes event on the `RemediationRequest` when `CapturePreRemediationHash` returns a degraded reason. The EffectivenessAssessment then proceeds in **degraded mode** — the EA skips the hash comparison component and relies on the remaining health-check signals (alert state, metric thresholds, pod readiness) to determine effectiveness.
 
 ## Workflow Execution
 


### PR DESCRIPTION
## Summary

Fixes confirmed findings from Issue #88 (Audit, Async Propagation & RBAC triage):

**Audit Pipeline:**
- **H9**: Fix batch DLQ — batch handler returns HTTP 500 on PostgreSQL failure, does **not** use Valkey DLQ (known gap GAP-10)
- **M-AP1**: Fix Prometheus metrics — only `audit_events_dropped_total` (CounterVec with `service` label) is a registered Prometheus metric; `buffered_count`, `written_count`, `failed_batch_count` are internal atomics
- **M-AP2**: Fix service count from "7 Go services" to 9 `cmd/*/main.go` binaries
- **L-AP1**: Fix retry backoff — 3 attempts = 2 backoff waits (1s, 4s), 9s only if `MaxRetries` > 3
- **L-AP2**: Note Gateway chart overrides `batchSize` to 100 (not library default 1000)

**Async Propagation:**
- **M-AS1**: Fix CRD detection — uses `IsBuiltInGroup(group)` API group allowlist; non-built-in groups treated as CRDs; no operator/controller detection
- **L-AS1**: Clarify GitOps flag driven by `PostRCAContext.DetectedLabels.GitOpsManaged` (JSON field from HAPI), not a Kubernetes object label

**Security & RBAC:**
- **M-SR1**: Fix `HashCaptureDegraded` attribution — emitted by **RemediationOrchestrator** on `RemediationRequest` when `CapturePreRemediationHash` returns degraded reason, not by EM

## No-action items (per plan)

- L-AS2 (no annotation-based triggers) — confirmed by team, no docs change needed
- L-SR1 (DataStorage client ClusterRole verbs) — table already lists role without enumerating verbs
- L-SR2 (credential resolution 6 steps) — already fixed by PR #39
- L-SR3 (no general TLS/NetworkPolicy section) — scope limitation, no action

## Test plan

- [ ] Confirm batch endpoint returns 500 on PostgreSQL failure (no DLQ in handler)
- [ ] Verify `audit_events_dropped_total` is the only registered Prometheus metric in `pkg/audit/store.go`
- [ ] Confirm `cmd/*/main.go` binary count is 9
- [ ] Verify `IsBuiltInGroup` logic in `pkg/shared/` or `pkg/remediationorchestrator/`
- [ ] Confirm `HashCaptureDegraded` event is emitted by RO, not EM

Closes #88

Made with [Cursor](https://cursor.com)