### PR TITLE
docs: align workflow catalog wording with declarative CRDs

### DIFF
--- a/docs/api-reference/datastorage-api.md
+++ b/docs/api-reference/datastorage-api.md
@@ -55,7 +55,7 @@ http://data-storage-service.kubernaut-system.svc.cluster.local:8080
 
 | Method | Path | Description |
 |---|---|---|
-| `POST` | `/api/v1/workflows` | Register a workflow (called by Auth Webhook on `RemediationWorkflow` CRD admission; also supports direct registration from OCI schema image via `{"schemaImage": "<oci-ref>"}`) |
+| `POST` | `/api/v1/workflows` | Register a workflow (called by Auth Webhook on `RemediationWorkflow` CRD admission) |
 | `GET` | `/api/v1/workflows` | List workflows (filter by `status`, `environment`, `priority`, `component`, `workflow_name`) |
 | `GET` | `/api/v1/workflows/{workflow_id}` | Get a specific workflow |
 | `PATCH` | `/api/v1/workflows/{workflow_id}` | Update a workflow |

--- a/docs/architecture/workflow-selection.md
+++ b/docs/architecture/workflow-selection.md
@@ -237,7 +237,7 @@ After selection, the confidence score determines the next step:
 | `GET /api/v1/workflows/actions/{action_type}` | GET | Step 2: Scored candidates for action type |
 | `GET /api/v1/workflows/{workflow_id}` | GET | Step 3: Full schema with security gate |
 | `GET /api/v1/workflows` | GET | Catalog listing (no scoring) |
-| `POST /api/v1/workflows` | POST | Create from OCI schema |
+| `POST /api/v1/workflows` | POST | Register workflow catalog entry (Auth Webhook/CRD admission path) |
 | `PATCH /api/v1/workflows/{id}/disable` | PATCH | Disable workflow |
 | `PATCH /api/v1/workflows/{id}/enable` | PATCH | Enable workflow |
 | `PATCH /api/v1/workflows/{id}/deprecate` | PATCH | Deprecate workflow |

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,7 +89,7 @@ Kubernaut automates the entire incident response lifecycle through a six-stage p
 |---|---|
 | **Multi-Source Signal Ingestion** | Prometheus alerts (reactive and proactive), Kubernetes events, fingerprint-based deduplication at the Gateway, signal mode classification |
 | **AI-Powered Root Cause Analysis** | HolmesGPT with LLM providers (Vertex AI, OpenAI, LiteLLM), Kubernetes inspection tools, and configurable observability toolsets (Prometheus, Grafana Loki/Tempo, and more) |
-| **Workflow Catalog** | Searchable OCI-containerized workflows with label-based matching and confidence scoring |
+| **Workflow Catalog** | Searchable declarative `RemediationWorkflow` CRDs with category and label-based matching plus confidence scoring |
 | **Flexible Execution** | Kubernetes Jobs, Tekton Pipelines, or Ansible (AWX/AAP) |
 | **Resource Scope Management** | Label-based opt-in (`kubernaut.ai/managed=true`) controls which resources Kubernaut manages |
 | **Safety-First Design** | Admission webhooks, human approval gates, configurable confidence thresholds, effectiveness tracking |

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -138,13 +138,13 @@ kubectl label namespace my-app kubernaut.ai/managed=true
 
 ## Workflow Catalog
 
-Remediation workflows are packaged as **OCI images** containing a `workflow-schema.yaml` and stored in the **DataStorage** service as a searchable catalog. Each workflow has:
+Remediation workflows are defined as declarative **`RemediationWorkflow` CRDs** and registered in **DataStorage** as a searchable catalog via the Auth Webhook admission path. Each workflow has:
 
 - **Identity** — Name (`metadata.name`), version, and structured description (what, whenToUse, whenNotToUse, preconditions) under `spec`
 - **Action type** — Taxonomy type (e.g., `RestartPod`, `RollbackDeployment`, `IncreaseMemoryLimits`)
 - **Labels** — Signal name, severity, environment, component, priority (with wildcard and multi-value support)
 - **Parameters** — Typed inputs injected at runtime as environment variables (`UPPER_SNAKE_CASE`)
-- **Execution config** — Engine (`job` or `tekton`) and OCI bundle reference with digest
+- **Execution config** — Engine (`job`, `tekton`, or `ansible`) plus engine-specific execution settings. Tekton workflows may reference OCI bundles for pipeline execution artifacts
 
 During investigation, the LLM selects a workflow through a three-step discovery protocol:
 


### PR DESCRIPTION
## Summary
- Replace stale wording that implied workflows are stored as OCI schema images with declarative `RemediationWorkflow` CRD language.
- Update workflow catalog wording consistently across home page, concepts, workflow selection API table, and DataStorage API endpoint docs.
- Keep OCI references only where still accurate (e.g., Tekton execution bundle artifacts).

## Test plan
- [x] Verified updated wording in `docs/index.md`.
- [x] Verified `docs/user-guide/concepts.md` now describes CRD-first workflow registration.
- [x] Verified `docs/architecture/workflow-selection.md` API table no longer says "Create from OCI schema".
- [x] Verified `docs/api-reference/datastorage-api.md` no longer advertises direct `schemaImage` registration.
- [x] Searched docs for stale phrasing (`OCI-containerized workflows`, `Create from OCI schema`, `schemaImage`) and confirmed no remaining user-facing matches.

Upstream follow-up for generated CRD text is tracked in `kubernaut` issue #651 (milestone v1.3).

Made with [Cursor](https://cursor.com)