### PR TITLE
ci+docs: set v1.3 as default, standardize version display, archive old versions, fix toolset claims

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -63,6 +63,7 @@ jobs:
 
           if [ "$VERSION" = "v1.3" ]; then
             mike deploy --push --update-aliases "$VERSION" latest
+            mike set-default --push latest
           else
             mike deploy --push "$VERSION"
           fi

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -64,6 +64,8 @@ jobs:
           if [ "$VERSION" = "v1.3" ]; then
             mike deploy --push --update-aliases --title "$VERSION" "$VERSION" latest
             mike set-default --push latest
+            mike retitle --push v1.0 "v1.0 (archived)"
+            mike retitle --push v1.2 "v1.2 (archived)"
           else
             mike deploy --push --title "$VERSION" "$VERSION"
           fi

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -62,8 +62,8 @@ jobs:
           fi
 
           if [ "$VERSION" = "v1.3" ]; then
-            mike deploy --push --update-aliases "$VERSION" latest
+            mike deploy --push --update-aliases --title "$VERSION" "$VERSION" latest
             mike set-default --push latest
           else
-            mike deploy --push "$VERSION"
+            mike deploy --push --title "$VERSION" "$VERSION"
           fi

--- a/docs/architecture/ai-analysis.md
+++ b/docs/architecture/ai-analysis.md
@@ -78,10 +78,10 @@ If either timeout expires, the AIAnalysis transitions to `Failed`.
 
 ## Kubernaut Agent Investigation
 
-Kubernaut Agent is a Go service that orchestrates LLM-driven investigation with live Kubernetes access and configurable observability toolsets. During investigation, it:
+Kubernaut Agent is a Go service that orchestrates LLM-driven investigation with live Kubernetes access and optional Prometheus integration. During investigation, it:
 
 1. **Reads the enriched signal** — Alert details, target resource, namespace context
-2. **Investigates using K8s tools** — Inspects pod logs, events, resource state, and live metrics via `kubectl`; optionally queries Prometheus, Grafana Loki/Tempo, and other configured toolsets
+2. **Investigates using K8s tools** — Inspects pod logs, events, resource state via `kubectl`; optionally queries Prometheus for live metrics when enabled
 3. **Produces a root cause analysis** — Structured explanation of what went wrong
 4. **Resolves the target resource** — Calls `get_namespaced_resource_context` (or `get_cluster_resource_context` for cluster-scoped resources) to resolve the owner chain, compute a spec hash, fetch **remediation history** (past outcomes and effectiveness scores via internal DataStorage lookup), and detect **infrastructure labels** (GitOps, Helm, service mesh, HPA, PDB)
 5. **Discovers workflows via DataStorage** — The LLM uses a three-step protocol: `list_available_actions` → `list_workflows` → `get_workflow`. Signal context and detected labels are auto-injected as filters; DataStorage orders results by label-match scoring (scores not exposed to the LLM).

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,7 @@ Kubernaut automates the entire incident response lifecycle through a six-stage p
 
 1. **Signal Deduplication** — Receives alerts from Prometheus AlertManager and Kubernetes Events, validates resource scope, deduplicates and suppresses noise, and creates a `RemediationRequest`.
 2. **Signal Categorization** — Enriches the signal with Kubernetes context (owner chain, namespace labels, workload details), environment classification, priority assignment, business classification, severity normalization, and signal mode.
-3. **LLM Investigation** — The Kubernaut Agent investigates the incident live using Kubernetes inspection tools (logs, events, resource state, live metrics) and optionally Prometheus, Grafana Loki, and other configured toolsets. It produces a root cause analysis, resolves the target resource's owner chain and remediation history, detects infrastructure labels (GitOps, Helm, service mesh, HPA, PDB), and searches the workflow catalog for a matching remediation.
+3. **LLM Investigation** — The Kubernaut Agent investigates the incident live using Kubernetes inspection tools (logs, events, resource state) and optionally Prometheus for live metrics. It produces a root cause analysis, resolves the target resource's owner chain and remediation history, detects infrastructure labels (GitOps, Helm, service mesh, HPA, PDB), and searches the workflow catalog for a matching remediation.
 4. **Remediation Execution** — Runs the selected remediation via Kubernetes Jobs, Tekton Pipelines, or Ansible (AWX/AAP).
 5. **Effectiveness Assessment** — Evaluates whether the fix actually worked via spec hash comparison, health checks, alert resolution, and effectiveness scoring.
 6. **Multichannel Notification** — Notifies the team with the full remediation outcome, including the effectiveness assessment results.
@@ -88,7 +88,7 @@ Kubernaut automates the entire incident response lifecycle through a six-stage p
 | Capability | Description |
 |---|---|
 | **Multi-Source Signal Ingestion** | Prometheus alerts (reactive and proactive), Kubernetes events, fingerprint-based deduplication at the Gateway, signal mode classification |
-| **AI-Powered Root Cause Analysis** | Kubernaut Agent with LLM providers (Vertex AI, OpenAI, Anthropic, Bedrock, Ollama, and more via LangChainGo), Kubernetes inspection tools, and configurable observability toolsets (Prometheus, Grafana Loki/Tempo, and more) |
+| **AI-Powered Root Cause Analysis** | Kubernaut Agent with LLM providers (Vertex AI, OpenAI, Anthropic, Bedrock, Ollama, and more via LangChainGo), Kubernetes inspection tools, and Prometheus metrics (when enabled) |
 | **Workflow Catalog** | Searchable declarative `RemediationWorkflow` CRDs with category and label-based matching plus confidence scoring |
 | **Flexible Execution** | Kubernetes Jobs, Tekton Pipelines, or Ansible (AWX/AAP) |
 | **Resource Scope Management** | Label-based opt-in (`kubernaut.ai/managed=true`) controls which resources Kubernaut manages |


### PR DESCRIPTION
## Summary

- **Set v1.3 as default**: `mike set-default --push latest` makes the root URL redirect to v1.3
- **Standardize version display**: `--title` flag ensures version switcher shows `vX.Y` (not `vX.Y.Z`)
- **Archive old versions**: `mike retitle` marks v1.0 and v1.2 as `(archived)` after v1.3 deploys
- **Fix toolset claims**: Removed inaccurate Grafana Loki/Tempo references from `index.md` and `ai-analysis.md` — only Kubernetes and Prometheus (when enabled) are currently supported

## Version switcher after merge

| Version | Display |
|---------|---------|
| v1.3 | **v1.3** (default, latest) |
| v1.2 | v1.2 (archived) |
| v1.1 | v1.1 (archived) |
| v1.0 | v1.0 (archived) |

## Files changed

| File | Changes |
|------|---------|
| `.github/workflows/deploy-docs.yml` | `--title`, `mike set-default`, `mike retitle` for v1.0/v1.2 |
| `docs/index.md` | Remove Grafana Loki/Tempo from pipeline description and capabilities table |
| `docs/architecture/ai-analysis.md` | Remove Grafana Loki/Tempo from investigation toolset description |

## Test plan

- Verify deploy-docs workflow runs after merge to `release/v1.3`
- Verify root URL redirects to v1.3
- Verify version switcher shows `v1.3`, `v1.2 (archived)`, `v1.1 (archived)`, `v1.0 (archived)`