### PR TITLE
docs(v1.2): GA infrastructure + v1.1-to-v1.2 upgrade guide

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -36,8 +36,12 @@ jobs:
 
       - name: Fetch generated CRD API reference
         run: |
+          case "${{ github.ref_name }}" in
+            release/v1.2) CRD_REF="v1.2.0" ;;
+            *)            CRD_REF="main" ;;
+          esac
           curl -fsSL \
-            https://raw.githubusercontent.com/jordigilh/kubernaut/main/docs/generated/crds.md \
+            "https://raw.githubusercontent.com/jordigilh/kubernaut/${CRD_REF}/docs/generated/crds.md" \
             -o docs/api-reference/crds.md
 
       - name: Configure git for mike
@@ -50,13 +54,13 @@ jobs:
           VERSION="${{ github.event.inputs.version }}"
           if [ -z "$VERSION" ]; then
             case "${{ github.ref_name }}" in
-              release/v1.2) VERSION="v1.2-rc" ;;
+              release/v1.2) VERSION="v1.2" ;;
               *)            VERSION="v1.1" ;;
             esac
           fi
 
-          if [ "$VERSION" = "v1.2-rc" ]; then
-            mike deploy --push "$VERSION"
-          else
+          if [ "$VERSION" = "v1.2" ]; then
             mike deploy --push --update-aliases "$VERSION" latest
+          else
+            mike deploy --push "$VERSION"
           fi

