### PR TITLE
docs: feature enrichments (#66) and notification metrics DD-METRICS-001 (#68)

### DIFF
--- a/docs/architecture/effectiveness.md
+++ b/docs/architecture/effectiveness.md
@@ -178,7 +178,29 @@ Compares the resource specification before and after remediation to detect drift
 2. **Post-remediation hash**: Computed live via `CanonicalSpecHash(target.Spec)`
 3. **Comparison**: `postHash == preHash` → `Match=true` (spec unchanged). `postHash != preHash` can mean the remediation intentionally changed the spec (normal) or an external actor modified it during the assessment window (spec drift). The assessment distinguishes these by tracking whether the spec changed *after* the stabilization window began.
 
-**ConfigMap content (v1.2+)**: The RO and EM spec hash includes content from mounted ConfigMaps — specifically `.data` and `.binaryData` — while excluding Secret material. If a referenced ConfigMap changes between pre-capture and post-capture, the hash will differ, which is expected for effectiveness comparisons that include configuration mounted from ConfigMaps.
+#### ConfigMap Composite Fingerprinting
+
+The spec hash includes content from ConfigMaps referenced by the target workload, producing a **composite fingerprint** that detects configuration drift even when the workload spec itself is unchanged.
+
+**Hash algorithm** (`ConfigMapDataHash`): SHA-256 over sorted `.data` entries (`d:key=value`) and `.binaryData` entries (`b:key=base64(...)`) → returns `sha256:<hex>`.
+
+**ConfigMap reference extraction** (`ExtractConfigMapRefs`): walks the pod-template spec to collect all referenced ConfigMap names from:
+
+- Volume mounts (`volumes[].configMap`)
+- Projected volume sources (`volumes[].projected.sources[].configMap`)
+- `envFrom[].configMapRef`
+- `env[].valueFrom.configMapKeyRef`
+
+**Composite hash** (`CompositeResourceFingerprint`): combines the target resource's canonical spec fingerprint with per-ConfigMap content hashes into a single `sha256:...` digest. If no ConfigMaps are referenced, the fingerprint is returned unchanged (backward compatible).
+
+| Component | Role |
+|---|---|
+| **RO** (Remediation Orchestrator) | Captures **pre-remediation** composite hash (`capturePreRemediationHash` → `resolveConfigMapHashes`) |
+| **EM** (Effectiveness Monitor) | Computes **post-remediation** composite hash and compares to pre; runs spec drift guard on subsequent reconciles (`assessHash` → `resolveConfigMapHashes`) |
+
+**Sentinel hashes**: When a ConfigMap cannot be read (forbidden, missing, transient error), a sentinel hash is used so the set of referenced names stays stable and intermittent API failures don't false-positive as drift.
+
+If a referenced ConfigMap changes between pre-capture and post-capture without any change to the workload spec, the composite hash will differ, triggering `SpecDrift` classification.
 
 #### Canonical Hash Algorithm
 

--- a/docs/architecture/kubernaut-agent-investigation.md
+++ b/docs/architecture/kubernaut-agent-investigation.md
@@ -212,10 +212,12 @@ Probes the cluster to detect infrastructure characteristics of the root owner:
 | `serviceMesh` | Istio/Linkerd sidecar annotations |
 | `resourceQuotaConstrained` | Namespace has an active `ResourceQuota` |
 
-When `resourceQuotaConstrained` is detected, the `LabelDetector` also surfaces `quota_details` as a top-level field in the resource context response, containing the namespace's `ResourceQuota` spec (limits, requests, and used values). This gives the LLM visibility into capacity constraints during workflow selection — for example, preferring a scale-down workflow over scale-up when the namespace is near its quota.
+When `resourceQuotaConstrained` is detected, the `LabelDetector` also surfaces **`quota_details`** as a structured `map[string]QuotaResourceUsage` in the resource context response, containing per-resource `hard` and `used` values from all `ResourceQuota` objects in the namespace (e.g., `cpu: {hard: "4", used: "2.5"}`). This gives the LLM visibility into capacity constraints during workflow selection — for example, preferring a scale-down workflow over scale-up when the namespace is near its quota.
+
+The detection pipeline is: `Investigator.Investigate` → `resolveEnrichmentCached` → `Enricher.Enrich` → `LabelDetector.DetectLabels` → `detectResourceQuota`. On detection failure (empty namespace, API error), `"resourceQuotaConstrained"` is appended to `failedDetections` and the enrichment continues with best-effort results.
 
 !!! note "LimitRange detection"
-    LimitRange detection is not implemented in v1.2. Only ResourceQuota constraints are surfaced.
+    LimitRange detection is **not implemented** in v1.3. Only ResourceQuota constraints are surfaced. LimitRange may be added in a future release.
 
 These labels are stored in `session_state` and automatically injected into all subsequent workflow discovery queries. They serve two purposes:
 

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -2,7 +2,7 @@
 
 All Kubernaut services expose Prometheus-compatible metrics and standard health check endpoints. This page provides a complete metrics reference for building Grafana dashboards and alerting rules.
 
-In **v1.3**, the Kubernaut Agent metrics were renamed from the legacy `holmesgpt_*` namespace to `aiagent_api_*`. **Effectiveness Monitor** and **Notification** metrics remain stable from v1.2.
+In **v1.3**, the Kubernaut Agent metrics were renamed from the legacy `holmesgpt_*` namespace to `aiagent_api_*`. **Effectiveness Monitor** metrics remain stable from v1.2. **Notification** metrics were refactored internally (DD-METRICS-001: 3-layer → 1-layer) but the metric names and semantics are unchanged.
 
 ## Health Checks
 
@@ -92,14 +92,17 @@ scrape_configs:
 
 ## Notification Metrics
 
+!!! note "DD-METRICS-001: Metrics wiring pattern"
+    In v1.3, the Notification controller's metrics were collapsed from a **3-layer stack** (interface → recorder → raw metrics) to a **single dependency-injected `*Metrics` struct**, matching the pattern mandated by DD-METRICS-001 for all CRD controllers. The metrics struct is injected into both the reconciler and the delivery orchestrator at startup via `NewMetrics()`. Test isolation uses `NewMetricsWithRegistry(prometheus.NewRegistry())` instead of interface mocking.
+
 | Metric | Type | Labels | Description |
 |---|---|---|---|
+| `kubernaut_notification_reconciler_active` | Gauge | `phase` | Active notification backlog by phase (Pending, Sending, Sent, Retrying, PartiallySent, Failed) |
 | `kubernaut_notification_delivery_attempts_total` | Counter | `channel`, `status` | Delivery attempts per channel |
 | `kubernaut_notification_delivery_duration_seconds` | Histogram | `channel` | Delivery duration per channel |
-| `kubernaut_notification_delivery_retries_total` | Counter | `channel`, `reason` | Delivery retries per channel |
+| `kubernaut_notification_delivery_retries_total` | Counter | `channel` | Delivery retries per channel |
 | `kubernaut_notification_channel_circuit_breaker_state` | Gauge | `channel` | Circuit breaker state (0=closed, 1=open, 2=half-open) |
-| `kubernaut_notification_channel_health_score` | Gauge | `channel` | Channel health score (0--100) |
-| `kubernaut_notification_reconciler_active` | Gauge | `phase` | Active notification backlog by phase |
+| `kubernaut_notification_channel_health_score` | Gauge | `channel` | Channel health score (0–100) |
 
 ## Effectiveness Monitor Metrics
 

--- a/docs/user-guide/audit-and-observability.md
+++ b/docs/user-guide/audit-and-observability.md
@@ -53,13 +53,23 @@ Every stage of the remediation lifecycle emits audit events:
 
 Each event contains core fields: `event_id`, `event_timestamp`, `event_type`, `event_category`, `event_action`, `event_outcome`, `actor_type`/`actor_id`, `resource_type`/`resource_id`, `correlation_id`, `namespace`, and `event_data`. See [Architecture: Audit Pipeline](../architecture/audit-pipeline.md#event-structure) for the complete event structure and field definitions.
 
-### LLM token usage (`aiagent.response.complete`)
+### LLM token usage
 
-Events with type `aiagent.response.complete` include **`total_prompt_tokens`** and **`total_completion_tokens`** in the payload for token accounting and cost analysis.
+Token usage is recorded at two levels in the Kubernaut Agent investigation pipeline:
+
+| Event type | Scope | Payload fields |
+|---|---|---|
+| `aiagent.llm.response` | Per-turn (each LLM call) | `prompt_tokens`, `completion_tokens`, `total_tokens` |
+| `aiagent.response.complete` | Cumulative (full investigation) | `total_prompt_tokens`, `total_completion_tokens`, `total_tokens` |
+
+Cumulative totals are tracked by an internal `TokenAccumulator` and emitted on investigation completion.
+
+!!! warning "Token fields are NOT on `aianalysis.*` events"
+    The `aianalysis.analysis.completed` event (emitted by the AIAnalysis controller) does **not** include token fields. Token usage is exclusively on the `aiagent.*` events from the Kubernaut Agent investigator pipeline. When querying for token cost analysis, filter to `aiagent.llm.response` (per-turn) or `aiagent.response.complete` (cumulative).
 
 ### `finish_reason` and truncation (v1.3)
 
-HolmesGPT API investigation **response** events in this same category can include **`finish_reason`**, taken from the provider completion, so you can see whether a response ended with **`length` (max tokens)**, `stop`, `tool_calls`, and so on in your audit store.
+Kubernaut Agent investigation **response** events can include **`finish_reason`**, taken from the provider completion, so you can see whether a response ended with **`length` (max tokens)**, `stop`, `tool_calls`, and so on in your audit store.
 
 A **`truncation_detected`** event is emitted when truncation triggers the **token escalation** path. Its `event_data` can include **`escalated_max_tokens: true` when a second attempt runs with a higher max-token cap (capped, for example, at 16,384; see [Investigation Pipeline: LLM output resilience](../architecture/kubernaut-agent-investigation.md#llm-output-resilience)).
 


### PR DESCRIPTION
## Summary

Addresses two issues based on replies from the Kubernaut v1.3 team:

### #66 — Feature enrichments

- **ResourceQuota enrichment** — Expanded documentation with structured `quota_details` (`map[string]QuotaResourceUsage` with `hard`/`used` per resource), full detection pipeline path (`Investigator → resolveEnrichmentCached → Enricher → LabelDetector → detectResourceQuota`), and `failedDetections` handling. Clarified that **LimitRange detection is NOT implemented** in v1.3.
- **ConfigMap composite fingerprinting** — New section in `effectiveness.md` documenting `ConfigMapDataHash` (SHA-256 over sorted entries), `ExtractConfigMapRefs` (walks pod-template for volumes, projected, envFrom, valueFrom), `CompositeResourceFingerprint` (combines target spec + ConfigMap hashes), sentinel hashes for API failures, and RO/EM role table.
- **LLM token audit events** — Clarified that token fields are exclusively on `aiagent.*` events (`aiagent.llm.response` per-turn, `aiagent.response.complete` cumulative), NOT on `aianalysis.*` events. Added structured table and explicit warning callout.

### #68 — DD-METRICS-001 notification metrics

- Added DD-METRICS-001 callout explaining the 3→1 layer collapse (interface → recorder → metrics → single DI `*Metrics` struct).
- Fixed `delivery_retries_total` labels (removed stale `reason` label — only `channel` in source).
- Reordered metrics table to match struct declaration order.
- Updated `reconciler_active` phase label values (Pending, Sending, Sent, Retrying, PartiallySent, Failed).
- Corrected intro text about notification metrics stability.

## Files changed

| File | Changes |
|---|---|
| `docs/architecture/kubernaut-agent-investigation.md` | ResourceQuota enrichment details, LimitRange clarification |
| `docs/architecture/effectiveness.md` | ConfigMap composite fingerprinting section |
| `docs/user-guide/audit-and-observability.md` | LLM token event type clarification |
| `docs/operations/monitoring.md` | DD-METRICS-001 note, notification metrics corrections |

## Test plan

- [ ] Verify `mkdocs serve` builds without warnings
- [ ] Confirm DD-METRICS-001 callout renders correctly
- [ ] Check ConfigMap fingerprinting section is clearly structured
- [ ] Verify warning callout for token events renders

Closes #66, closes #68

Made with [Cursor](https://cursor.com)