### PR TITLE
docs(v1.3): notification coverage for block reasons and terminal failures (BR-ORCH-036)

### DIFF
--- a/docs/architecture/notification.md
+++ b/docs/architecture/notification.md
@@ -29,6 +29,28 @@ API values use **PascalCase** enum strings for `type`/`priority` (e.g. `Completi
 
 **Notification priority** (when used on the request) uses PascalCase: `Critical`, `High`, `Medium`, `Low`.
 
+### NR Naming Conventions
+
+All NotificationRequest names are **deterministic**, enabling Get-before-Create idempotency (at most one NR of each type per RR):
+
+| NR Type | Naming Pattern | Scope |
+|---|---|---|
+| ManualReview | `nr-manual-review-<rr-name>` | One per RR |
+| Escalation | `nr-escalation-<rr-name>` | One per RR |
+| Block reason | `nr-block-<lowercased-reason>-<rr-name>` | One per (RR, block reason) |
+| Approval | `nr-approval-<rr-name>` | One per RR |
+| Completion | `nr-completion-<rr-name>` | One per RR |
+| Bulk duplicate | `nr-bulk-<rr-name>` | One per RR |
+| Self-resolved | `nr-self-resolved-<rr-name>` | One per RR |
+
+ManualReview NRs use the **same name** regardless of origin. The `spec.reviewSource` field distinguishes the source:
+
+| `reviewSource` | Created by |
+|---|---|
+| `WorkflowExecution` | WFE PhaseFailed handler |
+| `AIAnalysis` | AI handler (NeedsHumanReview dispatch) |
+| `RoutingEngine` | IneffectiveChain block |
+
 ### Status
 
 For the complete field specification, see [NotificationRequest in the CRD Reference](../api-reference/crds.md#notificationrequest).

--- a/docs/architecture/remediation-routing.md
+++ b/docs/architecture/remediation-routing.md
@@ -147,6 +147,31 @@ The Blocked phase behaves differently based on the block type:
 
 The Gateway treats Blocked RRs as active, preventing new RRs for the same fingerprint.
 
+### Block-Reason Notifications (v1.3)
+
+When a RR enters the `Blocked` phase, the Orchestrator creates a NotificationRequest for **every** block reason. Prior to v1.3, most block reasons were silent (no NR, at most a K8s event).
+
+| Block Reason | NR Type | Priority | Previously |
+|---|---|---|---|
+| `ConsecutiveFailures` | Escalation | High | Silent (K8s Warning event only) |
+| `UnmanagedResource` | Escalation | High | Silent (no NR, no event) |
+| `DuplicateInProgress` | StatusUpdate | Low | Silent (no NR, no event) |
+| `ResourceBusy` | StatusUpdate | Low | Silent (no NR, no event) |
+| `RecentlyRemediated` | StatusUpdate | Low | Silent (K8s Normal event only) |
+| `ExponentialBackoff` | StatusUpdate | Low | Silent (K8s Normal event only) |
+| `IneffectiveChain` | ManualReview | High | Already documented |
+
+NR naming: `nr-block-<lowercased-reason>-<rr-name>` (one NR per block reason per RR).
+
+### Terminal Failure Escalation Notifications (v1.3)
+
+Two paths create Escalation NRs for terminal failures:
+
+- **`transitionToFailed`**: Any failure path reaching terminal `Failed` without a prior ManualReview or Escalation NR creates an Escalation NR (`nr-escalation-<rr-name>`). This covers config errors, SP failures, approval timeouts, WFE ref corruption, hash errors, and other previously-silent failure paths.
+- **`transitionToFailedTerminal`**: When a blocked RR's cooldown expires and transitions to terminal `Failed`, an Escalation NR is created with the block reason in the body.
+
+Both paths enforce a **double-NR guard**: if a ManualReview or Escalation NR already exists for the RR (e.g., from the WFE failure handler), no duplicate is created. The guard uses Get-before-Create on the deterministic NR name (`nr-escalation-<rr-name>`).
+
 ## Routing Checkpoints
 
 The routing engine evaluates blocking conditions at two points. Checks are evaluated in order; the first blocking condition wins.
@@ -295,8 +320,8 @@ Each child CRD status change triggers a reconcile of the parent RR. The reconcil
 
 When a RR reaches a terminal phase:
 
-1. **NotificationRequest** -- Created for `Completed`, `Failed`, and `TimedOut` outcomes
-2. **Duplicate notification** -- If `DuplicateCount > 0`, a bulk notification is created for tracked duplicates
+1. **NotificationRequest** -- Created for `Completed`, `Failed`, and `TimedOut` outcomes. For `Failed`, `transitionToFailed` creates an Escalation NR (`nr-escalation-<rr-name>`) unless a ManualReview or Escalation NR already exists (double-NR guard)
+2. **Duplicate notification** -- If `DuplicateCount > 0`, a bulk notification (`nr-bulk-<rr-name>`) is created for tracked duplicates
 3. **Consecutive failure update** -- `ConsecutiveFailureCount` and `NextAllowedExecution` are updated for backoff calculation
 
 ## Escalation Paths
@@ -304,11 +329,13 @@ When a RR reaches a terminal phase:
 | Trigger | Escalation | Mechanism |
 |---|---|---|
 | Rego policy requires approval (environment, sensitive kind, confidence) | Human approval | RemediationApprovalRequest CRD |
-| KA flags human review with selected workflow | Notification + Failed | NotificationRequest with rejected recommendation |
-| Failure at any stage | Team notification | NotificationRequest with error context |
-| No matching workflow | Team notification with RCA | NotificationRequest |
-| Consecutive ineffective remediations | Manual review | `IneffectiveChain` block + `RequiresManualReview` |
-| 3+ consecutive failures | Cooldown block | `ConsecutiveFailures` block (1h) |
+| KA flags human review with selected workflow | Notification + Failed | ManualReview NR (`nr-manual-review-<rr-name>`) |
+| WFE execution failure (v1.3) | ManualReview + Failed | ManualReview NR (`reviewSource=WorkflowExecution`, `priority=Critical`) before `transitionToFailed` |
+| Failure at any stage (v1.3) | Escalation NR | `nr-escalation-<rr-name>` (double-NR guard) |
+| No matching workflow | Team notification with RCA | ManualReview NR |
+| Consecutive ineffective remediations | Manual review | `IneffectiveChain` block + ManualReview NR |
+| 3+ consecutive failures (v1.3) | Escalation NR + block | `nr-block-consecutivefailures-<rr-name>` |
+| Blocked RR cooldown expiry (v1.3) | Escalation NR | `nr-escalation-<rr-name>` (block reason in body) |
 
 ## Handoff to Workflow Execution
 

--- a/docs/architecture/workflow-execution.md
+++ b/docs/architecture/workflow-execution.md
@@ -282,8 +282,10 @@ The WFE controller reports status back to the Orchestrator through the CRD statu
 
 ```
 WFE Completed → RO creates EffectivenessAssessment → Verifying phase
-WFE Failed    → RO creates EA (for tracking) + NotificationRequest → Failed phase
+WFE Failed    → WFE handler creates ManualReview NR → RO transitionToFailed → Failed phase
 ```
+
+In v1.3, when a WorkflowExecution enters `PhaseFailed`, the WFE handler creates a **ManualReview NR** (`nr-manual-review-<rr-name>`) with `reviewSource=WorkflowExecution` and `priority=Critical` **before** calling `transitionToFailed`. The subsequent `transitionToFailed` Escalation NR is suppressed by the double-NR guard (a ManualReview NR already exists for this RR).
 
 For Ansible executions, the handoff is identical -- the AWX job status is mapped to the same WFE phases (`Completed`/`Failed`), so the Orchestrator does not need to distinguish between execution engines.
 

--- a/docs/operations/upgrading/1.2-to-1.3.md
+++ b/docs/operations/upgrading/1.2-to-1.3.md
@@ -201,6 +201,30 @@ The Kubernaut Agent Prometheus metrics are:
 
 The legacy `holmesgpt_llm_token_usage_total` referenced in some CRD descriptions is stale and does not correspond to any live metric.
 
+### Notification coverage for block reasons and terminal failures (BR-ORCH-036)
+
+The Remediation Orchestrator now creates NotificationRequests for **all** block reasons and terminal failure paths that were previously silent. Operators will see new notifications after upgrading:
+
+**Block-reason notifications**: When a RR enters `Blocked`, a NotificationRequest is created for every block reason:
+
+| Block Reason | NR Type | Priority |
+|---|---|---|
+| `ConsecutiveFailures` | Escalation | High |
+| `UnmanagedResource` | Escalation | High |
+| `DuplicateInProgress` | StatusUpdate | Low |
+| `ResourceBusy` | StatusUpdate | Low |
+| `RecentlyRemediated` | StatusUpdate | Low |
+| `ExponentialBackoff` | StatusUpdate | Low |
+| `IneffectiveChain` | ManualReview | High |
+
+**Terminal failure escalation**: `transitionToFailed` and `transitionToFailedTerminal` now create Escalation NRs (`nr-escalation-<rr-name>`) for failure paths that previously had no notification. A double-NR guard prevents duplicates.
+
+**WFE PhaseFailed**: WorkflowExecution failures now create a ManualReview NR (`reviewSource=WorkflowExecution`, `priority=Critical`) before transitioning to Failed.
+
+**NeedsHumanReview dispatch fix**: AIAnalysis with `NeedsHumanReview=true` and no `SelectedWorkflow` now correctly creates a ManualReview NR via the AI handler.
+
+NR naming follows deterministic patterns (e.g., `nr-block-<reason>-<rr-name>`, `nr-escalation-<rr-name>`, `nr-manual-review-<rr-name>`). See [Notification Pipeline: NR Naming Conventions](../../architecture/notification.md#nr-naming-conventions) for the full catalog. Operators with existing notification routing rules should review [Routing New v1.3 Notification Types](../../user-guide/notifications.md#routing-new-v13-notification-types) for guidance on filtering and routing the new NR types.
+
 ## Upgrade Procedure
 
 ```bash

--- a/docs/user-guide/notifications.md
+++ b/docs/user-guide/notifications.md
@@ -244,6 +244,66 @@ spec:
     maxBackoffSeconds: 120
 ```
 
+## Routing New v1.3 Notification Types
+
+v1.3 introduces notifications for block reasons and terminal failures that were previously silent. Operators with existing routing rules should add routes for these new NR types.
+
+### Escalation NRs (block reasons and terminal failures)
+
+Match `type: Escalation` to capture:
+
+- **Block-reason escalations** (`nr-block-consecutivefailures-*`, `nr-block-unmanagedresource-*`) -- persistent blocks requiring operator investigation
+- **Terminal failure escalations** (`nr-escalation-*`) -- failure paths that previously had no notification
+
+These are **High** priority. Route to your primary ops investigation channel.
+
+```yaml
+routes:
+  - match:
+      type: Escalation
+    receiver: ops-escalation-channel
+```
+
+### StatusUpdate NRs (transient blocks)
+
+Match `type: StatusUpdate` with `priority: Low` to capture transient block notifications (`DuplicateInProgress`, `ResourceBusy`, `RecentlyRemediated`, `ExponentialBackoff`). These are informational -- route to a low-priority channel or suppress in high-traffic environments.
+
+```yaml
+routes:
+  - match:
+      type: StatusUpdate
+      priority: Low
+    receiver: low-priority-channel
+```
+
+### ManualReview NRs by source
+
+ManualReview NRs can be further distinguished by `review-source` to route different failure types to different teams:
+
+| `review-source` | Meaning | Suggested action |
+|---|---|---|
+| `WorkflowExecution` | Execution failure | Ops investigation |
+| `AIAnalysis` | AI couldn't recommend a workflow | Catalog update / workflow authoring |
+| `RoutingEngine` | Repeated ineffective remediations | Root cause investigation |
+
+```yaml
+routes:
+  - match:
+      type: ManualReview
+      review-source: WorkflowExecution
+    receiver: ops-failures-channel
+  - match:
+      type: ManualReview
+      review-source: AIAnalysis
+    receiver: workflow-authors-channel
+  - match:
+      type: ManualReview
+      review-source: RoutingEngine
+    receiver: ops-escalation-channel
+```
+
+See [Notification Pipeline: NR Naming Conventions](../architecture/notification.md#nr-naming-conventions) for the complete NR naming catalog.
+
 ## Enabling Slack: End-to-End Walkthrough
 
 1. **Create a Slack Incoming Webhook** in your workspace (Apps > Incoming Webhooks > Add to Channel)


### PR DESCRIPTION
## Summary

Documents the late-breaking BR-ORCH-036 notification gap remediation for v1.3.0:

- **Block-reason notifications (#810)**: 6 previously-silent block reasons now create NotificationRequests (ConsecutiveFailures, UnmanagedResource, DuplicateInProgress, ResourceBusy, RecentlyRemediated, ExponentialBackoff)
- **Terminal failure escalation (#808, #809)**: `transitionToFailed` and `transitionToFailedTerminal` create Escalation NRs with a double-NR guard to prevent duplicates
- **WFE PhaseFailed ManualReview (#807)**: WorkflowExecution failures create a ManualReview NR (`reviewSource=WorkflowExecution`, `priority=Critical`) before transitioning to Failed
- **NeedsHumanReview dispatch fix (#805)**: AIAnalysis with `NeedsHumanReview=true` and no `SelectedWorkflow` now correctly creates a ManualReview NR
- **Complete NR naming catalog**: 7 deterministic naming patterns documented in notification.md
- **Operator routing guidance**: Explicit routing examples for Escalation, StatusUpdate, and ManualReview NR types in the user guide

References issue #116 (BR-ORCH-036 comment). Kubernaut PRs: #813, #815, #816, #817.

## Files changed (5)

| File | Changes |
|------|---------|
| `docs/architecture/remediation-routing.md` | Block-reason NR table, terminal failure escalation, double-NR guard, updated escalation paths |
| `docs/architecture/workflow-execution.md` | WFE PhaseFailed ManualReview NR before transitionToFailed |
| `docs/architecture/notification.md` | NR naming conventions section with full catalog + reviewSource table |
| `docs/operations/upgrading/1.2-to-1.3.md` | New feature section for BR-ORCH-036 |
| `docs/user-guide/notifications.md` | "Routing New v1.3 Notification Types" section with YAML examples |

## Test plan

- Verify block-reason NR table covers all 7 block reasons with correct types and priorities
- Verify NR naming patterns are consistent across all doc files
- Verify routing YAML examples use correct match keys (kebab-case: `type`, `review-source`)
- Verify cross-references between upgrade guide, notification architecture, and user guide are valid


Made with [Cursor](https://cursor.com)