### PR TITLE
docs(v1.2): per-workflow ServiceAccount, TokenRequest, WE RBAC

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -122,7 +122,7 @@ Each CRD has its own phase state machine. The Orchestrator monitors child CRD st
 
 ## Namespace Model
 
-All Kubernaut services run in the `kubernaut-system` namespace. Workflow execution (Jobs/Tekton PipelineRuns) runs in a separate `kubernaut-workflows` namespace. By default, executions use the shared `kubernaut-workflow-runner` ServiceAccount. Starting with v1.2, workflows can declare a dedicated ServiceAccount via `spec.serviceAccountName` on the `RemediationWorkflow` CRD, enabling per-workflow least-privilege RBAC. See [Security & RBAC -- Per-Workflow ServiceAccount](security-rbac.md#per-workflow-serviceaccount-v12) for details.
+All Kubernaut services run in the `kubernaut-system` namespace. Workflow execution (Jobs/Tekton PipelineRuns) runs in a separate `kubernaut-workflows` namespace. By default, executions use the execution namespace default ServiceAccount (commonly configured as `kubernaut-workflow-runner` in shared-SA deployments). Starting with v1.2, workflows can declare a dedicated ServiceAccount via `spec.execution.serviceAccountName` on the `RemediationWorkflow` CRD (propagated to `WorkflowExecution.spec.serviceAccountName`), enabling per-workflow least-privilege RBAC. See [Security & RBAC -- Per-Workflow ServiceAccount](security-rbac.md#per-workflow-serviceaccount-v12) for details.
 
 ## Configuration
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -122,7 +122,7 @@ Each CRD has its own phase state machine. The Orchestrator monitors child CRD st
 
 ## Namespace Model
 
-All Kubernaut services run in the `kubernaut-system` namespace. Workflow execution (Jobs/Tekton PipelineRuns) runs in a separate `kubernaut-workflows` namespace with a shared ServiceAccount (`kubernaut-workflow-runner`). Per-workflow scoped RBAC is planned for v1.2.
+All Kubernaut services run in the `kubernaut-system` namespace. Workflow execution (Jobs/Tekton PipelineRuns) runs in a separate `kubernaut-workflows` namespace. By default, executions use the shared `kubernaut-workflow-runner` ServiceAccount. Starting with v1.2, workflows can declare a dedicated ServiceAccount via `spec.serviceAccountName` on the `RemediationWorkflow` CRD, enabling per-workflow least-privilege RBAC. See [Security & RBAC -- Per-Workflow ServiceAccount](security-rbac.md#per-workflow-serviceaccount-v12) for details.
 
 ## Configuration
 

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -92,7 +92,7 @@ If the `view` ClusterRole lacks read permission for a particular resource type (
 
 ## Workflow Execution
 
-Remediation workflows (Jobs, Tekton PipelineRuns, Ansible playbooks) execute in the `kubernaut-workflows` namespace under the `kubernaut-workflow-runner` ServiceAccount. This is the broadest ClusterRole in the system because workflows need to act on the cluster to remediate issues.
+Remediation workflows (Jobs, Tekton PipelineRuns, Ansible playbooks) execute in the `kubernaut-workflows` namespace. By default, workflow executions run with the execution namespace default ServiceAccount. Many deployments bind that default to `kubernaut-workflow-runner`, which carries the broadest ClusterRole in the system because workflows need to act on the cluster to remediate issues.
 
 | apiGroup | Resources | Verbs | Purpose |
 |---|---|---|---|
@@ -121,7 +121,12 @@ Additionally, a namespace-scoped `workflowexecution-dep-reader` Role grants `get
 
 ### Per-Workflow ServiceAccount (v1.2)
 
-Starting with v1.2, workflows can declare a dedicated ServiceAccount via the `spec.serviceAccountName` field on the `RemediationWorkflow` CRD. When set, the WE controller creates a short-lived token via the Kubernetes [TokenRequest API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) instead of using the shared `kubernaut-workflow-runner` SA. This enables least-privilege RBAC per workflow — each SA needs only the permissions required by its specific remediation.
+Starting with v1.2, workflows can declare a dedicated ServiceAccount via the `spec.execution.serviceAccountName` field on the `RemediationWorkflow` CRD. This value is propagated into `WorkflowExecution.spec.serviceAccountName`.
+
+- **Job/Tekton execution**: the service account name is set directly on the created Job or PipelineRun.
+- **Ansible execution**: the WE controller requests a short-lived token via the Kubernetes [TokenRequest API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) and injects it into AWX credentials.
+
+This enables least-privilege RBAC per workflow — each SA needs only the permissions required by its specific remediation.
 
 The WE controller's ClusterRole includes the following permissions for TokenRequest:
 
@@ -130,9 +135,12 @@ The WE controller's ClusterRole includes the following permissions for TokenRequ
 | (core) | `serviceaccounts` | get | Look up the per-workflow SA |
 | (core) | `serviceaccounts/token` | create | Create short-lived tokens via TokenRequest |
 
-**TTL validation:** The controller validates that the requested token TTL meets the minimum required for the execution. If the TTL is insufficient, it sets a `TokenTTLInsufficient` status condition on the WorkflowExecution and emits a warning event.
+**TTL validation (Ansible path):** When an execution timeout is configured, the controller validates that the requested token TTL covers the execution window. If the TTL is insufficient, it sets `TokenTTLInsufficient` on the WorkflowExecution and emits a warning event (`TokenTTLShortened`).
 
-**Fallback behavior:** When `spec.serviceAccountName` is not set on a workflow, the controller falls back to the shared `kubernaut-workflow-runner` ServiceAccount. Existing workflows require no changes.
+**Fallback behavior:** If `serviceAccountName` is not set:
+
+- Job/Tekton run with the execution namespace default ServiceAccount.
+- Ansible falls back to controller in-cluster credentials for AWX credential injection.
 
 For the Ansible executor (#501), TokenRequest tokens replace the controller's own in-cluster SA token for AWX credential injection, ensuring each playbook runs with the minimum permissions declared by the workflow author.
 
@@ -165,7 +173,7 @@ The credential type resolution follows a 6-step process:
 
 The v2 kubeconfig template conditionally includes `certificate-authority-data` when the cluster CA is available, or sets `insecure-skip-tls-verify: true` otherwise. AWX injects the rendered kubeconfig as a temp file and sets `K8S_AUTH_KUBECONFIG` to point to it, ensuring `kubernetes.core` modules use the injected credentials instead of in-cluster config.
 
-Ephemeral credentials are cleaned up after the AWX job completes. See [BR-WE-017](https://github.com/jordigilh/kubernaut/blob/main/docs/requirements/BR-WE-017-shared-sa-execution-model.md) for the full shared SA model. In v1.2, workflows can declare a dedicated ServiceAccount via `spec.serviceAccountName` — see [Per-Workflow ServiceAccount](#per-workflow-serviceaccount-v12) above.
+Ephemeral credentials are cleaned up after the AWX job completes. See [BR-WE-017](https://github.com/jordigilh/kubernaut/blob/main/docs/requirements/BR-WE-017-shared-sa-execution-model.md) for the full shared SA model. In v1.2, workflows can declare a dedicated ServiceAccount via `spec.execution.serviceAccountName` — see [Per-Workflow ServiceAccount](#per-workflow-serviceaccount-v12) above.
 
 ## Internal Service Communication
 

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -115,12 +115,26 @@ Remediation workflows (Jobs, Tekton PipelineRuns, Ansible playbooks) execute in 
 | (core) | `endpoints` | get, list | Check service endpoint health |
 | `batch` | `jobs` | get, list, create, delete | pg_dump/pg_restore Job lifecycle (disk-pressure-emptydir scenario) |
 
-The last four rules were added for production Ansible playbooks (DD-WE-007). In v1.2, per-workflow SA scoping ([#501](https://github.com/jordigilh/kubernaut/issues/501)) will replace the shared ClusterRole with schema-declared RBAC per execution.
+The last four rules were added for production Ansible playbooks (DD-WE-007).
 
 Additionally, a namespace-scoped `workflowexecution-dep-reader` Role grants `get`, `list`, `watch` on Secrets and ConfigMaps in the execution namespace for dependency validation before workflow launch.
 
-!!! info "Per-workflow scoped RBAC"
-    All workflows share the `kubernaut-workflow-runner` ServiceAccount. Per-workflow scoped RBAC (restricting each workflow to only the resources it needs) is planned for v1.2.
+### Per-Workflow ServiceAccount (v1.2)
+
+Starting with v1.2, workflows can declare a dedicated ServiceAccount via the `spec.serviceAccountName` field on the `RemediationWorkflow` CRD. When set, the WE controller creates a short-lived token via the Kubernetes [TokenRequest API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) instead of using the shared `kubernaut-workflow-runner` SA. This enables least-privilege RBAC per workflow — each SA needs only the permissions required by its specific remediation.
+
+The WE controller's ClusterRole includes the following permissions for TokenRequest:
+
+| apiGroup | Resources | Verbs | Purpose |
+|---|---|---|---|
+| (core) | `serviceaccounts` | get | Look up the per-workflow SA |
+| (core) | `serviceaccounts/token` | create | Create short-lived tokens via TokenRequest |
+
+**TTL validation:** The controller validates that the requested token TTL meets the minimum required for the execution. If the TTL is insufficient, it sets a `TokenTTLInsufficient` status condition on the WorkflowExecution and emits a warning event.
+
+**Fallback behavior:** When `spec.serviceAccountName` is not set on a workflow, the controller falls back to the shared `kubernaut-workflow-runner` ServiceAccount. Existing workflows require no changes.
+
+For the Ansible executor (#501), TokenRequest tokens replace the controller's own in-cluster SA token for AWX credential injection, ensuring each playbook runs with the minimum permissions declared by the workflow author.
 
 ## OCP Monitoring RBAC
 
@@ -151,7 +165,7 @@ The credential type resolution follows a 6-step process:
 
 The v2 kubeconfig template conditionally includes `certificate-authority-data` when the cluster CA is available, or sets `insecure-skip-tls-verify: true` otherwise. AWX injects the rendered kubeconfig as a temp file and sets `K8S_AUTH_KUBECONFIG` to point to it, ensuring `kubernetes.core` modules use the injected credentials instead of in-cluster config.
 
-Ephemeral credentials are cleaned up after the AWX job completes. See [BR-WE-017](https://github.com/jordigilh/kubernaut/blob/main/docs/requirements/BR-WE-017-shared-sa-execution-model.md) for the full shared SA model and the planned v1.2 transition to per-workflow ServiceAccounts.
+Ephemeral credentials are cleaned up after the AWX job completes. See [BR-WE-017](https://github.com/jordigilh/kubernaut/blob/main/docs/requirements/BR-WE-017-shared-sa-execution-model.md) for the full shared SA model. In v1.2, workflows can declare a dedicated ServiceAccount via `spec.serviceAccountName` — see [Per-Workflow ServiceAccount](#per-workflow-serviceaccount-v12) above.
 
 ## Internal Service Communication
 

--- a/docs/architecture/workflow-execution.md
+++ b/docs/architecture/workflow-execution.md
@@ -233,7 +233,9 @@ When a WFE spec omits `engineConfig`, the controller resolves it from the workfl
 
 ## Execution Namespace and RBAC
 
-All Jobs and PipelineRuns execute in the dedicated `kubernaut-workflows` namespace. They share a common ServiceAccount (`kubernaut-workflow-runner`) managed by the controller. See [Security & RBAC -- Workflow Execution](security-rbac.md#workflow-execution) for the full list of permissions granted to this ServiceAccount. Per-workflow scoped RBAC is planned for v1.2.
+All Jobs and PipelineRuns execute in the dedicated `kubernaut-workflows` namespace. By default they use the shared `kubernaut-workflow-runner` ServiceAccount. See [Security & RBAC -- Workflow Execution](security-rbac.md#workflow-execution) for the full list of permissions granted to this ServiceAccount.
+
+Starting with v1.2, workflows can declare a dedicated ServiceAccount via `spec.serviceAccountName` on the `RemediationWorkflow` CRD. When set, the WE controller creates a short-lived token via the Kubernetes TokenRequest API and injects it into the Job, PipelineRun, or AWX credential instead of the shared SA token. This enables least-privilege RBAC per workflow. See [Security & RBAC -- Per-Workflow ServiceAccount](security-rbac.md#per-workflow-serviceaccount-v12) for details on the TokenRequest flow, TTL validation, and fallback behavior.
 
 ## Parameter Injection
 

--- a/docs/architecture/workflow-execution.md
+++ b/docs/architecture/workflow-execution.md
@@ -233,9 +233,14 @@ When a WFE spec omits `engineConfig`, the controller resolves it from the workfl
 
 ## Execution Namespace and RBAC
 
-All Jobs and PipelineRuns execute in the dedicated `kubernaut-workflows` namespace. By default they use the shared `kubernaut-workflow-runner` ServiceAccount. See [Security & RBAC -- Workflow Execution](security-rbac.md#workflow-execution) for the full list of permissions granted to this ServiceAccount.
+All Jobs and PipelineRuns execute in the dedicated `kubernaut-workflows` namespace. By default they use the execution namespace default ServiceAccount (commonly configured as `kubernaut-workflow-runner` in shared-SA deployments). See [Security & RBAC -- Workflow Execution](security-rbac.md#workflow-execution) for the full list of permissions granted to the shared execution role.
 
-Starting with v1.2, workflows can declare a dedicated ServiceAccount via `spec.serviceAccountName` on the `RemediationWorkflow` CRD. When set, the WE controller creates a short-lived token via the Kubernetes TokenRequest API and injects it into the Job, PipelineRun, or AWX credential instead of the shared SA token. This enables least-privilege RBAC per workflow. See [Security & RBAC -- Per-Workflow ServiceAccount](security-rbac.md#per-workflow-serviceaccount-v12) for details on the TokenRequest flow, TTL validation, and fallback behavior.
+Starting with v1.2, workflows can declare a dedicated ServiceAccount via `spec.execution.serviceAccountName` on the `RemediationWorkflow` CRD (propagated to `WorkflowExecution.spec.serviceAccountName`). This enables least-privilege RBAC per workflow.
+
+- Job/Tekton: the service account name is set directly on the created Job/PipelineRun.
+- Ansible: the controller requests a short-lived token via the Kubernetes TokenRequest API for AWX credential injection.
+
+See [Security & RBAC -- Per-Workflow ServiceAccount](security-rbac.md#per-workflow-serviceaccount-v12) for details on TokenRequest scope, TTL validation, and fallback behavior.
 
 ## Parameter Injection
 

--- a/docs/user-guide/workflow-authoring.md
+++ b/docs/user-guide/workflow-authoring.md
@@ -220,19 +220,22 @@ This is a **tiebreaker/ordering influence**, not an override. It won't overcome 
 
 ## Per-Workflow ServiceAccount
 
-The optional `spec.serviceAccountName` field on a `RemediationWorkflow` lets each workflow run with its own least-privilege ServiceAccount instead of the shared `kubernaut-workflow-runner`. When set, the WE controller creates a short-lived token via the Kubernetes TokenRequest API and injects it into the Job, PipelineRun, or AWX credential.
+The optional `spec.execution.serviceAccountName` field on a `RemediationWorkflow` lets each workflow run with its own least-privilege ServiceAccount instead of the execution namespace default.
 
 ```yaml
 spec:
-  serviceAccountName: my-workflow-sa
   execution:
+    serviceAccountName: my-workflow-sa
     engine: job
     bundle: registry.example.com/workflows/my-workflow@sha256:...
 ```
 
-The ServiceAccount must exist in the `kubernaut-workflows` namespace (or the configured execution namespace) with only the RBAC permissions required by the workflow. If `serviceAccountName` is omitted, the shared `kubernaut-workflow-runner` SA is used.
+The ServiceAccount must exist in the `kubernaut-workflows` namespace (or the configured execution namespace) with only the RBAC permissions required by the workflow. If `serviceAccountName` is omitted:
 
-See [Security & RBAC -- Per-Workflow ServiceAccount](../architecture/security-rbac.md#per-workflow-serviceaccount-v12) for the TokenRequest flow, TTL validation, and fallback behavior.
+- Job/Tekton use the execution namespace default ServiceAccount.
+- Ansible falls back to controller in-cluster credentials unless `WorkflowExecution.spec.serviceAccountName` is set.
+
+TokenRequest is used by the Ansible path for AWX credential injection when the workflow specifies a service account. See [Security & RBAC -- Per-Workflow ServiceAccount](../architecture/security-rbac.md#per-workflow-serviceaccount-v12) for scope, TTL validation, and fallback behavior.
 
 ## Standard Resource Parameters
 

--- a/docs/user-guide/workflow-authoring.md
+++ b/docs/user-guide/workflow-authoring.md
@@ -218,6 +218,22 @@ Custom label matches add to the raw score (before normalization to 0-1). See [Wo
 
 This is a **tiebreaker/ordering influence**, not an override. It won't overcome a strong semantic mismatch in descriptions -- if the LLM strongly prefers a lower-ranked workflow based on its `whenToUse`, it will still pick it.
 
+## Per-Workflow ServiceAccount
+
+The optional `spec.serviceAccountName` field on a `RemediationWorkflow` lets each workflow run with its own least-privilege ServiceAccount instead of the shared `kubernaut-workflow-runner`. When set, the WE controller creates a short-lived token via the Kubernetes TokenRequest API and injects it into the Job, PipelineRun, or AWX credential.
+
+```yaml
+spec:
+  serviceAccountName: my-workflow-sa
+  execution:
+    engine: job
+    bundle: registry.example.com/workflows/my-workflow@sha256:...
+```
+
+The ServiceAccount must exist in the `kubernaut-workflows` namespace (or the configured execution namespace) with only the RBAC permissions required by the workflow. If `serviceAccountName` is omitted, the shared `kubernaut-workflow-runner` SA is used.
+
+See [Security & RBAC -- Per-Workflow ServiceAccount](../architecture/security-rbac.md#per-workflow-serviceaccount-v12) for the TokenRequest flow, TTL validation, and fallback behavior.
+
 ## Standard Resource Parameters
 
 Every workflow receives a set of standard `TARGET_RESOURCE_*` parameters that identify the Kubernetes resource selected for remediation. **HAPI (HolmesGPT API)** derives these from the K8s-verified `root_owner` during investigation and injects them into the selected workflow's parameters before the AIAnalysis completes -- workflow authors do not need to populate them manually.
@@ -318,6 +334,7 @@ spec:
     priority: "*"
   customLabels:
     risk_tolerance: "high"
+  serviceAccountName: restart-pods-sa
   execution:
     engine: job
     bundle: registry.example.com/workflows/restart-pods@sha256:abc123...


### PR DESCRIPTION
## Summary

- Document per-workflow ServiceAccount model (`spec.serviceAccountName`) with CRD field relocation from `spec.executionConfig`
- Document TokenRequest flow, TTL validation (`TokenTTLInsufficient` condition), fallback to shared SA, and Ansible executor integration (#501)
- Add `serviceaccounts/token create` and `serviceaccounts get` to WE ClusterRole documentation (#637)
- Update "planned for v1.2" references to present tense
- Add per-workflow SA section and example to `workflow-authoring.md`

## Issues

Closes #61, #38. Partially addresses #70.

## Test plan

- [ ] Kubernaut team: validate TokenRequest flow, RBAC model, CRD field relocation, and fallback behavior against v1.2.0 source
- [ ] Verify anchor link `#per-workflow-serviceaccount-v12` resolves correctly

Made with [Cursor](https://cursor.com)