### PR TITLE
docs: User Guide consistency sweep (#73)

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -173,7 +173,7 @@ All controllers (`aianalysis`, `signalprocessing`, `remediationorchestrator`, `w
 
 | Parameter | Description | Default |
 |---|---|---|
-| `effectivenessmonitor.config.assessment.stabilizationWindow` | Wait time after remediation before assessment | `30s` |
+| `effectivenessmonitor.config.assessment.stabilizationWindow` | EM-internal stabilization window (logged at startup). **Note:** the actual stabilization delay enforced by the EM reconciler is read from `EA.spec.config.stabilizationWindow`, which is set by the RO (default `5m` via `remediationorchestrator.config.effectivenessAssessment.stabilizationWindow`). | `30s` |
 | `effectivenessmonitor.config.assessment.validityWindow` | Time window for assessment validity | `300s` |
 | `effectivenessmonitor.config.assessment.maxConcurrentReconciles` | Maximum concurrent EA reconciliations | `5` |
 | `effectivenessmonitor.external.prometheusUrl` | Prometheus URL | `http://kube-prometheus-stack-prometheus.monitoring.svc:9090` |

--- a/docs/user-guide/effectiveness.md
+++ b/docs/user-guide/effectiveness.md
@@ -17,7 +17,7 @@ The remediation orchestrator and effectiveness monitor include **mounted ConfigM
 
 When a remediation reaches a terminal phase, the Orchestrator creates an `EffectivenessAssessment` CRD. The Effectiveness Monitor then:
 
-1. **Waits for stabilization** — Two configurable windows control timing: the Remediation Orchestrator waits **5 minutes** (`remediationorchestrator.config.effectivenessAssessment.stabilizationWindow`) before creating the EA, and the Effectiveness Monitor waits **30 seconds** (`effectivenessmonitor.config.assessment.stabilizationWindow`) after EA creation before running assessments
+1. **Waits for stabilization** — The Remediation Orchestrator creates the EA with a **stabilization window** (default: **5 minutes**, from `remediationorchestrator.config.effectivenessAssessment.stabilizationWindow`). The Effectiveness Monitor enforces this window using `EA.spec.config.stabilizationWindow` — the EM does not start running assessment scorers until this duration has elapsed after the EA's creation. The stabilization window that governs the EM reconciler behavior comes from the **EA spec** (set by the RO), not from the EM's own Helm config.
 2. **Evaluates effectiveness** through multiple dimensions
 3. **Records the assessment** in the audit trail
 

--- a/docs/user-guide/notifications.md
+++ b/docs/user-guide/notifications.md
@@ -29,6 +29,10 @@ Notifications are routed using a ConfigMap with an AlertManager-style `route` + 
 
 **ConfigMap:** `notification-routing-config`
 
+When neither `notification.routing.content` nor `notification.routing.existingConfigMap` is set, the chart generates a default routing config based on Helm values:
+
+**Default when `notification.slack.secretName` is set** (Slack + console):
+
 ```yaml
 route:
   receiver: slack-and-console
@@ -41,7 +45,18 @@ receivers:
         credentialRef: slack-webhook
 ```
 
-The catch-all receiver routes **all** notification types to both Slack and console. New types added in future releases are automatically covered. Avoid matching specific types unless you intentionally want to suppress certain notifications from a channel.
+**Default when `notification.slack.secretName` is empty** (console only):
+
+```yaml
+route:
+  receiver: console
+receivers:
+  - name: console
+    consoleConfigs:
+      - enabled: true
+```
+
+The catch-all receiver routes **all** notification types to the configured channels. New types added in future releases are automatically covered. Avoid matching specific types unless you intentionally want to suppress certain notifications from a channel. See [Notification Routing ConfigMap](configmap-notification.md) for the complete reference.
 
 ### Match Fields
 

--- a/docs/user-guide/policies.md
+++ b/docs/user-guide/policies.md
@@ -171,7 +171,7 @@ The approval policy runs after Kubernaut Agent returns a successful workflow sel
 
 **Package:** `aianalysis.approval`
 
-**ConfigMap:** `approval.rego` mounted via `charts/kubernaut/files/rego/aianalysis/approval.rego`
+**ConfigMap:** `aianalysis-policies`, key `approval.rego`. Operators install the policy via `--set-file aianalysis.policies.content=approval.rego` or by providing a pre-created ConfigMap with `aianalysis.policies.existingConfigMap`. See [AIAnalysis Approval Policy ConfigMap](configmap-approval.md) for the full reference.
 
 ### Input Fields
 
@@ -191,7 +191,7 @@ Three mandatory triggers:
 
 1. **Missing remediation target** -- If `remediation_target` is absent or has an empty `kind`, approval is always required. Safety net for incomplete RCA.
 
-2. **Production environment** -- All production remediations require human approval, regardless of confidence. Controlled by setting `kubernaut.ai/environment=production` on the namespace.
+2. **Production environment** -- All production remediations require human approval, regardless of confidence (case-insensitive match: `Production`, `production`, `PRODUCTION`). Controlled by setting `kubernaut.ai/environment=production` on the namespace.
 
 3. **Sensitive resource kinds** -- Remediations targeting `Node` or `StatefulSet` resources always require approval, regardless of environment. These are high-impact resources where automated remediation carries elevated risk.
 


### PR DESCRIPTION
## Summary

Audited all 7 findings from issue #73 against the current docs and v1.3 source code. Fixed the 4 that were still inconsistent; the other 3 were already correct.

### Fixed

| ID | Finding | Fix |
|---|---|---|
| **H5** | Effectiveness stabilization window: "5 minutes" vs "30s" confusion | Clarified that the behavioral stabilization comes from `EA.spec.config.stabilizationWindow` (set by RO, default **5m**), not the EM Helm config (`30s`, logged but not used as the reconciler stabilization). Updated both `effectiveness.md` and `configuration.md`. |
| **M9** | Invalid ConfigMap path in `policies.md` | Replaced `charts/kubernaut/files/rego/aianalysis/approval.rego` with correct `aianalysis-policies` ConfigMap reference + installation instructions. Added case-insensitivity note for production matching. |
| **M11** | `notifications.md` showed only Slack+console default without conditional | Added both defaults: `slack-and-console` when `notification.slack.secretName` is set, `console-only` when empty. Cross-linked to `configmap-notification.md`. |

### Already correct (no changes)

| ID | Finding | Verification |
|---|---|---|
| **H4** | `restart-pods-v1` wrong action type | Table already has `restart-pod-v1` → `RestartPod` (singular), `graceful-restart-v1` → `GracefulRestart`. Confirmed against v1.3 test fixtures. |
| **M4** | ConfigMap `aianalysis-rego` | All references already use `aianalysis-policies`. |
| **M8** | WFE parameter injection | Lines 55-70 correctly attribute `TARGET_RESOURCE_*` to KA. WFE `TARGET_RESOURCE` (composite) documented separately. |
| **M12** | `workflowexecution.block.cleared` missing from audit | Present in both `audit-and-observability.md` and `compliance.md`. |

## Files changed

| File | Changes |
|---|---|
| `docs/user-guide/effectiveness.md` | Corrected stabilization window explanation |
| `docs/user-guide/configuration.md` | Added EM stabilizationWindow clarifying note |
| `docs/user-guide/policies.md` | Fixed ConfigMap path, added case-insensitivity |
| `docs/user-guide/notifications.md` | Added conditional routing defaults |

## Test plan

- [ ] Verify `mkdocs serve` builds without warnings
- [ ] Confirm dual routing examples render correctly in notifications.md
- [ ] Verify cross-link to configmap-approval.md resolves

Closes #73

Made with [Cursor](https://cursor.com)