### PR TITLE
docs: post-merge fixes for v1.4 release

### DIFF
--- a/docs/assets/images/fleet-operations.svg
+++ b/docs/assets/images/fleet-operations.svg
@@ -74,6 +74,38 @@
   <text x="1440" y="498" text-anchor="middle" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11px" fill="#6A6E73">MCP + klusterlet + Prometheus</text>
   <text x="1440" y="516" text-anchor="middle" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10px" fill="#0891B2">No Kubernaut CRDs, no controllers</text>
 
+  <!-- ====== STEP ANNOTATIONS ====== -->
+
+  <!-- Step 1: Remote Prometheus → Thanos -->
+  <circle cx="390" cy="420" r="12" fill="#0891B2"/>
+  <text x="390" y="425" text-anchor="middle" font-family="Inter, sans-serif" font-size="12px" font-weight="700" fill="white">1</text>
+
+  <!-- Step 2: Alertmanager → Kubernaut Engine -->
+  <line x1="540" y1="265" x2="600" y2="265" stroke="#D97706" stroke-width="2"/>
+  <polygon points="600,265 592,260 592,270" fill="#D97706"/>
+  <circle cx="570" cy="245" r="12" fill="#D97706"/>
+  <text x="570" y="250" text-anchor="middle" font-family="Inter, sans-serif" font-size="12px" font-weight="700" fill="white">2</text>
+
+  <!-- Step 3: Engine → Keycloak (JWT for investigation) -->
+  <line x1="1020" y1="265" x2="1080" y2="265" stroke="#6366F1" stroke-width="2"/>
+  <polygon points="1080,265 1072,260 1072,270" fill="#6366F1"/>
+  <circle cx="1050" cy="245" r="12" fill="#6366F1"/>
+  <text x="1050" y="250" text-anchor="middle" font-family="Inter, sans-serif" font-size="12px" font-weight="700" fill="white">3</text>
+
+  <!-- Step 4: Engine → Remote cluster (MCP investigation) -->
+  <circle cx="810" cy="420" r="12" fill="#0891B2"/>
+  <text x="810" y="425" text-anchor="middle" font-family="Inter, sans-serif" font-size="12px" font-weight="700" fill="white">4</text>
+
+  <!-- Step 5: Engine → Keycloak (JWT for remediation) -->
+  <circle cx="1050" cy="295" r="12" fill="#6366F1"/>
+  <text x="1050" y="300" text-anchor="middle" font-family="Inter, sans-serif" font-size="12px" font-weight="700" fill="white">5</text>
+
+  <!-- Step 6: Engine → AWX (dispatch playbook) -->
+  <line x1="1300" y1="265" x2="1360" y2="265" stroke="#059669" stroke-width="2"/>
+  <polygon points="1360,265 1352,260 1352,270" fill="#059669"/>
+  <circle cx="1330" cy="245" r="12" fill="#059669"/>
+  <text x="1330" y="250" text-anchor="middle" font-family="Inter, sans-serif" font-size="12px" font-weight="700" fill="white">6</text>
+
   <!-- Zero credentials bar -->
   <rect x="200" y="570" width="1520" height="46" rx="10" fill="#0891B2" opacity="0.04" stroke="#0891B2" stroke-width="1"/>
   <text x="960" y="599" text-anchor="middle" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14px" font-weight="600" fill="#0891B2">Zero persistent credentials on remote clusters &#x2014; ephemeral SAs with OCM-managed lifecycle</text>

--- a/docs/whats-next/index.md
+++ b/docs/whats-next/index.md
@@ -198,9 +198,9 @@ Hub-and-spoke deployment using [OCM](https://open-cluster-management.io/) (Open 
 
 Accept signals described in plain language — not just structured Prometheus alerts or Kubernetes events. Operators, chat bots, and external agents can trigger investigations by describing symptoms conversationally. Kubernaut resolves the intent (cluster, service, symptom) and opens an investigation automatically. See the "Starting from a natural language signal" example under [Interactive Sessions](#interactive-sessions).
 
-## Selective Trust — Trust Ladder Level 2
+## Observe Mode (Trust Ladder Level 2)
 
-v1.4 shipped **global dry-run** (Level 1 — Observe), where the entire pipeline runs through AI analysis but stops before execution. Level 2 builds on this by introducing **per-workflow dry-run overrides**: trusted workflows that have been validated in observe mode graduate to real execution, while new or untested workflows remain in dry-run. Combined with the Backstage console, operators get dashboard visibility and a guided onboarding path for new clusters.
+Building on v1.4's global dry-run mode, v1.5 adds operator dashboard visibility through the Backstage console and a guided onboarding path for new clusters.
 
 ---
 

--- a/docs/whats-next/index.md
+++ b/docs/whats-next/index.md
@@ -4,11 +4,6 @@ hide:
   - toc
 ---
 
----
-hide:
-  - navigation
----
-
 # What's Next
 
 Kubernaut v1.5 is the next major milestone, focused on agentic architecture and interactive sessions. The features below are in active development.


### PR DESCRIPTION
## Summary

Post-merge fixes following PR #135.

- **Revert Observe Mode heading** — the "Selective Trust — Trust Ladder Level 2" rename was based on an incorrect assumption about per-workflow dry-runs. Reverted to original "Observe Mode (Trust Ladder Level 2)" with the correct v1.5 scope (Backstage dashboard visibility and guided onboarding)
- **Restore fleet diagram step arrows** — re-add numbered step annotations (1–6) to `fleet-operations.svg` so the remediation flow legend can be cross-referenced visually in the diagram
- **Fix duplicate frontmatter** — remove duplicate `hide: - navigation` YAML block in `whats-next/index.md` that was rendering as visible text on the page

## Test plan

- [ ] Verify "What's Next" page renders without visible frontmatter text
- [ ] Verify fleet operations diagram shows numbered steps matching the text legend
- [ ] Verify "Observe Mode" heading and text are correct

Made with [Cursor](https://cursor.com)