### PR TITLE
docs(v1.2): effectiveness monitor and notification pipeline updates

### DIFF
--- a/docs/architecture/effectiveness.md
+++ b/docs/architecture/effectiveness.md
@@ -38,16 +38,17 @@ stateDiagram-v2
 | **Completed** | Assessment complete, results stored in status |
 | **Failed** | Terminal failure: the assessment could not be completed. Examples include the target resource no longer existing, unrecoverable errors during reconciliation, or dependencies such as Prometheus remaining unavailable after the configured retry budget. |
 
-On relevant phase transitions, the Effectiveness Monitor emits an `assessment.scheduled` event so operators and automation can observe when the next assessment step is expected.
+On relevant phase transitions, the Effectiveness Monitor emits an `effectiveness.assessment.scheduled` audit event so operators and automation can observe when the next assessment step is expected.
 
 ### EM controller assessment tuning
 
-The EM controller exposes two assessment reconciliation knobs:
+The EM controller exposes assessment timing and concurrency knobs:
 
 | Parameter | Purpose |
 |---|---|
-| `requeueInterval` | How long to wait before requeuing when the assessment must be deferred (e.g., waiting for propagation, stabilization, or backoff). |
-| `maxRetries` | Maximum retries for transient failures (e.g., Prometheus or API errors) before marking the assessment as failed. |
+| `stabilizationWindow` | Wait time before starting assessment scorers after EA creation. |
+| `validityWindow` | Total window before the assessment expires. |
+| `maxConcurrentReconciles` | Maximum number of EA reconciliations processed in parallel by the controller. |
 
 ### Assessment paths
 
@@ -58,7 +59,7 @@ Each completed assessment is classified into one of four paths, reflecting how f
 | `no_execution` | No meaningful assessment run (e.g., prerequisites not met). |
 | `partial` | Some components assessed; others skipped or incomplete before the deadline. |
 | `full` | All applicable components assessed successfully within the window. |
-| `timed-out` | The validity window expired before all components could be assessed. |
+| `metrics_timed_out` / `alert_decay_timeout` / `expired` | Assessment deadline paths where the validity window expired before full convergence. |
 
 ## Timing Model
 
@@ -161,7 +162,7 @@ Compares pre-remediation and post-remediation metrics from Prometheus:
 - Clamped to [0.0, 1.0]
 - Overall score: average of per-metric improvements
 
-Respects `PrometheusCheckAfter` deadline and uses `PrometheusLookback` (default: 10m) for the query range.
+Respects `PrometheusCheckAfter` deadline and uses `PrometheusLookback` (default: 30m) for the query range.
 
 **Reliability (v1.2+)**: The interaction between `ValidityWindow` and alert duration was corrected so metrics windows align with the assessment timeline. Metrics scoring is now reliable when both are configured.
 

--- a/docs/architecture/effectiveness.md
+++ b/docs/architecture/effectiveness.md
@@ -20,7 +20,7 @@ stateDiagram-v2
     Pending --> WaitingForPropagation : HashComputeDelay set
     Pending --> Stabilizing : No propagation delay
     Pending --> Assessing : Direct (edge case)
-    Pending --> Failed : Target not found
+    Pending --> Failed : Terminal failure
     WaitingForPropagation --> Stabilizing : Propagation delay elapsed
     WaitingForPropagation --> Failed : Error
     Stabilizing --> Assessing : Stabilization window elapsed
@@ -36,7 +36,29 @@ stateDiagram-v2
 | **Stabilizing** | Waiting for the stabilization window. Derived timing fields (`ValidityDeadline`, `PrometheusCheckAfter`, `AlertManagerCheckAfter`) are computed and persisted. |
 | **Assessing** | Actively running component scorers (health, hash, alerts, metrics) |
 | **Completed** | Assessment complete, results stored in status |
