### PR TITLE
docs(v1.2): SP, HAPI, Gateway, and Rego policy updates

### DIFF
--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -35,9 +35,9 @@ The Prometheus adapter expects alerts to carry standard Kubernetes labels for re
 | Label | Required | Description |
 |---|---|---|
 | `namespace` | Yes (namespaced resources) | Target resource namespace |
-| `severity` | Yes | Alert severity (normalized by SP Rego) |
+| `severity` | Recommended | Alert severity (normalized by SP Rego; defaults to `unknown` when absent) |
 | `alertname` | Yes | Alert name (becomes `SignalName`) |
-| One of: `deployment`, `statefulset`, `daemonset`, `replicaset`, `node`, `service`, `job_name`, `cronjob`, `pod` | Yes | Target resource identity |
+| One of: `horizontalpodautoscaler`, `poddisruptionbudget`, `persistentvolumeclaim`, `deployment`, `statefulset`, `daemonset`, `replicaset`, `node`, `service`, `job_name`, `cronjob`, `pod` | Yes | Target resource identity |
 
 The adapter uses a priority list to select the resource label: HPA > PDB > PVC > Deployment > StatefulSet > DaemonSet > ReplicaSet > Node > Service > Job (`job_name`) > CronJob > Pod.
 

--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -26,6 +26,33 @@ flowchart LR
 
 Each signal source uses a dedicated **adapter** that parses the source-specific payload format into a common `NormalizedSignal` structure. Adapters are registered at startup via `RegisterAdapter()`.
 
+## Expected Signal Labels
+
+### AlertManager Label Contract
+
+The Prometheus adapter expects alerts to carry standard Kubernetes labels for resource identification. The Gateway uses these labels to resolve the target resource:
+
+| Label | Required | Description |
+|---|---|---|
+| `namespace` | Yes (namespaced resources) | Target resource namespace |
+| `severity` | Yes | Alert severity (normalized by SP Rego) |
+| `alertname` | Yes | Alert name (becomes `SignalName`) |
+| One of: `deployment`, `statefulset`, `daemonset`, `replicaset`, `node`, `service`, `job_name`, `cronjob`, `pod` | Yes | Target resource identity |
+
+The adapter uses a priority list to select the resource label: HPA > PDB > PVC > Deployment > StatefulSet > DaemonSet > ReplicaSet > Node > Service > Job (`job_name`) > CronJob > Pod.
+
+### Kubernetes Event Exporter Label Contract
+
+The Kubernetes Event adapter expects the Event Exporter to forward events with these fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `involvedObject.kind` | Yes | Resource kind |
+| `involvedObject.name` | Yes | Resource name |
+| `involvedObject.namespace` | Recommended | Resource namespace |
+| `reason` | Yes | Event reason (becomes `SignalName`) |
+| `type` | Yes | `Warning` or `Error` (`Normal` events are filtered out) |
+
 ## Signal Adapters
 
 ### Prometheus Adapter

--- a/docs/architecture/hapi-investigation.md
+++ b/docs/architecture/hapi-investigation.md
@@ -59,11 +59,11 @@ Remediation history is automatically included by the resource-context tools via 
 
 The LLM operates as an autonomous agent -- it calls Kubernetes tools iteratively, synthesizes findings, and makes decisions. HAPI provides the prompt framing, tools, and validation; the LLM drives the investigation.
 
-!!! warning "Mandatory JSON mode"
-    HAPI requires the LLM provider to support JSON mode (`ChatOptions{JSONMode: true}`). This ensures the LLM returns structured responses that HAPI can parse reliably. Most modern providers (OpenAI, Azure OpenAI, Anthropic) support this natively. Providers without JSON mode support will produce unparseable responses.
+!!! warning "Mandatory structured JSON responses"
+    HAPI requires the LLM provider/runtime to support schema-constrained JSON responses. This ensures the LLM returns structured payloads that HAPI can parse reliably. Most modern providers (OpenAI, Azure OpenAI, Anthropic) support this natively.
 
 !!! note "LLM model-dependent escalation behavior"
