### PR TITLE
fix(architecture): post-review followup — 2 HIGH, 5 MEDIUM consistency fixes

### DIFF
--- a/docs/architecture/async-propagation.md
+++ b/docs/architecture/async-propagation.md
@@ -31,7 +31,7 @@ Kubernaut uses configurable propagation delays that are **additive based on dete
 | Parameter | Default | Applies When | Configurable Via |
 |---|---|---|---|
 | `gitOpsSyncDelay` | 3 minutes | Target is GitOps-managed (ArgoCD/Flux) | `remediationorchestrator.config.asyncPropagation.gitOpsSyncDelay` |
-| `operatorReconcileDelay` | 1 minute | Target is an operator-managed CR | `remediationorchestrator.config.asyncPropagation.operatorReconcileDelay` |
+| `operatorReconcileDelay` | 1 minute | Target belongs to a non-built-in API group (CRD) | `remediationorchestrator.config.asyncPropagation.operatorReconcileDelay` |
 | `stabilizationWindow` | 5 minutes | Always (all targets) | `remediationorchestrator.config.effectivenessAssessment.stabilizationWindow` |
 
 ## When Delays Apply
@@ -45,7 +45,7 @@ The propagation delay is computed from two independent flags (`isGitOps`, `isCRD
 | **Custom Resource (non-built-in API group)** | `operatorReconcileDelay` | `operatorReconcileDelay` + `stabilizationWindow` |
 | **GitOps + CRD** (both) | `gitOpsSyncDelay` + `operatorReconcileDelay` | Both delays + `stabilizationWindow` |
 
-The delays are additive -- if a target is both GitOps-managed and an operator CR, both delays compound. Setting either delay to `0` disables that stage.
+The delays are additive — if a target is both GitOps-managed and belongs to a non-built-in API group, both delays compound. Setting either delay to `0` disables that stage.
 
 ## Integration with Effectiveness Assessment
 

--- a/docs/architecture/audit-pipeline.md
+++ b/docs/architecture/audit-pipeline.md
@@ -15,7 +15,7 @@ graph LR
     end
 
     DS[DataStorage<br/>REST API] --> PG[(PostgreSQL<br/>audit_events)]
-    DS --> RD[(Valkey<br/>DLQ)]
+    DS -.->|"single-event paths only"| RD[(Valkey<br/>DLQ)]
 ```
 
 ### Design Principles
@@ -40,7 +40,7 @@ Every Go service instantiates a `BufferedAuditStore` from `pkg/audit/store.go`:
 
 ### Flush Triggers
 
-Events are flushed in three scenarios:
+Events are flushed in four scenarios:
 
 1. **Batch full** -- When the in-memory batch reaches `BatchSize`, it is sent immediately
 2. **Timer** -- Every `FlushInterval`, the current batch is sent regardless of size
@@ -162,7 +162,7 @@ This ensures every human action has a recorded identity, timestamp, and context 
 
 ## Dead Letter Queue
 
-When DataStorage cannot write to PostgreSQL, failed batches are enqueued to Valkey streams for retry:
+DataStorage uses Valkey streams as a dead letter queue for **single-event write paths** (e.g., notification audit events). The **batch endpoint** (`POST /api/v1/audit/events/batch`) does **not** use the DLQ — it returns HTTP 500 on PostgreSQL failure and relies on the caller's retry logic (see GAP-10 in the source).
 
 | Stream | Purpose |
 |---|---|

--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -82,7 +82,7 @@ sequenceDiagram
     participant GW as Gateway
     participant K8s as Kubernetes API
 
-    Source->>GW: POST /signals/prometheus (Bearer token)
+    Source->>GW: POST /api/v1/signals/prometheus (Bearer token)
     GW->>K8s: TokenReview (validate token)
     K8s-->>GW: User identity
     GW->>K8s: SubjectAccessReview (create services/gateway-service)

--- a/docs/architecture/hapi-investigation.md
+++ b/docs/architecture/hapi-investigation.md
@@ -417,9 +417,9 @@ flowchart TD
     HasWFReview -->|present| HRFailed["Human Review + Workflow<br/><small>Phase: Failed (any review scenario)</small>"]
     HasWFReview -->|null| HRCompleted["Manual Review Required<br/><small>Phase: Completed</small>"]
     NHR -->|false| HasWF{"selected_workflow?"}
-    HasWF -->|null| Resolved{"Problem resolved?"}
+    HasWF -->|null| Resolved{"Resolved or<br/>not actionable?"}
     HasWF -->|present| Confidence{"confidence >= 0.7?"}
-    Resolved -->|yes| NoAction["No Action Required<br/><small>Phase: Completed</small>"]
+    Resolved -->|"resolved / not actionable"| NoAction["No Action Required<br/><small>Phase: Completed<br/>(Outcome 2 or 9)</small>"]
     Resolved -->|no| NoWFFailure["No Workflow Found<br/><small>Phase: Failed</small>"]
     Confidence -->|no| LowConf["Low Confidence<br/><small>Phase: Failed</small>"]
     Confidence -->|yes| Rego["Rego Evaluation<br/><small>Phase: Analyzing</small>"]

--- a/docs/architecture/signal-processing.md
+++ b/docs/architecture/signal-processing.md
@@ -37,7 +37,7 @@ stateDiagram-v2
 |---|---|---|
 | **Pending** | CRD just created, set `StartTime` | 100ms |
 | **Enriching** | Gather Kubernetes context and custom labels | 100ms |
-| **Classifying** | Evaluate Rego policies for environment, priority, severity, signal mode | 100ms |
+| **Classifying** | Evaluate Rego policies for environment, priority, severity; determine signal mode via YAML lookup | 100ms |
 | **Categorizing** | Business classification from namespace labels + environment mapping | None |
 | **Completed** | All results stored in status, `Ready=True` | None |
 | **Failed** | Terminal -- severity policy error or unrecoverable failure | None |
@@ -213,7 +213,7 @@ Transient errors trigger exponential backoff with the DD-SHARED-001 pattern. Reg
 ### Permanent Errors
 
 - **Severity policy failure**: Transitions directly to `Failed` with `RegoEvaluationError`. No requeue.
-- **Other policy failures**: Enrichment and priority failures are retried (treated as transient).
+- **Kubernetes API errors during enrichment or classification**: Network timeouts, API server errors, and context cancellation during K8s API calls are retried (treated as transient). Rego evaluation errors are never retried.
 
 ## Hot-Reload
 


### PR DESCRIPTION
## Summary

Fixes found during post-merge critical review of PRs #89-#94:

### HIGH
- **gateway.md**: Authentication sequence diagram still used `POST /signals/prometheus` — fixed to `/api/v1/signals/prometheus`
- **audit-pipeline.md**: DLQ section and architecture diagram contradicted H9 fix (batch handler returns 500, does NOT use Valkey DLQ). Fixed diagram to show DLQ edge as "single-event paths only" and rewrote DLQ section header to clarify scope.

### MEDIUM
- **signal-processing.md**: Phase table said Classifying includes "signal mode" under Rego — fixed to show signal mode as YAML lookup
- **signal-processing.md**: Error handling "Other policy failures" was ambiguous — clarified K8s API errors vs Rego errors
- **hapi-investigation.md**: Outcome 9 (not actionable) shared same flowchart diamond as Outcome 2 (self-resolved) without distinction — updated diagram to show both paths
- **async-propagation.md**: Delay model table and prose still used "operator-managed CR" — replaced with "non-built-in API group (CRD)"
- **audit-pipeline.md**: "three scenarios" but four flush triggers listed — fixed to "four scenarios"

## Test plan

- [ ] Verify all Mermaid diagrams render correctly
- [ ] Confirm DLQ section and diagram are now internally consistent
- [ ] Verify no remaining `operator-managed CR` phrasing in async-propagation.md

Made with [Cursor](https://cursor.com)