### PR TITLE
docs(v1.3): upgrade guide (1.2 to 1.3) + final cleanup

### DIFF
--- a/docs/operations/upgrading/1.2-to-1.3.md
+++ b/docs/operations/upgrading/1.2-to-1.3.md
@@ -1,0 +1,222 @@
+# Upgrading from v1.2 to v1.3
+
+This guide covers all changes when upgrading Kubernaut from chart version **1.2.0** to **1.3.0**.
+
+!!! warning "v1.0 and v1.2 deprecated"
+    v1.0.0 and v1.2.0 are effectively deprecated once v1.3.0 is released. No production usage is expected for those releases. There is no need to support backwards compatibility.
+
+## Breaking Changes Requiring Action
+
+### 1. holmesgpt-api renamed to kubernaut-agent
+
+The HolmesGPT API Python service has been replaced by a Go service called **Kubernaut Agent**. All Helm values, Kubernetes resources, and configuration references have been renamed:
+
+| Resource | v1.2 Name | v1.3 Name |
+|---|---|---|
+| Helm values key | `holmesgptApi.*` | `kubernautAgent.*` |
+| SDK ConfigMap | `holmesgpt-api-config` | `kubernaut-agent-sdk-config` |
+| App ConfigMap | — | `kubernaut-agent-config` |
+| ServiceAccount | `holmesgpt-api-sa` | `kubernaut-agent-sa` |
+| ClusterRole | `holmesgpt-api-investigator` | `kubernaut-agent-investigator` |
+| ClusterRoleBinding | `holmesgpt-api-investigator-binding` | `kubernaut-agent-investigator-binding` |
+| Deployment | `holmesgpt-api` | `kubernaut-agent` |
+| Service | `holmesgpt-api` | `kubernaut-agent` |
+
+**Action required:** Update your `values.yaml` or `--set` flags from `holmesgptApi.*` to `kubernautAgent.*`. If you use `existingSdkConfigMap`, update the value name reference.
+
+!!! note "Known cosmetic leftover"
+    The RoleBinding `aianalysis-controller-holmesgpt-access` retains the old name but correctly binds to the renamed `kubernaut-agent-client` ClusterRole. This is tracked as tech debt.
+
+### 2. LiteLLM removed — LangChainGo provider list
+
+LiteLLM is no longer used. The Kubernaut Agent uses **LangChainGo** for LLM integration. Supported providers:
+
+| Config `llm.provider` | Backend |
+|---|---|
+| `openai` | OpenAI or OpenAI-compatible API |
+| `ollama` | Ollama |
+| `azure` | Azure OpenAI |
+| `vertex` | Google Vertex AI (Gemini models) |
+| `vertex_ai` | Claude on Google Vertex AI (Anthropic Go SDK) |
+| `anthropic` | Anthropic API (direct) |
+| `bedrock` | Amazon Bedrock |
+| `huggingface` | Hugging Face |
+| `mistral` | Mistral |
+
+**Action required:** If your SDK config uses `provider: litellm`, change to `provider: openai` with `endpoint` set to your OpenAI-compatible server origin (**without** `/v1` — the agent appends it). For air-gapped environments, `ollama` is recommended.
+
+!!! warning "Vertex AI provider distinction"
+    `vertex` = Gemini models on Vertex AI. `vertex_ai` = Claude models on Vertex AI. These use separate code paths.
+
+### 3. Inter-service TLS by default
+
+All inter-service communication now uses HTTPS. The Helm helper `kubernaut.datastorage.url` is hardcoded to `https://`.
+
+**Action required:** None if using `tls.mode: hook` (default) — the chart generates self-signed certificates automatically via a pre-install/pre-upgrade hook Job. If you were previously passing HTTP URLs in custom configuration, update them to HTTPS.
+
+For cert-manager integration, set:
+
+```yaml
+tls:
+  mode: cert-manager
+  certManager:
+    issuerRef:
+      name: my-cluster-issuer
+```
+
+### 4. Three-port service model
+
+Services now expose three dedicated ports:
+
+| Port | Protocol | Purpose |
+|---|---|---|
+| 8080 | HTTPS (when TLS enabled) | Primary API |
+| 8081 | HTTP (always) | Health probes (`/healthz`, `/readyz`) |
+| 9090 | HTTP (always) | Prometheus metrics (`/metrics`) |
+
+**Action required:** Update any custom probes, monitoring, or network policies that referenced `:8080/healthz` to use `:8081/healthz` and `:8081/readyz`. The `/livez` endpoint does not exist.
+
+Full three-port Services apply to Gateway, DataStorage, Kubernaut Agent, and AIAnalysis controller. Other controllers expose only metrics (9090) as a Service; health (8081) is pod-level only. AuthWebhook uses port 443 → 9443.
+
+### 5. RemediationWorkflow label arrays (F8)
+
+`component`, `severity`, and `environment` fields in `RemediationWorkflow.spec.labels` are now **arrays** (`[]string`, `minItems: 1`). `priority` remains a single string.
+
+**Action required:** Update your RemediationWorkflow CRDs:
+
+```yaml
+# v1.2 (single string)
+labels:
+  severity: critical
+  component: Deployment
+
+# v1.3 (array)
+labels:
+  severity:
+    - critical
+  component:
+    - Deployment
+```
+
+### 6. PascalCase AssessmentReason values (F13)
+
+`EffectivenessAssessment` reason values are now PascalCase:
+
+| v1.2 (snake_case) | v1.3 (PascalCase) |
+|---|---|
+| `full` | `Full` |
+| `partial` | `Partial` |
+| `spec_drift` | `SpecDrift` |
+| `expired` | `Expired` |
+| `no_execution` | `NoExecution` |
+| `metrics_timed_out` | `MetricsTimedOut` |
+| `alert_decay_timeout` | `AlertDecayTimeout` |
+| `unrecoverable` | `Unrecoverable` |
+
+**Action required:** Update any custom tooling, dashboards, or scripts that filter on assessment reason values.
+
+### 7. Content integrity enforcement (F14)
+
+Re-registering a workflow with the same (name, version) but different content now returns HTTP 409 Conflict (`content-integrity-violation`). Same content returns idempotent 200.
+
+**Action required:** If you have automation that re-registers workflows, ensure it bumps the version when content changes.
+
+## Automatic Migrations (No Action Required)
+
+### CRD schemas
+
+Applied automatically by the `pre-upgrade` hook via `kubectl apply --server-side --force-conflicts`. New CRD fields (label arrays, PascalCase enums) are enforced by OpenAPI validation.
+
+### TLS certificates
+
+Generated automatically by the `tls-cert-gen` hook Job (when `tls.mode: hook`). The Job checks certificate expiration with `openssl x509 -checkend $((30*86400))` and regenerates if within 30 days.
+
+### Database migrations
+
+Run automatically via the post-upgrade hook using goose.
+
+## New Features (No Action Required)
+
+### Investigation pipeline rewrite (F6)
+
+The investigation now uses **two distinct LLM invocations** instead of a single session:
+
+1. **Invocation 1 (RCA)**: Root cause analysis with its own schema and tool set
+2. **Invocation 2 (Workflow Selection)**: New LLM session with structured context from Invocation 1 — no shared chat history
+
+This improves reliability and allows independent schema validation per phase.
+
+### LLM output resilience (F4)
+
+The Kubernaut Agent includes parser defenses for unreliable LLM outputs:
+
+- Double-serialization unwrap
+- Balanced JSON extraction (strips trailing garbage)
+- Single-element array unwrap
+- Type coercion (string confidence → float)
+- Truncation detection with one retry (2x tokens, capped at 16384)
+- Partial RCA guard
+
+### SDK config hot-reload (F5)
+
+SDK config changes are detected via fsnotify without pod restart. Fields requiring restart: `llm.provider`, `llm.structured_output`, `llm.oauth2.token_url`, `llm.oauth2.client_id`, `llm.oauth2.client_secret`. All other fields are hot-reloadable. Active investigations are pinned to the client/model snapshot at start.
+
+### Tool output caps (F11)
+
+Tool outputs exceeding 100,000 characters are hard-truncated with `[TRUNCATED]`. An optional summarizer can condense output before truncation.
+
+### Cluster-scoped resource enrichment (F12)
+
+The `get_cluster_resource_context` tool now properly handles cluster-scoped resources (Nodes, PersistentVolumes, ClusterRoles). Per-investigation enrichment cache avoids redundant API calls.
+
+### ManualReviewRequired terminal state (F9)
+
+`ManualReviewRequired` now appears in three paths: Completed (with 24h cooldown), Failed (workflow rejection), and Blocked (IneffectiveChain).
+
+### Inconclusive outcome (#722)
+
+When `AlertAssessed=true` and `AlertScore=0` (alert still firing after remediation), the RO sets the RR outcome to `Inconclusive`. When AlertManager is unavailable, the system fails open to `Remediated`.
+
+### specHash on root owner (#729)
+
+The `get_namespaced_resource_context` tool now computes `specHash` from the root owner after resolving the ownership chain, ensuring history correlation at the correct abstraction level.
+
+### PK collision recovery (#730)
+
+DataStorage gracefully handles deterministic UUID collisions during workflow re-registration using SAVEPOINT/ROLLBACK and re-activation of superseded rows.
+
+### workflowDisplayName (F10)
+
+RemediationRequest status now shows `ActionType:WorkflowName` (resolved from DataStorage) instead of raw UUIDs.
+
+### Prometheus metric rename
+
+The Kubernaut Agent Prometheus metrics are:
+
+| Metric | Description |
+|---|---|
+| `aiagent_api_llm_tokens_total` | Token consumption (label `type`: `prompt` or `completion`) |
+| `aiagent_api_llm_requests_total` | LLM API call count (label `status`: `success` or `error`) |
+| `aiagent_api_llm_request_duration_seconds` | LLM request latency |
+
+The legacy `holmesgpt_llm_token_usage_total` referenced in some CRD descriptions is stale and does not correspond to any live metric.
+
+## Upgrade Procedure
+
+```bash
+# 1. Back up CRDs and values
+kubectl get crd -o yaml > crds-backup.yaml
+helm get values kubernaut -n kubernaut-system > values-backup.yaml
+
+# 2. Update values for v1.3 renames
+# Edit values-backup.yaml: holmesgptApi.* → kubernautAgent.*
+
+# 3. Upgrade
+helm upgrade kubernaut oci://quay.io/kubernaut-ai/charts/kubernaut \
+  --version 1.3.0 -n kubernaut-system \
+  -f values-v1.3.yaml
+
+# 4. Verify
+kubectl get pods -n kubernaut-system
+kubectl get rr -n kubernaut-system
+```