-    Escalation behavior (e.g., when the LLM decides to switch from a failing workflow to human review) depends on the specific LLM model's reasoning capabilities. Different models may make different escalation decisions given the same remediation history context. In v1.2, HAPI's Pydantic validation schema was fixed to properly validate escalation responses on cycle 2+ (#624), ensuring consistent behavior across retry attempts.
+    Escalation behavior (e.g., when the LLM decides to switch from a failing workflow to human review) depends on the specific LLM model's reasoning capabilities. Different models may make different escalation decisions given the same remediation history context. In v1.2, HAPI's structured response parsing/validation path was hardened (#624), improving reliability of repeated analysis cycles.
 
 ## Pre-RCA: Prompt Construction
 
@@ -199,10 +199,10 @@ The response contains two tiers of history with different query strategies, time
 
 | Tier | Window | Query Strategy | Detail Level |
 |---|---|---|---|
-| **Tier 1** | Last 24 hours | By `target_resource` via `QueryROEventsByTarget`, then hash match computed post-query via `CorrelateTier1Chain` / `ComputeHashMatch` | Full: effectiveness score, health checks, metric deltas, hash match |
+| **Tier 1** | Last 24 hours | By `spec_hash` via `QueryROEventsBySpecHash` | Full: effectiveness score, health checks, metric deltas, hash match |
 | **Tier 2** | 24 hours – 90 days | By `spec_hash` via `QueryROEventsBySpecHash` | Summary: effectiveness score, hash match, assessment reason |
 
-- **Tier 1** queries by target resource and time window first, then correlates results by computing hash match in-memory. This captures the full recent remediation chain for the target resource regardless of spec hash, giving the LLM visibility into the immediate history.
+- **Tier 1** queries directly by spec hash for the last 24h, returning high-detail recent entries for the same configuration.
 - **Tier 2** queries directly by spec hash, surfacing only outcomes for the same configuration. This helps the LLM identify recurring patterns across a longer time horizon.
 
 **How the chain is visible:** Every entry in both tiers carries `preRemediationSpecHash` and `postRemediationSpecHash`. DataStorage annotates each entry with a `hashMatch` field by comparing the caller's `currentSpecHash` against these stored hashes. This lets the LLM trace the full chain of configuration transitions and outcomes.
@@ -232,7 +232,7 @@ Consider a Deployment `my-app` in production that has been failing repeatedly in
 3. **Third attempt**: Config now at `BBB`, `RollbackDeployment` was tried, scored 0.20 (poor), config changed to `CCC`
 4. **GitOps reverted the rollback**, pushing config back to `AAA` -- triggering this new investigation
 
-Tier 1 returns all three entries because they all target the same resource in the last 24 hours:
+Tier 1 returns entries in the last 24 hours that match the current spec-hash correlation criteria:
 
 ```json
 {
@@ -373,8 +373,8 @@ To prevent unbounded remediation loops, the Remediation Orchestrator enforces tw
 
 | Config Key | Default | Description |
 |---|---|---|
-| `remediationorchestrator.config.ineffectiveChainThreshold` | 3 | Maximum consecutive "completed but still broken" remediations (matching pre- and post-remediation spec hashes) before the RR is blocked with `IneffectiveChain` |
-| `remediationorchestrator.config.recurrenceCountThreshold` | 5 | Maximum recurrence count (re-firing signals for the same fingerprint) before the RR is blocked |
+| `remediationorchestrator.config.routing.ineffectiveChainThreshold` | 3 | Maximum ineffective remediation-chain depth before the RR is blocked with `IneffectiveChain` |
+| `remediationorchestrator.config.routing.recurrenceCountThreshold` | 5 | Safety-net cap on ineffective-chain remediation entries within the routing lookback window |
 
 When either threshold is exceeded, the Orchestrator blocks the RemediationRequest and emits a notification directing operators to investigate manually. The dual-hash query semantics (matching both `pre_remediation_spec_hash` and `post_remediation_spec_hash`) enable accurate chain detection via DataStorage.
 

--- a/docs/architecture/hapi-investigation.md
+++ b/docs/architecture/hapi-investigation.md
@@ -59,6 +59,12 @@ Remediation history is automatically included by the resource-context tools via 
 
 The LLM operates as an autonomous agent -- it calls Kubernetes tools iteratively, synthesizes findings, and makes decisions. HAPI provides the prompt framing, tools, and validation; the LLM drives the investigation.
 
+!!! warning "Mandatory JSON mode"
+    HAPI requires the LLM provider to support JSON mode (`ChatOptions{JSONMode: true}`). This ensures the LLM returns structured responses that HAPI can parse reliably. Most modern providers (OpenAI, Azure OpenAI, Anthropic) support this natively. Providers without JSON mode support will produce unparseable responses.
+
+!!! note "LLM model-dependent escalation behavior"
+    Escalation behavior (e.g., when the LLM decides to switch from a failing workflow to human review) depends on the specific LLM model's reasoning capabilities. Different models may make different escalation decisions given the same remediation history context. In v1.2, HAPI's Pydantic validation schema was fixed to properly validate escalation responses on cycle 2+ (#624), ensuring consistent behavior across retry attempts.
+
 ## Pre-RCA: Prompt Construction
 
 Before any tools are called, HAPI assembles the initial prompt from the enriched signal. This context frames the entire investigation:
@@ -163,6 +169,12 @@ Probes the cluster to detect infrastructure characteristics of the root owner:
 | `stateful` | Resource is StatefulSet or has PersistentVolumeClaims |
 | `networkIsolated` | NetworkPolicy exists in the namespace |
 | `serviceMesh` | Istio/Linkerd sidecar annotations |
+| `resourceQuotaConstrained` | Namespace has an active `ResourceQuota` |
+
+When `resourceQuotaConstrained` is detected, the `LabelDetector` also surfaces `quota_details` as a top-level field in the resource context response, containing the namespace's `ResourceQuota` spec (limits, requests, and used values). This gives the LLM visibility into capacity constraints during workflow selection — for example, preferring a scale-down workflow over scale-up when the namespace is near its quota.
+
+!!! note "LimitRange detection"
+    LimitRange detection is not implemented in v1.2. Only ResourceQuota constraints are surfaced.
 
 These labels are stored in `session_state` and automatically injected into all subsequent workflow discovery queries. They serve two purposes:
 
@@ -192,9 +204,6 @@ The response contains two tiers of history with different query strategies, time
 
 - **Tier 1** queries by target resource and time window first, then correlates results by computing hash match in-memory. This captures the full recent remediation chain for the target resource regardless of spec hash, giving the LLM visibility into the immediate history.
 - **Tier 2** queries directly by spec hash, surfacing only outcomes for the same configuration. This helps the LLM identify recurring patterns across a longer time horizon.
-
-!!! warning "Known issue: Tier 1 query strategy"
-    Tier 1 queries by target resource rather than spec hash by design at v1.1 — the hash match is computed post-query by `CorrelateTier1Chain`. A known issue ([kubernaut#586](https://github.com/jordigilh/kubernaut/issues/586)) tracks tightening this to filter by spec hash at the query level in v1.2.
 
 **How the chain is visible:** Every entry in both tiers carries `preRemediationSpecHash` and `postRemediationSpecHash`. DataStorage annotates each entry with a `hashMatch` field by comparing the caller's `currentSpecHash` against these stored hashes. This lets the LLM trace the full chain of configuration transitions and outcomes.
 
@@ -358,6 +367,17 @@ flowchart LR
 
 This is Kubernaut's "learning" mechanism -- not model fine-tuning, but contextual memory via the audit trail. The more remediations a resource undergoes, the richer the context available to the LLM for future decisions.
 
+### IneffectiveChain Guardrails (v1.2)
+
+To prevent unbounded remediation loops, the Remediation Orchestrator enforces two configurable thresholds:
+
+| Config Key | Default | Description |
+|---|---|---|
+| `remediationorchestrator.config.ineffectiveChainThreshold` | 3 | Maximum consecutive "completed but still broken" remediations (matching pre- and post-remediation spec hashes) before the RR is blocked with `IneffectiveChain` |
+| `remediationorchestrator.config.recurrenceCountThreshold` | 5 | Maximum recurrence count (re-firing signals for the same fingerprint) before the RR is blocked |
+
+When either threshold is exceeded, the Orchestrator blocks the RemediationRequest and emits a notification directing operators to investigate manually. The dual-hash query semantics (matching both `pre_remediation_spec_hash` and `post_remediation_spec_hash`) enable accurate chain detection via DataStorage.
+
 ## Workflow Selection: Three-Step Discovery
 
 After resource context is gathered (Phase 2: Enrich), the LLM enters the Workflow Select phase. The `session_state["detected_labels"]` from the previous phase are automatically injected into all DataStorage queries as context filters.
@@ -491,6 +511,9 @@ The LLM investigates and determines the alert is not actionable — for example,
 
 **Fields:** `selected_workflow=null`, `Outcome=WorkflowNotNeeded`, `SubReason=NotActionable`
 **Next:** AA sets `Outcome=NoActionRequired`. No workflow execution. Rego is never evaluated.
+
+!!! note "Confidence floor for not-actionable responses"
+    When the LLM returns `actionable=false` with a confidence below 0.8, HAPI floors the confidence to 0.8. This prevents the AA controller from misclassifying a deliberate "not actionable" determination as a low-confidence failure (Outcome 7).
 
 !!! note "Only Outcome 1 reaches Rego"
     Outcomes 2–9 are all handled by the AA controller's response processor **before** Rego evaluation. The Rego approval policy only runs when the LLM successfully selects a workflow with `needs_human_review=false` and `confidence >= 0.7`.

--- a/docs/user-guide/approval.md
+++ b/docs/user-guide/approval.md
@@ -13,9 +13,9 @@ Approval is determined by a **user-replaceable Rego policy** evaluated during th
 
 The shipped `approval.rego` makes decisions based on **environment**, **remediation target presence**, and **sensitive resource kinds**:
 
-- **Production namespaces** (`kubernaut.ai/environment=production`) — always require approval, regardless of confidence
+- **Production namespaces** (`kubernaut.ai/environment=production`) — always require approval, regardless of confidence. Environment matching is **case-insensitive** (e.g., `Production`, `production`, `PRODUCTION` all match).
 - **Sensitive resource kinds** (Node, StatefulSet) — always require approval, regardless of environment
-- **Non-production namespaces** (`staging`, `development`, `qa`, `test`) — auto-approved when `remediation_target` is present and the resource kind is not sensitive
+- **Non-production namespaces** (`staging`, `development`, `qa`, `test`) — auto-approved when `remediation_target` is present and the resource kind is not sensitive. Environment matching is case-insensitive.
 - **Missing remediation target** — always requires approval (default-deny safety per ADR-055)
 
 When approval is required, a `RemediationApprovalRequest` CRD is created and the remediation enters the `AwaitingApproval` phase.

--- a/docs/user-guide/configmap-approval.md
+++ b/docs/user-guide/configmap-approval.md
@@ -59,7 +59,7 @@ The policy must produce these outputs:
 
 ## Default Behavior
 
-The reference policy (`charts/kubernaut/examples/approval.rego`) implements:
+The reference policy (`charts/kubernaut/files/defaults/approval.rego`) implements:
 
 - **Production environments**: Always require approval (controlled via `kubernaut.ai/environment=production` namespace label). Environment matching is **case-insensitive** — `Production`, `production`, `PRODUCTION` all match.
 - **Sensitive resources** (Node, StatefulSet): Always require approval regardless of environment
@@ -130,4 +130,4 @@ The approval policy supports hot-reload via fsnotify (~60s kubelet sync delay). 
 
 ## Reference File
 
-A complete reference policy is available in the chart: `charts/kubernaut/examples/approval.rego`
+A complete reference policy is available in the chart: `charts/kubernaut/files/defaults/approval.rego`

--- a/docs/user-guide/configmap-approval.md
+++ b/docs/user-guide/configmap-approval.md
@@ -61,7 +61,7 @@ The policy must produce these outputs:
 
 The reference policy (`charts/kubernaut/examples/approval.rego`) implements:
 
-- **Production environments**: Always require approval (controlled via `kubernaut.ai/environment=production` namespace label)
+- **Production environments**: Always require approval (controlled via `kubernaut.ai/environment=production` namespace label). Environment matching is **case-insensitive** — `Production`, `production`, `PRODUCTION` all match.
 - **Sensitive resources** (Node, StatefulSet): Always require approval regardless of environment
 - **Missing remediation target**: Always require approval (safety default)
 - **Non-production**: Auto-approved unless critical safety conditions are met
@@ -103,7 +103,7 @@ default reason := "Auto-approved (testing mode)"
 
 ```rego
 require_approval if {
-  input.environment == "staging"
+  lower(input.environment) == "staging"
   input.confidence < 0.9
 }
 ```

--- a/docs/user-guide/policies.md
+++ b/docs/user-guide/policies.md
@@ -4,6 +4,12 @@ Kubernaut uses [OPA Rego](https://www.openpolicyagent.org/docs/latest/policy-lan
 
 All policies are deployed as ConfigMaps and can be customized. See [SignalProcessing Rego Policies](configmap-policies.md) for provisioning details.
 
+!!! info "Case-insensitive matching (v1.2)"
+    Starting with v1.2, environment and severity matching in both workflow discovery filters and approval Rego policies is **case-insensitive**. For example, `Production`, `production`, and `PRODUCTION` all match equivalently. The default policies use `lower()` for comparisons. Custom policies should follow the same pattern.
+
+!!! info "Embedded default SP Rego (v1.2)"
+    Starting with v1.2, the Helm chart ships a default `signalprocessing-policy.rego` so installations work without `--set-file`. Users who previously relied on an empty ConfigMap should be aware the chart now generates a default policy with standard severity, priority, and environment rules.
+
 ## Policy Overview
 
 | Policy File | Service | Purpose | Hot-Reload |

--- a/docs/user-guide/rego-reference.md
+++ b/docs/user-guide/rego-reference.md
@@ -7,6 +7,9 @@ All policies are deployed as ConfigMaps and support hot-reload. See [Rego Polici
 !!! tip "Writing custom policies"
     Every `input.*` field listed below is available in your Rego rules. The default policies shipped with Kubernaut use only a subset -- you can reference any field to build richer logic tailored to your organization.
 
+!!! info "Case-insensitive matching (v1.2)"
+    Starting with v1.2, environment and severity matching in both workflow discovery filters and approval policies is case-insensitive. The default policies use `lower()` for all comparisons. Custom policies should follow the same pattern to ensure consistent behavior — e.g., `lower(input.environment) == "production"` instead of `input.environment == "production"`.
+
 ---
 
 ## Signal Processing Policy


### PR DESCRIPTION
## Summary

- Remove Tier 1 query strategy warning (#586 — fixed in v1.2, now queries by spec hash)
- Document ResourceQuota detection and `quota_details` field (#366); explicitly note LimitRange is NOT implemented
- Add IneffectiveChain guardrails with `ineffectiveChainThreshold` and `recurrenceCountThreshold` config knobs (#616)
- Document HAPI confidence floor for not-actionable responses (#607)
- Add mandatory JSON mode requirement note (#98)
- Add LLM model-dependent escalation and Pydantic validation fix notes (#97, #624)
- Document Gateway AlertManager label contract and Event Exporter label contract (#96)
- Update all Rego/approval docs for case-insensitive matching (#595, #604)
- Document embedded default SP Rego policy shipped with Helm chart (#604)

## Issues

Closes #67 (SP + gateway parts), #96, #97, #98.

## Test plan

- [ ] Kubernaut team: validate IneffectiveChain threshold defaults and dual-hash query semantics
- [ ] Kubernaut team: confirm ResourceQuota-only scope (no LimitRange), confidence floor value (0.8)
- [ ] Kubernaut team: verify Gateway AlertManager label priority list matches source
- [ ] Demo-scenarios team: check if case-insensitive matching impacts any demo Rego policies

Made with [Cursor](https://cursor.com)