-| **Failed** | Assessment could not be completed (e.g., target not found) |
+| **Failed** | Terminal failure: the assessment could not be completed. Examples include the target resource no longer existing, unrecoverable errors during reconciliation, or dependencies such as Prometheus remaining unavailable after the configured retry budget. |
+
+On relevant phase transitions, the Effectiveness Monitor emits an `assessment.scheduled` event so operators and automation can observe when the next assessment step is expected.
+
+### EM controller assessment tuning
+
+The EM controller exposes two assessment reconciliation knobs:
+
+| Parameter | Purpose |
+|---|---|
+| `requeueInterval` | How long to wait before requeuing when the assessment must be deferred (e.g., waiting for propagation, stabilization, or backoff). |
+| `maxRetries` | Maximum retries for transient failures (e.g., Prometheus or API errors) before marking the assessment as failed. |
+
+### Assessment paths
+
+Each completed assessment is classified into one of four paths, reflecting how fully the EM could run the configured scorers within the validity window:
+
+| Path | Meaning |
+|---|---|
+| `no_execution` | No meaningful assessment run (e.g., prerequisites not met). |
+| `partial` | Some components assessed; others skipped or incomplete before the deadline. |
+| `full` | All applicable components assessed successfully within the window. |
+| `timed-out` | The validity window expired before all components could be assessed. |
 
 ## Timing Model
 
@@ -141,6 +163,8 @@ Compares pre-remediation and post-remediation metrics from Prometheus:
 
 Respects `PrometheusCheckAfter` deadline and uses `PrometheusLookback` (default: 10m) for the query range.
 
+**Reliability (v1.2+)**: The interaction between `ValidityWindow` and alert duration was corrected so metrics windows align with the assessment timeline. Metrics scoring is now reliable when both are configured.
+
 ### Spec Hash Comparison (DD-EM-002)
 
 Compares the resource specification before and after remediation to detect drift:
@@ -148,6 +172,8 @@ Compares the resource specification before and after remediation to detect drift
 1. **Pre-remediation hash**: From `EA.Spec.PreRemediationSpecHash` (captured by RO before execution) or queried from DataStorage
 2. **Post-remediation hash**: Computed live via `CanonicalSpecHash(target.Spec)`
 3. **Comparison**: `postHash == preHash` → `Match=true` (spec unchanged). `postHash != preHash` can mean the remediation intentionally changed the spec (normal) or an external actor modified it during the assessment window (spec drift). The assessment distinguishes these by tracking whether the spec changed *after* the stabilization window began.
+
+**ConfigMap content (v1.2+)**: The RO and EM spec hash includes content from mounted ConfigMaps — specifically `.data` and `.binaryData` — while excluding Secret material. If a referenced ConfigMap changes between pre-capture and post-capture, the hash will differ, which is expected for effectiveness comparisons that include configuration mounted from ConfigMaps.
 
 #### Canonical Hash Algorithm
 