--- a/docs/operations/upgrading/1.2-to-1.3.md
+++ b/docs/operations/upgrading/1.2-to-1.3.md
@@ -183,7 +183,7 @@ The `get_namespaced_resource_context` tool now computes `specHash` from the root
 
 ### PK collision recovery (#730)
 
-DataStorage gracefully handles deterministic UUID collisions during workflow re-registration using SAVEPOINT/ROLLBACK and re-activation of superseded rows.
+DataStorage's `SupersedeAndCreate` function gracefully handles deterministic UUID collisions during workflow re-registration using SAVEPOINT/ROLLBACK and re-activation of superseded rows.
 
 ### workflowDisplayName (F10)
 

--- a/docs/operations/upgrading/index.md
+++ b/docs/operations/upgrading/index.md
@@ -52,6 +52,7 @@ See the [installation guide](../../getting-started/installation.md#2-provision-s
 
 ## Version-Specific Notes
 
+- [**v1.2 to v1.3**](1.2-to-1.3.md) — holmesgpt-api → kubernaut-agent rename, LiteLLM removed (LangChainGo), inter-service TLS by default, three-port model, two-invocation investigation pipeline, label arrays, PascalCase AssessmentReason, content integrity enforcement.
 - [**v1.1 to v1.2**](1.1-to-1.2.md) — CRD schema hardening (typed enums, `metav1.Duration`), storm detection removal, PascalCase enum migration, per-workflow ServiceAccount, database migrations 002-004.
 
-v1.0 is end-of-life and no longer documented.
+v1.0 and v1.2 are end-of-life and no longer documented.


### PR DESCRIPTION
## Summary

Creates the v1.2-to-v1.3 upgrade guide and updates the upgrading index.

The upgrade guide covers:
- **7 breaking changes** requiring action: rename, LiteLLM removal, TLS, three-port model, label arrays, PascalCase enums, content integrity
- **3 automatic migrations**: CRD schemas, TLS certificates, database migrations
- **11 new features**: two-invocation pipeline, LLM resilience, SDK hot-reload, tool caps, cluster-scoped enrichment, ManualReviewRequired, Inconclusive, specHash root owner, SupersedeAndCreate, workflowDisplayName, Prometheus metric rename
- Step-by-step upgrade procedure

Part 5 of 5 for v1.3 documentation update. References issue #116.

## Test plan

- [ ] Verify upgrade guide renders correctly
- [ ] Verify all breaking changes have "Action required" callouts
- [ ] Verify upgrade procedure steps are complete and correct
- [ ] Verify upgrading index links work

Made with [Cursor](https://cursor.com)