### PR TITLE
docs: update logo to dark-mode infinity-K design

### DIFF
--- a/docs/assets/images/logo.svg
+++ b/docs/assets/images/logo.svg
@@ -1,6 +1,7 @@
 <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
-  <rect x="10" y="10" width="180" height="180" rx="32" ry="32" fill="#f0f0f0" stroke="#ccc" stroke-width="4"/>
-  <line x1="48" y1="128" x2="152" y2="42" stroke="#1a1a2e" stroke-width="9" stroke-linecap="round"/>
-  <line x1="48" y1="72" x2="152" y2="158" stroke="#1a1a2e" stroke-width="9" stroke-linecap="round"/>
-  <line x1="82" y1="42" x2="82" y2="158" stroke="#EE0000" stroke-width="9" stroke-linecap="round"/>
+  <rect x="10" y="10" width="180" height="180" rx="32" ry="32" fill="#1a1a2e" stroke="#333" stroke-width="3"/>
+  <path d="M100,92 C82,66 38,66 38,100 C38,134 82,134 100,108"
+        fill="none" stroke="#e0e0e0" stroke-width="8" stroke-linecap="round"/>
+  <path d="M100,92 C118,66 162,66 162,100 C162,134 118,134 100,108"
+        fill="none" stroke="#EE0000" stroke-width="8" stroke-linecap="round"/>
 </svg>


### PR DESCRIPTION
## Summary
- Replace the old crossing-K logo (light background) with the new dark-mode infinity-K mark.
- The dark background logo works well in the Material theme header bar across both light and dark color schemes.

## Test plan
- [x] Verified new SVG renders correctly as site logo and favicon.
- [x] After merge, docs deploy will rebuild v1.2 with the updated logo.

Made with [Cursor](https://cursor.com)