### PR TITLE
docs: add Kubernaut logo to v1.2 docs

### DIFF
--- a/docs/assets/images/logo.svg
+++ b/docs/assets/images/logo.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="10" width="180" height="180" rx="32" ry="32" fill="#f0f0f0" stroke="#ccc" stroke-width="4"/>
+  <line x1="48" y1="128" x2="152" y2="42" stroke="#1a1a2e" stroke-width="9" stroke-linecap="round"/>
+  <line x1="48" y1="72" x2="152" y2="158" stroke="#1a1a2e" stroke-width="9" stroke-linecap="round"/>
+  <line x1="82" y1="42" x2="82" y2="158" stroke="#EE0000" stroke-width="9" stroke-linecap="round"/>
+</svg>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,8 @@ theme:
   font:
     text: Inter
     code: JetBrains Mono
+  logo: assets/images/logo.svg
+  favicon: assets/images/logo.svg
   icon:
     repo: fontawesome/brands/github
   features:


### PR DESCRIPTION
## Summary
- Cherry-pick the Kubernaut logo SVG and mkdocs.yml theme config (logo + favicon) from main (PR #110) so the v1.2 published docs display the site icon.

## Why
PR #110 added the logo to `main` but `release/v1.2` was not updated, so the live `latest` docs (served from v1.2) are missing the logo.

## Test plan
- [x] Verified `docs/assets/images/logo.svg` matches `main`.
- [x] Verified `mkdocs.yml` has `logo:` and `favicon:` entries (without duplicates).
- [x] After merge, docs deploy will rebuild v1.2 with the logo visible.

Made with [Cursor](https://cursor.com)