### PR TITLE
ci: protect latest alias on docs deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version label to deploy (e.g., v1.1)"
+        description: "Version label to deploy (e.g., v1.2)"
         required: false
         default: ""
 
@@ -49,6 +49,11 @@ jobs:
         run: |
           VERSION="${{ github.event.inputs.version }}"
           if [ -z "$VERSION" ]; then
-            VERSION="v1.1"
+            VERSION="v1.2"
           fi
-          mike deploy --push --update-aliases "$VERSION" latest
+
+          if [ "$VERSION" = "v1.2" ]; then
+            mike deploy --push --update-aliases "$VERSION" latest
+          else
+            mike deploy --push "$VERSION"
+          fi


### PR DESCRIPTION
## Summary
- Change `main` docs deploy default version from `v1.1` to `v1.2`.
- Update workflow dispatch help text to reflect current target (`v1.2`).
- Guard alias updates so only `v1.2` deploys can update `latest`.

## Why
Recent `main` deploys re-pointed `latest` back to archived `v1.1` because the workflow always ran `mike deploy --update-aliases ... latest` with a default of `v1.1`.

This patch prevents future alias regressions while still allowing manual deploys of other versions without changing `latest`.

## Test plan
- [x] Review workflow logic for default branch deploy path (`VERSION` unset).
- [x] Verify `v1.2` path still executes `mike deploy --update-aliases ... latest`.
- [x] Verify non-`v1.2` manual versions run `mike deploy --push` without alias updates.

Made with [Cursor](https://cursor.com)