--- a/docs/operations/upgrading/1.1-to-1.2.md
+++ b/docs/operations/upgrading/1.1-to-1.2.md
@@ -1,0 +1,124 @@
+# Upgrading from v1.1 to v1.2
+
+This guide covers breaking changes and required actions when upgrading Kubernaut from **v1.1.x** to **v1.2.0**.
+
+## Prerequisites
+
+- Kubernaut v1.1.x running and healthy
+- `helm` v3.12+ and `kubectl` access to the cluster
+
+## Upgrade Command
+
+```bash
+helm upgrade kubernaut oci://quay.io/kubernaut-ai/charts/kubernaut \
+  --version {{ chart_version }} \
+  -n kubernaut-system --reuse-values
+```
+
+The `pre-upgrade` hook applies updated CRD schemas automatically. Database migrations (002–004) run via the `db-migrate` init container as part of the Helm hook — no manual action is required.
+
+---
+
+## Breaking Changes
+
+### 1. Storm Detection Removed (#448)
+
+All storm detection functionality has been removed per DD-GATEWAY-015. The following `RemediationRequest` spec fields no longer exist in the v1.2 CRD:
+
+| Removed field | Type |
+|---|---|
+| `spec.isStorm` | `bool` |
+| `spec.stormType` | `string` |
+| `spec.stormWindow` | `string` |
+| `spec.stormAlertCount` | `int` |
+| `spec.affectedResources` | `[]string` |
+
+**Action required:** If you have any custom tooling, scripts, or Rego policies that reference these fields, remove those references before upgrading. The CRD validation will reject any manifests that include these fields after the upgrade.
+
+Gateway and HAPI storm-related prompts and internal state have also been removed. No Helm values reference storm detection, so no `values.yaml` changes are needed.
+
+### 2. CRD Typed Enums (#453, #455, #459)
+
+String fields on several CRDs have been replaced with **typed enums**. After the upgrade, the CRD OpenAPI schema validates enum values strictly — any existing CR with a free-form string value that does not match the enum set will fail validation on the next update.
+
+Affected CRDs:
+
+- **NotificationRequest** (#453): `spec.notificationType`, `spec.priority`, and structured fields replace unstructured string maps
+- **WorkflowExecution** (#455): `status.executionStatus` is now a typed enum; duration fields migrated to `metav1.Duration`
+- **RemediationWorkflow / ActionType** (#459): `status.catalogStatus` is now a typed enum
+
+**Action required:** If you create or patch these CRs programmatically, verify your values match the documented enum sets in the [CRD reference](../../api-reference/crds.md).
+
+### 3. `metav1.Duration` Fields (#455)
+
+WorkflowExecution duration fields now use Go's `metav1.Duration` format instead of plain strings. Values must be expressed as Go duration strings (e.g., `30s`, `5m`, `1h`).
+
+**Action required:** If you set duration fields on WorkflowExecution CRs manually or via tooling, ensure they use the Go duration format.
+
+### 4. PascalCase Enum Migration (#453, #459, #483, #640)
+
+`NotificationType` and `NotificationPriority` enum values have been migrated from lowercase to PascalCase. The OpenAPI/catalog enum values exposed through the DataStorage API have also been aligned.
+
+| Field | Old values | New values |
+|---|---|---|
+| `NotificationType` | `escalation`, `simple`, `status-update`, `approval`, `manual-review`, `completion` | `Escalation`, `Simple`, `StatusUpdate`, `Approval`, `ManualReview`, `Completion` |
+| `NotificationPriority` | `critical`, `high`, `medium`, `low` | `Critical`, `High`, `Medium`, `Low` |
+
+**Action required:**
+
+- Update **notification routing ConfigMaps** that use `match` fields filtering on notification type or priority. See [Notification Routing](../../user-guide/configmap-notification.md) for the updated syntax.
+- Update any **API consumers** that filter or match on DataStorage/catalog enum values (e.g., `catalogStatus`).
+
+### 5. Per-Workflow ServiceAccount (#481)
+
+The RemediationWorkflow CRD introduces a new optional `spec.serviceAccountName` field. This field replaces the previous `spec.executionConfig.serviceAccountName` location.
+
+**Action required:** If you previously used `spec.executionConfig.serviceAccountName`, move the value to `spec.serviceAccountName`. Users who relied on the shared `kubernaut-workflow-runner` ServiceAccount require no changes — workflows without `spec.serviceAccountName` continue to use the shared SA.
+
+### 6. Database Migrations
+
+Migrations **002**, **003**, and **004** are applied automatically by the `db-migrate` init container during the Helm upgrade hook:
+
+- **002**: Schema extensions for typed enums and structured notification fields
+- **003**: Data migration for PascalCase enum values
+- **004**: Adds index on `post_remediation_spec_hash` for IneffectiveChain query performance
+
+**Action required:** None. Migrations run automatically. Ensure the `db-migrate` init container has network access to PostgreSQL.
+
+---
+
+## New Features (No Action Required)
+
+These features are additive and do not require migration steps:
+
+- **Per-workflow ServiceAccount with TokenRequest** (#481, #501): Workflows can specify a dedicated SA; the WE controller creates short-lived tokens via the Kubernetes TokenRequest API.
+- **ResourceQuota detection** (#366): HAPI now detects namespace `ResourceQuota` constraints and surfaces them to the LLM during investigation.
+- **Effectiveness Monitor improvements** (#573): New `Failed` phase, scheduled assessment events, and additional config knobs.
+- **Notification enrichment** (#318, #546, #615, #626): Completion notifications include EA verification results, hash-capture degradation indicators, cluster name/UUID, and RemediationRequest name.
+- **IneffectiveChain guardrails** (#616): New `ineffectiveChainThreshold` and `recurrenceCountThreshold` config knobs on the RemediationOrchestrator.
+- **Case-insensitive matching** (#595, #604): Workflow discovery filters and approval Rego policies now match environment and severity fields case-insensitively.
+- **Deterministic UUIDs** (#548): ActionType and RemediationWorkflow IDs are now deterministic (UUIDv5 from content hash) for PVC-wipe resilience.
+- **Embedded default SP Rego** (#604): The Helm chart ships a default `signalprocessing-policy.rego`, so installs work without `--set-file`.
+- **ConfigMap content in spec hash** (#396): RO/EM spec hash computation now includes mounted ConfigMap content (excluding Secrets).
+- **LLM token usage in audit** (#435): Audit traces and Prometheus metrics now include LLM token consumption data.
+- **Mandatory JSON mode** (#98): LLM providers must support JSON mode (`ChatOptions{JSONMode: true}`). Most modern providers (OpenAI, Azure OpenAI, Anthropic) support this natively.
+
+---
+
+## Verification
+
+After upgrading, verify the deployment is healthy:
+
+```bash
+helm test kubernaut -n kubernaut-system
+
+kubectl get pods -n kubernaut-system
+kubectl get pods -n kubernaut-workflows
+```
+
+Check that CRD schemas are updated:
+
+```bash
+kubectl get crd remediationrequests.kubernaut.ai -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties}' | python3 -m json.tool | grep -c stormType
+# Expected: 0 (storm fields removed)
+```

--- a/docs/operations/upgrading/1.1-to-1.2.md
+++ b/docs/operations/upgrading/1.1-to-1.2.md
@@ -15,7 +15,12 @@ helm upgrade kubernaut oci://quay.io/kubernaut-ai/charts/kubernaut \
   -n kubernaut-system --reuse-values
 ```
 
-The `pre-upgrade` hook applies updated CRD schemas automatically. Database migrations (002–004) run via the `db-migrate` init container as part of the Helm hook — no manual action is required.
+The chart runs two separate upgrade hooks:
+
+- **CRD upgrade job (`pre-upgrade`)** applies updated CRD schemas automatically.
+- **Migration job (`post-install,post-upgrade`)** runs database migrations automatically.
+
+No manual migration action is required.
 
 ---
 
@@ -23,7 +28,7 @@ The `pre-upgrade` hook applies updated CRD schemas automatically. Database migra
 
 ### 1. Storm Detection Removed (#448)
 
-All storm detection functionality has been removed per DD-GATEWAY-015. The following `RemediationRequest` spec fields no longer exist in the v1.2 CRD:
+All storm detection functionality has been removed per DD-GATEWAY-015. The v1.2 changelog highlights `stormCorrelationId` and `stormWindowId` removal at the API contract level, and the following `RemediationRequest` spec fields were removed from the CRD:
 
 | Removed field | Type |
 |---|---|
@@ -43,17 +48,17 @@ String fields on several CRDs have been replaced with **typed enums**. After the
 
 Affected CRDs:
 
-- **NotificationRequest** (#453): `spec.notificationType`, `spec.priority`, and structured fields replace unstructured string maps
-- **WorkflowExecution** (#455): `status.executionStatus` is now a typed enum; duration fields migrated to `metav1.Duration`
+- **NotificationRequest** (#453): `spec.type` and `spec.priority` are typed enums; structured fields replace unstructured string maps
+- **WorkflowExecution** (#455): `status.phase` is a typed enum (`Pending`, `Running`, `Completed`, `Failed`) and `status.executionStatus` is now a typed object with enum-backed status details
 - **RemediationWorkflow / ActionType** (#459): `status.catalogStatus` is now a typed enum
 
 **Action required:** If you create or patch these CRs programmatically, verify your values match the documented enum sets in the [CRD reference](../../api-reference/crds.md).
 
 ### 3. `metav1.Duration` Fields (#455)
 
-WorkflowExecution duration fields now use Go's `metav1.Duration` format instead of plain strings. Values must be expressed as Go duration strings (e.g., `30s`, `5m`, `1h`).
+WorkflowExecution duration fields now use Go's `metav1.Duration` format instead of plain strings. Values should be expressed as Go duration strings (e.g., `30s`, `5m`, `1h`).
 
-**Action required:** If you set duration fields on WorkflowExecution CRs manually or via tooling, ensure they use the Go duration format.
+**Action required:** If you set duration fields on WorkflowExecution CRs manually or via tooling, ensure they use the Go duration format. Note: the CRD schema stores duration as a string; invalid values are rejected during controller/runtime processing.
 
 ### 4. PascalCase Enum Migration (#453, #459, #483, #640)
 
@@ -69,21 +74,25 @@ WorkflowExecution duration fields now use Go's `metav1.Duration` format instead 
 - Update **notification routing ConfigMaps** that use `match` fields filtering on notification type or priority. See [Notification Routing](../../user-guide/configmap-notification.md) for the updated syntax.
 - Update any **API consumers** that filter or match on DataStorage/catalog enum values (e.g., `catalogStatus`).
 
-### 5. Per-Workflow ServiceAccount (#481)
+### 5. Per-Workflow ServiceAccount (#481, #501)
 
-The RemediationWorkflow CRD introduces a new optional `spec.serviceAccountName` field. This field replaces the previous `spec.executionConfig.serviceAccountName` location.
+Two related changes were introduced:
 
-**Action required:** If you previously used `spec.executionConfig.serviceAccountName`, move the value to `spec.serviceAccountName`. Users who relied on the shared `kubernaut-workflow-runner` ServiceAccount require no changes — workflows without `spec.serviceAccountName` continue to use the shared SA.
+- **RemediationWorkflow**: new optional `spec.execution.serviceAccountName` field for workflow-level service account declaration.
+- **WorkflowExecution**: `serviceAccountName` moved from `spec.executionConfig.serviceAccountName` to top-level `spec.serviceAccountName`.
+
+**Action required:** If you patch `WorkflowExecution` resources directly and previously used `spec.executionConfig.serviceAccountName`, move it to `spec.serviceAccountName`. For workflow catalog definitions, declare service accounts under `spec.execution.serviceAccountName`.
 
 ### 6. Database Migrations
 
-Migrations **002**, **003**, and **004** are applied automatically by the `db-migrate` init container during the Helm upgrade hook:
+Migrations **002** through **005** are applied automatically by the Helm migration job:
 
-- **002**: Schema extensions for typed enums and structured notification fields
-- **003**: Data migration for PascalCase enum values
+- **002**: Adds `service_account_name` to workflow catalog schema
+- **003**: Capitalizes catalog status values (PascalCase migration)
 - **004**: Adds index on `post_remediation_spec_hash` for IneffectiveChain query performance
+- **005**: Adds effectiveness correlation index improvements
 
-**Action required:** None. Migrations run automatically. Ensure the `db-migrate` init container has network access to PostgreSQL.
+**Action required:** None. Migrations run automatically. Ensure the Helm migration job has network access to PostgreSQL.
 
 ---
 
@@ -91,7 +100,7 @@ Migrations **002**, **003**, and **004** are applied automatically by the `db-mi
 
 These features are additive and do not require migration steps:
 
-- **Per-workflow ServiceAccount with TokenRequest** (#481, #501): Workflows can specify a dedicated SA; the WE controller creates short-lived tokens via the Kubernetes TokenRequest API.
+- **Per-workflow ServiceAccount with TokenRequest** (#481, #501): Workflows can specify a dedicated SA. For the Ansible path, the WE controller creates short-lived tokens via the Kubernetes TokenRequest API.
 - **ResourceQuota detection** (#366): HAPI now detects namespace `ResourceQuota` constraints and surfaces them to the LLM during investigation.
 - **Effectiveness Monitor improvements** (#573): New `Failed` phase, scheduled assessment events, and additional config knobs.
 - **Notification enrichment** (#318, #546, #615, #626): Completion notifications include EA verification results, hash-capture degradation indicators, cluster name/UUID, and RemediationRequest name.
@@ -101,7 +110,7 @@ These features are additive and do not require migration steps:
 - **Embedded default SP Rego** (#604): The Helm chart ships a default `signalprocessing-policy.rego`, so installs work without `--set-file`.
 - **ConfigMap content in spec hash** (#396): RO/EM spec hash computation now includes mounted ConfigMap content (excluding Secrets).
 - **LLM token usage in audit** (#435): Audit traces and Prometheus metrics now include LLM token consumption data.
-- **Mandatory JSON mode** (#98): LLM providers must support JSON mode (`ChatOptions{JSONMode: true}`). Most modern providers (OpenAI, Azure OpenAI, Anthropic) support this natively.
+- **Mandatory structured JSON responses** (#98): LLM providers must support schema-constrained JSON responses. Most modern providers (OpenAI, Azure OpenAI, Anthropic) support this natively.
 
 ---
 
@@ -110,7 +119,7 @@ These features are additive and do not require migration steps:
 After upgrading, verify the deployment is healthy:
 
 ```bash
-helm test kubernaut -n kubernaut-system
+helm status kubernaut -n kubernaut-system
 
 kubectl get pods -n kubernaut-system
 kubectl get pods -n kubernaut-workflows

--- a/docs/operations/upgrading/index.md
+++ b/docs/operations/upgrading/index.md
@@ -52,4 +52,6 @@ See the [installation guide](../../getting-started/installation.md#2-provision-s
 
 ## Version-Specific Notes
 
-No active version-specific migration guides. v1.0 is end-of-life and no longer documented.
+- [**v1.1 to v1.2**](1.1-to-1.2.md) — CRD schema hardening (typed enums, `metav1.Duration`), storm detection removal, PascalCase enum migration, per-workflow ServiceAccount, database migrations 002-004.
+
+v1.0 is end-of-life and no longer documented.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,8 +45,8 @@ theme:
     - toc.follow
 
 extra:
-  chart_version: "1.2.0-rc"
-  image_tag: "v1.2.0-rc"
+  chart_version: "1.2.0"
+  image_tag: "v1.2.0"
   version:
     provider: mike
     default: latest
@@ -151,7 +151,9 @@ nav:
       - Monitoring: operations/monitoring.md
       - Event Exporter: operations/event-exporter.md
       - Troubleshooting: operations/troubleshooting.md
-      - Upgrading: operations/upgrading/index.md
+      - Upgrading:
+          - operations/upgrading/index.md
+          - v1.1 to v1.2: operations/upgrading/1.1-to-1.2.md
       - Disconnected Install: operations/disconnected-install.md
   - Compliance:
       - SOC2 Alignment: user-guide/compliance.md


### PR DESCRIPTION
## Summary

- Update version macros to `1.2.0` GA (`chart_version`, `image_tag`)
- Update CI workflow to deploy `v1.2` as `latest` alias, and fetch CRDs from the `v1.2.0` tag
- Create comprehensive v1.1-to-v1.2 upgrade guide covering all breaking changes:
  - Storm detection removal (#448) — 5 `RemediationRequest` spec fields removed
  - CRD typed enums (#453, #455, #459) — string fields replaced with validated enums
  - `metav1.Duration` fields (#455) — Go duration format required
  - PascalCase enum migration (#453, #459, #483, #640) — notification type/priority values
  - Per-workflow ServiceAccount (#481) — field relocated from `spec.executionConfig` to `spec.serviceAccountName`
  - Database migrations 002-004 — automatic via Helm hook
- Link upgrade guide from `operations/upgrading/index.md` nav

## Issues

Closes #69. Partially addresses #60, #62, #67.

## Test plan

- [ ] Verify `mkdocs serve` renders the upgrade guide correctly
- [ ] Verify CI workflow logic deploys `v1.2` with `latest` alias
- [ ] Kubernaut team: validate breaking change field names and enum values against v1.2.0 source
- [ ] Demo-scenarios team: check PascalCase enum migration impact on demo routing configs

Made with [Cursor](https://cursor.com)