--- a/docs/architecture/notification.md
+++ b/docs/architecture/notification.md
@@ -16,7 +16,7 @@ For the complete field specification, see [NotificationRequest in the CRD Refere
 
 ### Notification Types
 
-API values use **PascalCase** enum strings (e.g. `Completion`, `StatusUpdate`). Routing `match` keys compare against these values.
+API values use **PascalCase** enum strings for `type`/`priority` (e.g. `Completion`, `StatusUpdate`, `Critical`). Routing `match` keys compare against these values for those fields. `severity` remains source/signal-derived (typically lowercase from Signal Processing normalization).
 
 | Type | Description |
 |---|---|
@@ -261,7 +261,7 @@ The enrichment layer uses a `WorkflowNameResolver` interface, allowing alternati
 
 ### Effectiveness assessment in completion messages
 
-For **completion** notifications, `buildCompletionBody` loads the effectiveness assessment using `RemediationRequest.Status.EffectivenessAssessmentRef`. The body includes the assessment reason, per-component scores (health, alerts, metrics, hash), and hash comparison details so operators can see outcome and evidence in one place.
+For **completion** notifications, the Remediation Orchestrator loads the effectiveness assessment via `RemediationRequest.Status.EffectivenessAssessmentRef` before building the message body. The notification includes assessment reason, per-component scores (health, alerts, metrics, hash), and hash comparison details so operators can see outcome and evidence in one place.
 
 ### Hash-capture degradation
 
@@ -277,7 +277,7 @@ Notifications include the **RemediationRequest** resource name. Body fields are 
 
 ### Workflow not needed (NoAction)
 
-When `handleWorkflowNotNeeded` runs (remediation not required), the pipeline emits a **`StatusUpdate`** notification so operators still get a lifecycle update.
+When `handleWorkflowNotNeeded` runs (remediation not required), the pipeline emits a **`StatusUpdate`** notification when self-resolved notifications are enabled, so operators still get a lifecycle update.
 
 ## Audit Events
 

--- a/docs/architecture/notification.md
+++ b/docs/architecture/notification.md
@@ -16,14 +16,18 @@ For the complete field specification, see [NotificationRequest in the CRD Refere
 
 ### Notification Types
 
+API values use **PascalCase** enum strings (e.g. `Completion`, `StatusUpdate`). Routing `match` keys compare against these values.
+
 | Type | Description |
 |---|---|
-| `escalation` | Escalation to human review |
-| `simple` | Basic status notification |
-| `status-update` | Phase change update |
-| `approval` | Approval request |
-| `manual-review` | Manual review required |
-| `completion` | Remediation outcome (success or failure) |
+| `Escalation` | Escalation to human review |
+| `Simple` | Basic status notification |
+| `StatusUpdate` | Phase change update |
+| `Approval` | Approval request |
+| `ManualReview` | Manual review required |
+| `Completion` | Remediation outcome (success or failure) |
+
+**Notification priority** (when used on the request) uses PascalCase: `Critical`, `High`, `Medium`, `Low`.
 
 ### Status
 
@@ -252,6 +256,28 @@ If the workflow UUID is absent from the workflow context, the DataStorage lookup
 ### Extensibility
 
 The enrichment layer uses a `WorkflowNameResolver` interface, allowing alternative resolution backends (e.g., in-memory cache, external catalog) without changing the delivery pipeline.
+
+## Completion and status notification content
+
+### Effectiveness assessment in completion messages
+
+For **completion** notifications, `buildCompletionBody` loads the effectiveness assessment using `RemediationRequest.Status.EffectivenessAssessmentRef`. The body includes the assessment reason, per-component scores (health, alerts, metrics, hash), and hash comparison details so operators can see outcome and evidence in one place.
+
+### Hash-capture degradation
+
+When pre- or post-remediation hash capture fails in a non-fatal (soft-fail) path, completion notifications indicate **EA degraded**, with the reason and guidance — for example, verifying RBAC for the view `ClusterRole` if the EM cannot read mounted ConfigMaps or related resources.
+
+### Cluster identification
+
+Every notification body begins with cluster context: **`Cluster: <name> (<uuid>)`**, across console, log, file, and Slack channels. **Timeout** notifications also include the cluster identifier so multi-cluster operators can route quickly.
+
+### RemediationRequest name and body layout
+
+Notifications include the **RemediationRequest** resource name. Body fields are **reordered** for faster triage (high-signal context first).
+
+### Workflow not needed (NoAction)
+
+When `handleWorkflowNotNeeded` runs (remediation not required), the pipeline emits a **`StatusUpdate`** notification so operators still get a lifecycle update.
 
 ## Audit Events
 

--- a/docs/user-guide/configmap-notification.md
+++ b/docs/user-guide/configmap-notification.md
@@ -93,9 +93,9 @@ receivers:
 
 | Key | Source | Example Values |
 |---|---|---|
-| `type` | Notification type | `escalation`, `simple`, `status-update`, `approval`, `manual-review`, `completion` |
-| `severity` | Signal severity | `critical`, `high`, `medium`, `low` |
-| `priority` | Signal priority | `P0`, `P1`, `P2`, `P3` (also accepts `critical`, `high`, `medium`, `low`) |
+| `type` | Notification type | `Escalation`, `Simple`, `StatusUpdate`, `Approval`, `ManualReview`, `Completion` |
+| `severity` | Signal severity | `Critical`, `High`, `Medium`, `Low` |
+| `priority` | Signal priority | `P0`, `P1`, `P2`, `P3` (also accepts `Critical`, `High`, `Medium`, `Low`) |
 | `phase` | Remediation phase | `signal-processing`, `ai-analysis`, `executing` |
 | `environment` | Namespace environment | `production`, `staging`, `development` |
 

--- a/docs/user-guide/configmap-notification.md
+++ b/docs/user-guide/configmap-notification.md
@@ -94,8 +94,8 @@ receivers:
 | Key | Source | Example Values |
 |---|---|---|
 | `type` | Notification type | `Escalation`, `Simple`, `StatusUpdate`, `Approval`, `ManualReview`, `Completion` |
-| `severity` | Signal severity | `Critical`, `High`, `Medium`, `Low` |
-| `priority` | Signal priority | `P0`, `P1`, `P2`, `P3` (also accepts `Critical`, `High`, `Medium`, `Low`) |
+| `severity` | Signal severity | `critical`, `high`, `medium`, `low` |
+| `priority` | Notification priority | `Critical`, `High`, `Medium`, `Low` |
 | `phase` | Remediation phase | `signal-processing`, `ai-analysis`, `executing` |
 | `environment` | Namespace environment | `production`, `staging`, `development` |
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -174,9 +174,8 @@ All controllers (`aianalysis`, `signalprocessing`, `remediationorchestrator`, `w
 | Parameter | Description | Default |
 |---|---|---|
 | `effectivenessmonitor.config.assessment.stabilizationWindow` | Wait time after remediation before assessment | `30s` |
-| `effectivenessmonitor.config.assessment.validityWindow` | Time window for assessment validity | `120s` |
-| `effectivenessmonitor.config.assessment.requeueInterval` | Interval for requeuing when assessment work is deferred (propagation, stabilization, backoff) | See `values.yaml` |
-| `effectivenessmonitor.config.assessment.maxRetries` | Maximum retries for transient failures (e.g. Prometheus/API) before terminal failure | See `values.yaml` |
+| `effectivenessmonitor.config.assessment.validityWindow` | Time window for assessment validity | `300s` |
+| `effectivenessmonitor.config.assessment.maxConcurrentReconciles` | Maximum concurrent EA reconciliations | `5` |
 | `effectivenessmonitor.external.prometheusUrl` | Prometheus URL | `http://kube-prometheus-stack-prometheus.monitoring.svc:9090` |
 | `effectivenessmonitor.external.prometheusEnabled` | Enable Prometheus integration | `false` |
 | `effectivenessmonitor.external.alertManagerUrl` | AlertManager URL | `http://kube-prometheus-stack-alertmanager.monitoring.svc:9093` |

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -175,6 +175,8 @@ All controllers (`aianalysis`, `signalprocessing`, `remediationorchestrator`, `w
 |---|---|---|
 | `effectivenessmonitor.config.assessment.stabilizationWindow` | Wait time after remediation before assessment | `30s` |
 | `effectivenessmonitor.config.assessment.validityWindow` | Time window for assessment validity | `120s` |
+| `effectivenessmonitor.config.assessment.requeueInterval` | Interval for requeuing when assessment work is deferred (propagation, stabilization, backoff) | See `values.yaml` |
+| `effectivenessmonitor.config.assessment.maxRetries` | Maximum retries for transient failures (e.g. Prometheus/API) before terminal failure | See `values.yaml` |
 | `effectivenessmonitor.external.prometheusUrl` | Prometheus URL | `http://kube-prometheus-stack-prometheus.monitoring.svc:9090` |
 | `effectivenessmonitor.external.prometheusEnabled` | Enable Prometheus integration | `false` |
 | `effectivenessmonitor.external.alertManagerUrl` | AlertManager URL | `http://kube-prometheus-stack-alertmanager.monitoring.svc:9093` |

--- a/docs/user-guide/effectiveness.md
+++ b/docs/user-guide/effectiveness.md
@@ -5,6 +5,14 @@
 
 After a remediation workflow completes, Kubernaut evaluates whether the fix actually resolved the issue. This is handled by the **Effectiveness Monitor** — a CRD controller that watches `EffectivenessAssessment` resources.
 
+## Phase state and tuning
+
+Assessments normally progress through pending, propagation, stabilization, and active scoring to **Completed**. If the EM cannot finish — for example the target resource was deleted, or Prometheus stays unavailable after retries — the CRD moves to a terminal **`Failed`** phase. See [Architecture: Phase State Machine](../architecture/effectiveness.md#phase-state-machine).
+
+Helm values under `effectivenessmonitor.config.assessment` include **`requeueInterval`** (how long to wait before requeuing deferred work) and **`maxRetries`** (retry budget for transient dependency failures before failing the assessment). See [Configuration Reference](configuration.md#effectivenessmonitor).
+
+The remediation orchestrator and effectiveness monitor include **mounted ConfigMap `.data` / `.binaryData`** in the canonical spec hash (Secrets are excluded). If a referenced ConfigMap changes between pre- and post-capture, hashes will differ — treat that as a real configuration change for effectiveness comparison.
+
 ## How It Works
 
 When a remediation reaches a terminal phase, the Orchestrator creates an `EffectivenessAssessment` CRD. The Effectiveness Monitor then:

--- a/docs/user-guide/effectiveness.md
+++ b/docs/user-guide/effectiveness.md
@@ -9,7 +9,7 @@ After a remediation workflow completes, Kubernaut evaluates whether the fix actu
 
 Assessments normally progress through pending, propagation, stabilization, and active scoring to **Completed**. If the EM cannot finish — for example the target resource was deleted, or Prometheus stays unavailable after retries — the CRD moves to a terminal **`Failed`** phase. See [Architecture: Phase State Machine](../architecture/effectiveness.md#phase-state-machine).
 
-Helm values under `effectivenessmonitor.config.assessment` include **`requeueInterval`** (how long to wait before requeuing deferred work) and **`maxRetries`** (retry budget for transient dependency failures before failing the assessment). See [Configuration Reference](configuration.md#effectivenessmonitor).
+Helm values under `effectivenessmonitor.config.assessment` include `stabilizationWindow`, `validityWindow`, and `maxConcurrentReconciles`. Requeue cadence during in-progress assessment follows controller timing derived from scrape windows. See [Configuration Reference](configuration.md#effectivenessmonitor).
 
 The remediation orchestrator and effectiveness monitor include **mounted ConfigMap `.data` / `.binaryData`** in the canonical spec hash (Secrets are excluded). If a referenced ConfigMap changes between pre- and post-capture, hashes will differ — treat that as a real configuration change for effectiveness comparison.
 

--- a/docs/user-guide/notifications.md
+++ b/docs/user-guide/notifications.md
@@ -5,6 +5,8 @@
 
 Kubernaut sends notifications at key points in the remediation lifecycle: when human approval is required, when a remediation fails, when manual review is needed, and when a remediation completes. Notifications are routed through configurable channels using an AlertManager-style routing configuration.
 
+**Cluster context:** Message bodies include the cluster display name and UUID near the top (`Cluster: <name> (<uuid>)`) on every channel, including timeout notifications.
+
 ## Channel Overview
 
 | Channel | Status | Description |
@@ -47,9 +49,9 @@ Routes match on notification attributes:
 
 | Match Key | Source | Example Values |
 |---|---|---|
-| `type` | Notification type | `escalation`, `simple`, `status-update`, `approval`, `manual-review`, `completion` |
-| `severity` | Signal severity | `critical`, `high`, `medium`, `low` |
-| `priority` | Signal priority | `P0`, `P1`, `P2`, `P3` (also accepts `critical`, `high`, `medium`, `low`) |
+| `type` | Notification type | `Escalation`, `Simple`, `StatusUpdate`, `Approval`, `ManualReview`, `Completion` |
+| `severity` | Signal severity | `Critical`, `High`, `Medium`, `Low` |
+| `priority` | Signal priority | `P0`, `P1`, `P2`, `P3` (also accepts `Critical`, `High`, `Medium`, `Low`) |
 | `phase` | Remediation phase | `signal-processing`, `ai-analysis`, `executing` |
 | `environment` | Namespace environment | `production`, `staging`, `development` |
 | `review-source` | Why review was triggered | `WorkflowResolutionFailed`, `ExhaustedRetries` |
@@ -128,8 +130,8 @@ delivery:
   "timestamp": "2026-03-04T12:34:56Z",
   "notification_name": "approval-required-rr-12345",
   "notification_namespace": "kubernaut-system",
-  "type": "approval",
-  "priority": "critical",
+  "type": "Approval",
+  "priority": "Critical",
   "subject": "Human approval required for OOMKilled remediation",
   "body": "...",
   "metadata": {"environment": "production"},
@@ -147,7 +149,7 @@ Slack delivery sends Block Kit messages via Incoming Webhooks.
 
 1. **Header block** -- Priority emoji + subject (e.g., `:rotating_light: Human approval required for OOMKilled remediation`)
 2. **Section block** -- Notification body (Markdown converted to Slack mrkdwn)
-3. **Context block** -- `*Priority:* critical | *Type:* approval`
+3. **Context block** -- `*Priority:* Critical | *Type:* Approval`
 
 Priority emojis: Critical = :rotating_light:, High = :warning:, Medium = :information_source:, Low = :speech_balloon:
 

--- a/docs/user-guide/notifications.md
+++ b/docs/user-guide/notifications.md
@@ -50,8 +50,8 @@ Routes match on notification attributes:
 | Match Key | Source | Example Values |
 |---|---|---|
 | `type` | Notification type | `Escalation`, `Simple`, `StatusUpdate`, `Approval`, `ManualReview`, `Completion` |
-| `severity` | Signal severity | `Critical`, `High`, `Medium`, `Low` |
-| `priority` | Signal priority | `P0`, `P1`, `P2`, `P3` (also accepts `Critical`, `High`, `Medium`, `Low`) |
+| `severity` | Signal severity | `critical`, `high`, `medium`, `low` |
+| `priority` | Notification priority | `Critical`, `High`, `Medium`, `Low` |
 | `phase` | Remediation phase | `signal-processing`, `ai-analysis`, `executing` |
 | `environment` | Namespace environment | `production`, `staging`, `development` |
 | `review-source` | Why review was triggered | `WorkflowResolutionFailed`, `ExhaustedRetries` |


### PR DESCRIPTION
## Summary

- Document EM `Failed` phase, scheduled assessment event, new config knobs (`requeueInterval`, `maxRetries`), and four assessment paths (no_execution, partial, full, timed-out) (#573)
- Document ConfigMap content in RO/EM spec hash computation, excluding Secrets (#396)
- Document EA results embedded in completion notifications (#318)
- Document hash-capture degradation notifications with operator guidance (#546)
- Add cluster name/UUID to all notification channels (#615, #621)
- Update all notification type/priority enum values to PascalCase (#453, #459, #640)
- Document status-update notification for `handleWorkflowNotNeeded` / NoAction (#590)
- Add RR name in notifications (#626) and field reordering for faster triage (#627)
- Fix EM metrics reliability note for validityWindow vs alert duration (#625, #639)
- Add EM config knobs to `configuration.md`

## Issues

Closes #64, #65. Partially addresses #66, #68.

## Test plan

- [ ] Kubernaut team: validate EM assessment paths and config knob names against v1.2.0 source
- [ ] Kubernaut team: confirm PascalCase enum values match CRD definitions
- [ ] Demo-scenarios team: check PascalCase enum migration impact on demo notification routing configs

Made with [Cursor](https://cursor.com)