### PR TITLE
docs: small-batch fixes — #98, #38, #61, #96, #62, #65

### DIFF
--- a/docs/api-reference/crds.md
+++ b/docs/api-reference/crds.md
@@ -4,6 +4,8 @@ Kubernaut API reference for all Custom Resource Definitions.
 
 API Group: `kubernaut.ai/v1alpha1`
 
+!!! tip "Wide output columns"
+    All Kubernaut CRDs include additional printer columns visible with `kubectl get <resource> -o wide`. Key columns include: `PHASE`, `OUTCOME`, `AGE`, plus resource-specific fields like `SEVERITY`, `CONFIDENCE`, `WORKFLOW`, `ASSESSMENT-REASON`, and `DISPLAY-NAME`. Typed enums (e.g., `AssessmentReason`, notification `Type`/`Priority`) use **PascalCase** values. Duration fields use `metav1.Duration` format (e.g., `1h30m`, `5m`).
 
 ## AIAnalysis
 

--- a/docs/architecture/effectiveness.md
+++ b/docs/architecture/effectiveness.md
@@ -6,6 +6,9 @@
 !!! abstract "CRD Reference"
     For the complete EffectivenessAssessment CRD specification, see [API Reference: CRDs](../api-reference/crds.md#effectivenessassessment).
 
+!!! note "Design Decision"
+    This architecture follows **ADR-EM-001** (Effectiveness Monitor service integration), which defines the multi-component scoring model, timing derivation, and assessment paths described below.
+
 The Effectiveness Monitor evaluates whether a remediation actually resolved the issue. It operates as a CRD controller watching `EffectivenessAssessment` resources created by the Orchestrator after workflow execution completes (or fails).
 
 ## CRD Specification
@@ -42,15 +45,20 @@ On relevant phase transitions, the Effectiveness Monitor emits an `effectiveness
 
 ### EM controller assessment tuning
 
-The EM controller exposes assessment timing and concurrency knobs:
+The EM controller exposes assessment timing, concurrency, and external integration knobs:
 
-| Parameter | Purpose |
-|---|---|
-| `stabilizationWindow` | Wait time before starting assessment scorers after EA creation. |
-| `validityWindow` | Total window before the assessment expires. |
-| `maxConcurrentReconciles` | Maximum number of EA reconciliations processed in parallel by the controller. |
+| Parameter | Purpose | Default |
+|---|---|---|
+| `stabilizationWindow` | Wait time before starting assessment scorers after EA creation. | `30s` |
+| `validityWindow` | Total window before the assessment expires. | `300s` (5m) |
+| `maxConcurrentReconciles` | Maximum number of EA reconciliations processed in parallel by the controller. | `5` |
+| `prometheusLookback` | Duration before EA creation to query Prometheus for baseline metrics. Min: 1m. | `30m` |
+| `scrapeInterval` | Prometheus scrape interval used to derive requeue timing for metric assessment. Min: 5s. | `60s` |
+| `connectionTimeout` | HTTP client timeout for Prometheus/AlertManager connections. | `10s` |
 
 ### Assessment paths
+
+The Orchestrator creates an `EffectivenessAssessment` for **both successful and failed** workflow executions. This allows the EM to verify whether a failed workflow inadvertently resolved the issue (e.g., a restart that fixed a crash loop before the workflow itself failed) and feeds into the Orchestrator's `Inconclusive` outcome logic.
 
 Each completed assessment is classified with an **AssessmentReason** (PascalCase), reflecting how fully the EM could run the configured scorers within the validity window:
 

--- a/docs/architecture/kubernaut-agent-investigation.md
+++ b/docs/architecture/kubernaut-agent-investigation.md
@@ -41,7 +41,7 @@ The Helm chart supports three tiers for providing the SDK config -- see [Configu
 
 | Category | Settings |
 |---|---|
-| **Restart required** (process must restart to take effect) | `llm.provider`, `llm.structured_output`, `llm.oauth2.token_url`, `llm.oauth2.client_id`, `llm.oauth2.client_secret` |
+| **Restart required** (process must restart to take effect) | `llm.provider`, `llm.oauth2.token_url`, `llm.oauth2.client_id`, `llm.oauth2.client_secret` |
 | **Hot-reloadable** | `model`, `endpoint`, `api_key`, `temperature`, and other non-provider/core-auth LLM and toolset options |
 
 ## Pipeline Overview

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -135,7 +135,10 @@ The WE controller's ClusterRole includes the following permissions for TokenRequ
 | (core) | `serviceaccounts` | get | Look up the per-workflow SA |
 | (core) | `serviceaccounts/token` | create | Create short-lived tokens via TokenRequest |
 
-**TTL validation (Ansible path):** When an execution timeout is configured, the controller validates that the requested token TTL covers the execution window. If the TTL is insufficient, it sets `TokenTTLInsufficient` on the WorkflowExecution and emits a warning event (`TokenTTLShortened`).
+**TTL validation (Ansible path):** The controller requests tokens with a **3600s (1 hour)** TTL by default. When an execution timeout is configured, the controller validates that the requested token TTL covers the execution window. If the TTL is insufficient, it sets `TokenTTLInsufficient` on the WorkflowExecution and emits a warning event (`TokenTTLShortened`).
+
+!!! warning "Cluster-level TTL constraints"
+    The Kubernetes API server flag `--service-account-max-token-expiration` (or OpenShift `ServiceAccountTokenMaxExpiration`) can silently cap token TTLs below the requested duration. If the cap is lower than the workflow execution timeout, Ansible jobs may receive **401 Unauthorized** errors mid-execution. Ensure the cluster-level maximum is at least **3600s** (or greater than your longest workflow execution timeout). Check for `TokenTTLShortened` warning events on WorkflowExecution CRDs if Ansible jobs fail unexpectedly with authentication errors.
 
 **Fallback behavior:** If `serviceAccountName` is not set:
 

--- a/docs/architecture/workflow-execution.md
+++ b/docs/architecture/workflow-execution.md
@@ -233,9 +233,7 @@ When a WFE spec omits `engineConfig`, the controller resolves it from the workfl
 
 ## Execution Namespace and RBAC
 
-All Jobs and PipelineRuns execute in the dedicated `kubernaut-workflows` namespace. By default they use the execution namespace default ServiceAccount (commonly configured as `kubernaut-workflow-runner` in shared-SA deployments). See [Security & RBAC -- Workflow Execution](security-rbac.md#workflow-execution) for the full list of permissions granted to the shared execution role.
-
-Starting with v1.2, workflows can declare a dedicated ServiceAccount via `spec.execution.serviceAccountName` on the `RemediationWorkflow` CRD (propagated to `WorkflowExecution.spec.serviceAccountName`). This enables least-privilege RBAC per workflow.
+All Jobs and PipelineRuns execute in the dedicated `kubernaut-workflows` namespace. Each workflow declares its own ServiceAccount via `spec.execution.serviceAccountName` on the `RemediationWorkflow` CRD (propagated to `WorkflowExecution.spec.serviceAccountName`). This enables least-privilege RBAC per workflow. If omitted, the execution namespace default ServiceAccount is used.
 
 - Job/Tekton: the service account name is set directly on the created Job/PipelineRun.
 - Ansible: the controller requests a short-lived token via the Kubernetes TokenRequest API for AWX credential injection.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,6 +11,10 @@ This guide walks you through installing Kubernaut on a Kubernetes cluster using 
 | StorageClass | dynamic provisioning | For PostgreSQL and Valkey PVCs |
 | cert-manager | 1.12+ (production) | Required when `tls.mode=cert-manager`. Optional for dev (`tls.mode=hook` is default). |
 
+**LLM provider** (required for AI investigation):
+
+- Any [supported provider](../user-guide/configmap-kubernaut-agent.md#supported-providers) with JSON structured output support (`response_format: json_object` or equivalent). KA enables JSON mode on all LLM requests — models that do not support it will produce parse failures.
+
 **Workflow execution engine** (at least one):
 
 - Kubernetes Jobs (built-in, no extra dependency)

--- a/docs/user-guide/configmap-kubernaut-agent.md
+++ b/docs/user-guide/configmap-kubernaut-agent.md
@@ -65,7 +65,7 @@ llm:
   vertex_project: ""        # Vertex-specific (vertex and vertex_ai)
   vertex_location: ""       # Vertex-specific
   bedrock_region: ""        # Bedrock-specific
-  structured_output: false  # Requires pod restart to change
+  structured_output: false  # Reserved; KA always enables JSON mode internally (see note below)
   temperature: 0.7          # Creativity vs determinism (0.0--1.0)
   max_retries: 3            # LLM call retry count
   timeout_seconds: 120      # Per-call timeout
@@ -104,6 +104,9 @@ mcp_servers: {}             # Optional: Model Context Protocol servers
 
 !!! warning "Vertex AI provider distinction"
     `vertex` = Gemini models on Vertex AI. `vertex_ai` = Anthropic Claude models on Vertex AI. These use separate code paths and different SDKs.
+
+!!! warning "Mandatory JSON structured output"
+    KA internally sets `JSONMode: true` on every LLM request. This is **not configurable** — the `structured_output` field in the config is reserved and has no effect at runtime. Your LLM provider/model **must** support schema-constrained JSON responses (equivalent to `response_format: {"type": "json_object"}` in the OpenAI API). All listed providers support this natively. For self-hosted or air-gapped deployments using Ollama or OpenAI-compatible servers, ensure the model supports JSON mode (most instruction-tuned models do).
 
 ## Toolset Optimization
 
@@ -252,7 +255,6 @@ The SDK config supports hot-reload. Changes to the ConfigMap are detected via an
 **Restart-required fields** (changes are rejected with a warning log):
 
 - `llm.provider`
-- `llm.structured_output`
 - `llm.oauth2.token_url`, `llm.oauth2.client_id`, `llm.oauth2.client_secret`
 
 **Hot-reloadable fields**: `model`, `endpoint`, `api_key`, `azure_api_version`, `vertex_project`, `vertex_location`, `bedrock_region`, `temperature`, `max_retries`, `timeout_seconds`, `custom_headers`, `oauth2.scopes`

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -180,6 +180,9 @@ All controllers (`aianalysis`, `signalprocessing`, `remediationorchestrator`, `w
 | `effectivenessmonitor.external.prometheusEnabled` | Enable Prometheus integration | `false` |
 | `effectivenessmonitor.external.alertManagerUrl` | AlertManager URL | `http://kube-prometheus-stack-alertmanager.monitoring.svc:9093` |
 | `effectivenessmonitor.external.alertManagerEnabled` | Enable AlertManager integration | `false` |
+| `effectivenessmonitor.external.connectionTimeout` | HTTP client timeout for Prometheus/AlertManager connections | `10s` |
+| `effectivenessmonitor.external.prometheusLookback` | Duration before EA creation to query Prometheus for baseline metrics. Min: `1m`. | `30m` |
+| `effectivenessmonitor.external.scrapeInterval` | Prometheus scrape interval used to derive requeue timing for metric assessment. Min: `5s`. | `60s` |
 | `effectivenessmonitor.external.tlsCaFile` | Path to PEM CA bundle for HTTPS connections to Prometheus/AlertManager. On OCP with `ocpMonitoringRbac`, set to `/etc/ssl/em/service-ca.crt` (auto-mounted). | `""` |
 | `effectivenessmonitor.external.ocpMonitoringRbac` | Create `cluster-monitoring-view` ClusterRoleBinding and (when `alertManagerEnabled`) a ClusterRole granting `monitoring.coreos.com/alertmanagers/api` access for OCP's `kube-rbac-proxy`. Also sets `IS_OPENSHIFT` env and auto-configures TLS CA trust via a service-CA ConfigMap. | `false` |
 

--- a/docs/user-guide/signals.md
+++ b/docs/user-guide/signals.md
@@ -32,6 +32,22 @@ route:
 
 The Gateway validates each alert, extracts the target resource, checks scope labels, and creates a `RemediationRequest` CRD.
 
+#### Required AlertManager Labels
+
+The Gateway expects the following labels on incoming alerts:
+
+| Label | Required | Purpose |
+|---|---|---|
+| `namespace` | Yes | Target namespace for resource scope resolution. Without this, the Gateway cannot determine which resource to remediate. |
+| `alertname` | Yes | Used in fingerprint computation and signal deduplication. |
+| `severity` | Yes | Normalized during signal processing; used for routing and notification priority. |
+| `pod` | No | Preferred resource target identifier. |
+| `deployment` | No | Fallback resource target when `pod` is absent. |
+| `container` | No | Enrichment context for investigation. |
+
+!!! note "Thanos Ruler and OpenShift namespace labels"
+    When using Thanos Ruler or OpenShift user-workload monitoring, alerts may carry the namespace in a non-standard label (e.g., `exported_namespace` or `tenant_id`). The Gateway uses `namespace` as the canonical key. Configure AlertManager relabeling rules to map your environment's namespace label to `namespace` before forwarding to the Gateway.
+
 ### Kubernetes Events
 
 The Gateway accepts Kubernetes events via a webhook endpoint:
@@ -44,6 +60,18 @@ This captures events like `BackOff`, `OOMKilled`, `FailedScheduling`, and `Unhea
 
 !!! note "Event Exporter removed from chart in v1.1"
     The Event Exporter was previously bundled in the Helm chart. Since v1.1, Kubernetes event forwarding is a user-provided concern managed independently of the Kubernaut installation.
+
+#### Expected Event Fields
+
+When configuring your event exporter, ensure the webhook payload includes these fields from `involvedObject`:
+
+| Field | Required | Purpose |
+|---|---|---|
+| `involvedObject.namespace` | Yes | Target namespace for scope resolution. |
+| `involvedObject.name` | Yes | Resource name for remediation targeting. |
+| `involvedObject.kind` | Yes | Resource kind (e.g., `Pod`, `Deployment`). |
+| `reason` | Yes | Event reason (e.g., `BackOff`, `OOMKilled`), used as signal type. |
+| `message` | No | Human-readable context for investigation enrichment. |
 
 ## Signal Types
 


### PR DESCRIPTION
## Summary

Addresses six small/focused documentation issues for the v1.3 release:

- **#98 (JSON mode):** Documents that KA mandates `JSONMode: true` on all LLM requests — `structured_output` config is reserved with no runtime effect. Adds LLM provider prerequisite to installation page. Removes `structured_output` from restart-required fields.
- **#38 (TokenRequest TTL):** Documents the default 3600s TTL, `--service-account-max-token-expiration` cluster cap, and `TokenTTLShortened` troubleshooting guidance.
- **#61 (Per-workflow SA):** Updates `workflow-execution.md` to frame per-workflow ServiceAccount as the primary model (DD-WE-005 v2.0), removing stale "shared kubernaut-workflow-runner" framing.
- **#96 (Label contract):** Adds AlertManager required label contract table (`namespace`, `alertname`, `severity`) with Thanos/OCP relabeling note. Adds Kubernetes event exporter expected fields table.
- **#62 (CRD wide columns):** Adds CRD wide output columns, typed enums (PascalCase), and `metav1.Duration` format note to CRD reference.
- **#65 (EM ADR-EM-001 gaps):** Adds missing EM config knobs (`prometheusLookback`, `scrapeInterval`, `connectionTimeout`). Adds ADR-EM-001 reference. Documents WFE path differentiation (EA created for both successful and failed executions).

## Files changed

| File | Changes |
|---|---|
| `docs/user-guide/configmap-kubernaut-agent.md` | JSON mode callout, `structured_output` → reserved, removed from restart-required |
| `docs/getting-started/installation.md` | LLM provider prerequisite |
| `docs/architecture/security-rbac.md` | TokenRequest TTL default, cluster-cap warning |
| `docs/architecture/workflow-execution.md` | Per-workflow SA as primary model |
| `docs/user-guide/signals.md` | AM label contract, event exporter fields |
| `docs/api-reference/crds.md` | Wide columns / typed enums note |
| `docs/architecture/effectiveness.md` | ADR-EM-001 ref, missing config knobs, WFE path diff |
| `docs/user-guide/configuration.md` | 3 new EM external config params |
| `docs/architecture/kubernaut-agent-investigation.md` | Removed `structured_output` from restart table |

## Test plan

- [ ] Verify `mkdocs serve` builds without warnings
- [ ] Confirm new callouts render correctly (JSON mode, TTL warning)
- [ ] Check label contract and event fields tables display properly
- [ ] Verify cross-references to `configmap-kubernaut-agent.md#supported-providers` resolve

Closes #98, closes #38, closes #61, closes #96, closes #62, closes #65

Made with [Cursor](https://cursor.com)