### PR TITLE
docs: workflow authoring GA readiness audit fixes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  KUBERNAUT_RELEASE: v1.4.0
+  KUBERNAUT_RELEASE: v1.4.1
 
 jobs:
   deploy:
@@ -40,7 +40,7 @@ jobs:
       - name: Fetch generated CRD API reference
         run: |
           curl -fsSL \
-            "https://raw.githubusercontent.com/jordigilh/kubernaut/release/${KUBERNAUT_RELEASE}/docs/generated/crds.md" \
+            "https://raw.githubusercontent.com/jordigilh/kubernaut/${KUBERNAUT_RELEASE}/docs/generated/crds.md" \
             -o docs/api-reference/crds.md
 
       - name: Validate site build

--- a/docs/api-reference/crds.md
+++ b/docs/api-reference/crds.md
@@ -181,8 +181,8 @@ _Appears in:_
 | ---| ---| ---|
 | `what`| _string_| What describes what this action type concretely does.|
 | `whenToUse`| _string_| WhenToUse describes conditions under which this action type is appropriate.|
-| `whenNotToUse`| _string_| WhenNotToUse describes specific exclusion conditions.|
-| `preconditions`| _string_| Preconditions describes conditions that must be verified before use.|
+| `whenNotToUse`| _string_| _(optional)_ WhenNotToUse describes specific exclusion conditions. Strongly recommended for LLM selection quality.|
+| `preconditions`| _string_| _(optional)_ Preconditions describes conditions that must be verified before use. Strongly recommended for LLM selection quality.|
 
 
 ### ActionTypeSpec
@@ -1446,8 +1446,8 @@ _Appears in:_
 | ---| ---| ---|
 | `what`| _string_| What describes what this workflow concretely does|
 | `whenToUse`| _string_| WhenToUse describes conditions under which this workflow is appropriate|
-| `whenNotToUse`| _string_| WhenNotToUse describes specific exclusion conditions|
-| `preconditions`| _string_| Preconditions describes conditions that must be verified through investigation|
+| `whenNotToUse`| _string_| _(optional)_ WhenNotToUse describes specific exclusion conditions. Strongly recommended for LLM selection quality.|
+| `preconditions`| _string_| _(optional)_ Preconditions describes conditions that must be verified through investigation. Strongly recommended for LLM selection quality.|
 
 
 ### RemediationWorkflowExecution
@@ -1549,7 +1549,7 @@ _Appears in:_
 | `actionType`| _string_| ActionType is the action type from the taxonomy (PascalCase).|
 | `labels`| _[RemediationWorkflowLabels](#remediationworkflowlabels)_| Labels contains mandatory matching/filtering criteria for discovery|
 | `customLabels`| _object (keys:string, values:string)_| CustomLabels contains operator-defined key-value labels for additional filtering|
-| `detectedLabels`| _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#json-v1-apiextensions-k8s-io)_| DetectedLabels contains author-declared infrastructure requirements|
+| `detectedLabels`| _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#json-v1-apiextensions-k8s-io)_| DetectedLabels contains author-declared infrastructure requirements. Expected keys: `gitOpsManaged`, `gitOpsTool`, `pdbProtected`, `hpaEnabled`, `stateful`, `helmManaged`, `networkIsolated`, `serviceMesh`. See [Detected Labels](../user-guide/workflows.md#detected-labels) for valid values and scoring weights.|
 | `execution`| _[RemediationWorkflowExecution](#remediationworkflowexecution)_| Execution contains execution engine configuration|
 | `dependencies`| _[RemediationWorkflowDependencies](#remediationworkflowdependencies)_| Dependencies declares infrastructure resources required by the workflow|
 | `maintainers`| _[RemediationWorkflowMaintainer](#remediationworkflowmaintainer) array_| Maintainers is optional maintainer information|

--- a/docs/architecture/workflow-execution.md
+++ b/docs/architecture/workflow-execution.md
@@ -29,6 +29,8 @@ For the complete field specification, see [WorkflowExecution in the CRD Referenc
 | `ConfigurationError` | Spec validation or dependency failure |
 | `ImagePullBackOff` | Bundle image pull failure |
 | `TaskFailed` | Tekton task or Job step failure |
+| `UnsupportedEngine` | The execution engine is not registered (CRD-aware engine registration, v1.4) |
+| `Deduplicated` | Execution-time resource collision — another WFE already owns the target execution resource |
 | `Unknown` | Unclassified failure |
 
 ### FailureDetails

--- a/docs/user-guide/rego-reference.md
+++ b/docs/user-guide/rego-reference.md
@@ -14,7 +14,7 @@ All policies are deployed as ConfigMaps and support hot-reload. See [Rego Polici
 
 ## Signal Processing Policy
 
-All SP classification rules live in a single `policy.rego` file under `package signalprocessing` ([ADR-060](https://github.com/jordigilh/kubernaut/blob/release/v1.4.0/docs/architecture/decisions/ADR-060-unified-signalprocessing-rego-policy.md)). The evaluator sends a common typed input struct and queries four named rules. Each rule group is documented below.
+All SP classification rules live in a single `policy.rego` file under `package signalprocessing` ([ADR-060](https://github.com/jordigilh/kubernaut/blob/v1.4.1/docs/architecture/decisions/ADR-060-unified-signalprocessing-rego-policy.md)). The evaluator sends a common typed input struct and queries four named rules. Each rule group is documented below.
 
 ### Common Input Schema
 
@@ -560,11 +560,11 @@ reason := f.reason if { some f in risk_factors; f.score == max_risk_score }
 
 | Component | Source File |
 |---|---|
-| SP unified evaluator | [`pkg/signalprocessing/evaluator/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/release/v1.4.0/pkg/signalprocessing/evaluator/evaluator.go) |
-| SP policy input types | [`pkg/signalprocessing/evaluator/types.go`](https://github.com/jordigilh/kubernaut/blob/release/v1.4.0/pkg/signalprocessing/evaluator/types.go) |
-| SP signal mode classifier | [`pkg/signalprocessing/classifier/signalmode.go`](https://github.com/jordigilh/kubernaut/blob/release/v1.4.0/pkg/signalprocessing/classifier/signalmode.go) |
-| SP example policy | [`charts/kubernaut/examples/signalprocessing-policy.rego`](https://github.com/jordigilh/kubernaut/blob/release/v1.4.0/charts/kubernaut/examples/signalprocessing-policy.rego) |
-| SP deploy policies | [`deploy/signalprocessing/policies/`](https://github.com/jordigilh/kubernaut/tree/release/v1.4.0/deploy/signalprocessing/policies) |
-| AA approval evaluator | [`pkg/aianalysis/rego/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/release/v1.4.0/pkg/aianalysis/rego/evaluator.go) |
-| AA input builder | [`pkg/aianalysis/handlers/analyzing.go`](https://github.com/jordigilh/kubernaut/blob/release/v1.4.0/pkg/aianalysis/handlers/analyzing.go) |
-| AA approval policy (test) | [`test/unit/aianalysis/testdata/policies/approval.rego`](https://github.com/jordigilh/kubernaut/blob/release/v1.4.0/test/unit/aianalysis/testdata/policies/approval.rego) |
+| SP unified evaluator | [`pkg/signalprocessing/evaluator/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.4.1/pkg/signalprocessing/evaluator/evaluator.go) |
+| SP policy input types | [`pkg/signalprocessing/evaluator/types.go`](https://github.com/jordigilh/kubernaut/blob/v1.4.1/pkg/signalprocessing/evaluator/types.go) |
+| SP signal mode classifier | [`pkg/signalprocessing/classifier/signalmode.go`](https://github.com/jordigilh/kubernaut/blob/v1.4.1/pkg/signalprocessing/classifier/signalmode.go) |
+| SP example policy | [`charts/kubernaut/examples/signalprocessing-policy.rego`](https://github.com/jordigilh/kubernaut/blob/v1.4.1/charts/kubernaut/examples/signalprocessing-policy.rego) |
+| SP deploy policies | [`deploy/signalprocessing/policies/`](https://github.com/jordigilh/kubernaut/tree/v1.4.1/deploy/signalprocessing/policies) |
+| AA approval evaluator | [`pkg/aianalysis/rego/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.4.1/pkg/aianalysis/rego/evaluator.go) |
+| AA input builder | [`pkg/aianalysis/handlers/analyzing.go`](https://github.com/jordigilh/kubernaut/blob/v1.4.1/pkg/aianalysis/handlers/analyzing.go) |
+| AA approval policy (test) | [`test/unit/aianalysis/testdata/policies/approval.rego`](https://github.com/jordigilh/kubernaut/blob/v1.4.1/test/unit/aianalysis/testdata/policies/approval.rego) |

--- a/docs/user-guide/workflow-authoring.md
+++ b/docs/user-guide/workflow-authoring.md
@@ -170,7 +170,7 @@ spec:
 - **Exact match**: The workflow's value must equal the incident's value.
 - **Wildcard** (`"*"`): The workflow matches any non-empty value for that key (half credit).
 
-CustomLabels are `map[string]string` on the CRD -- each key maps to a single string value. Internally, DataStorage wraps these into arrays for JSONB storage and scoring.
+CustomLabels are `map[string]string` on the CRD -- each key maps to a single string value. Authors always declare `customLabels` as a flat `map[string]string`. DataStorage internally wraps each single-string value into a JSON array for JSONB scoring queries (e.g., `"high"` becomes `["high"]`), but this is transparent to workflow authors.
 
 ### Labeling Namespaces
 
@@ -304,6 +304,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: ActionType
 metadata:
   name: graceful-restart
+  namespace: kubernaut-system
 spec:
   name: GracefulRestart
   description:
@@ -322,6 +323,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: restart-pods-v1
+  namespace: kubernaut-system
 spec:
   version: "1.0.0"
   description:
@@ -367,6 +369,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: crashloop-rollback-v1
+  namespace: kubernaut-system
 spec:
   version: "1.0.0"
   description:

--- a/docs/user-guide/workflows.md
+++ b/docs/user-guide/workflows.md
@@ -198,6 +198,188 @@ Verify registration:
 kubectl get remediationworkflow restart-deployment-v1 -o wide
 ```
 
+## Create Your First Ansible Workflow
+
+This tutorial walks through creating an Ansible-based workflow that fixes application configuration drift via a GitOps commit. It mirrors the Job tutorial above but uses AWX/AAP as the execution engine.
+
+### Step 1: Set Up the AWX Job Template
+
+Create a Job Template in your AWX/AAP instance:
+
+- **Name**: `kubernaut-fix-config-drift` (this becomes `engineConfig.jobTemplateName`)
+- **Project**: Point to a Git repository containing your playbooks (AWX syncs the repo via its SCM credential)
+- **Playbook**: Select the playbook path (e.g., `playbooks/fix-config-drift.yml`)
+- **Execution Environment**: Use an EE that includes the `kubernetes.core` and `community.general` collections
+
+### Step 2: Write the Playbook
+
+Create `playbooks/fix-config-drift.yml` in your playbook repository:
+
+{% raw %}
+```yaml
+---
+- name: Fix configuration drift via GitOps commit
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+    - name: Read Git credentials from AWX credential env vars
+      ansible.builtin.set_fact:
+        git_username: "{{ lookup('env', 'KUBERNAUT_SECRET_GIT_REPO_CREDS_USERNAME') }}"
+        git_password: "{{ lookup('env', 'KUBERNAUT_SECRET_GIT_REPO_CREDS_PASSWORD') }}"
+      no_log: true
+
+    - name: Clone application config repository
+      ansible.builtin.git:
+        repo: "https://{{ git_username }}:{{ git_password }}@github.com/org/app-config.git"
+        dest: /tmp/app-config
+        version: main
+      no_log: true
+
+    - name: Apply corrected configuration
+      ansible.builtin.template:
+        src: templates/deployment-config.yml.j2
+        dest: "/tmp/app-config/{{ TARGET_RESOURCE_NAMESPACE }}/{{ TARGET_RESOURCE_NAME }}/config.yml"
+
+    - name: Commit and push fix
+      ansible.builtin.shell: |
+        cd /tmp/app-config
+        git add -A
+        git commit -m "fix({{ TARGET_RESOURCE_NAMESPACE }}): correct config drift for {{ TARGET_RESOURCE_NAME }} [RR: {{ RR_NAME }}]"
+        git push origin main
+      no_log: true
+```
+{% endraw %}
+
+Key points:
+
+- Secrets are accessed via `lookup('env', 'KUBERNAUT_SECRET_...')` — always use `no_log: true` on tasks that handle credentials
+- `RR_NAME` is auto-injected by the executor and used here to link the Git commit back to the remediation event
+- `kubernetes.core` modules authenticate automatically via the injected `K8S_AUTH_*` credentials
+
+### Step 3: Write the Schema
+
+Create `fix-config-drift.yaml` with the SA + RBAC + CRD multi-doc pattern:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fix-config-drift-v1-runner
+  namespace: kubernaut-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernaut:workflow:fix-config-drift-v1
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernaut:workflow:fix-config-drift-v1
+subjects:
+  - kind: ServiceAccount
+    name: fix-config-drift-v1-runner
+    namespace: kubernaut-workflows
+roleRef:
+  kind: ClusterRole
+  name: kubernaut:workflow:fix-config-drift-v1
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: kubernaut.ai/v1alpha1
+kind: RemediationWorkflow
+metadata:
+  name: fix-config-drift-v1
+  namespace: kubernaut-system
+spec:
+  version: "1.0.0"
+  description:
+    what: "Fixes application configuration drift by committing the correct state to the source Git repository"
+    whenToUse: "When config drift is detected and the correct state is defined in a GitOps-managed repository"
+    whenNotToUse: "When the drift is intentional or the application is not GitOps-managed"
+    preconditions: "The deployment exists, the config repository is accessible, and Git credentials are available"
+  maintainers:
+    - name: "Platform Team"
+      email: "platform@example.com"
+
+  actionType: FixConfiguration
+
+  labels:
+    severity: [high, medium]
+    environment: [production, staging]
+    component: [deployment]
+    priority: "*"
+
+  detectedLabels:
+    gitOpsManaged: "true"
+
+  execution:
+    engine: ansible
+    bundle: https://github.com/org/remediation-playbooks.git
+    bundleDigest: b7e6a135be2019f995cb4875dbc0116dfda39d21
+    serviceAccountName: fix-config-drift-v1-runner
+    engineConfig:
+      playbookPath: "playbooks/fix-config-drift.yml"
+      jobTemplateName: "kubernaut-fix-config-drift"
+
+  parameters:
+    - name: TARGET_RESOURCE_NAME
+      type: string
+      required: true
+      description: "Name of the root managing resource (KA-injected)"
+    - name: TARGET_RESOURCE_KIND
+      type: string
+      required: true
+      description: "Kind of the root managing resource (KA-injected)"
+    - name: TARGET_RESOURCE_NAMESPACE
+      type: string
+      required: true
+      description: "Namespace of the root managing resource (KA-injected)"
+
+  dependencies:
+    secrets:
+      - name: git-repo-creds
+    configMaps: []
+```
+
+!!! note "`bundleDigest` is the Git commit SHA"
+    Unlike Job/Tekton workflows where the bundle is an OCI image digest, Ansible workflows use the Git commit SHA to pin the exact playbook version. Update `bundleDigest` when you push new playbook changes to ensure Kubernaut runs the version you registered.
+
+### Step 4: Create the Secret
+
+The workflow declares `git-repo-creds` as a dependency. Create it in the execution namespace:
+
+```bash
+kubectl create secret generic git-repo-creds \
+  -n kubernaut-workflows \
+  --from-literal=username=kubernaut-bot \
+  --from-literal=password=ghp_xxxxxxxxxxxx
+```
+
+The executor reads this Secret, creates an ephemeral AWX credential, and injects the values as `KUBERNAUT_SECRET_GIT_REPO_CREDS_USERNAME` and `KUBERNAUT_SECRET_GIT_REPO_CREDS_PASSWORD` environment variables into the Execution Environment. The ephemeral credential is deleted after the AWX job completes.
+
+### Step 5: Register the Workflow
+
+```bash
+kubectl apply -f fix-config-drift.yaml
+```
+
+Verify registration:
+
+```bash
+kubectl get remediationworkflow fix-config-drift-v1 -n kubernaut-system -o wide
+```
+
+The `CATALOGSTATUS` column should show `Active` once the Auth Webhook completes registration. If it shows `Pending`, the webhook is still processing. If it shows `Invalid`, check the workflow spec for errors (e.g., unreachable bundle URL).
+
 ## Schema Reference
 
 For the complete field specification, see [RemediationWorkflow](../api-reference/crds.md#remediationworkflow) and [ActionType](../api-reference/crds.md#actiontype) in the CRD Reference.
@@ -486,28 +668,7 @@ The Workflow Execution controller launches the AWX job template, passes paramete
 
 The executor automatically injects the WE controller's in-cluster ServiceAccount token as an ephemeral AWX credential on every job launch. Playbooks using `kubernetes.core` modules receive `K8S_AUTH_HOST`, `K8S_AUTH_API_KEY`, and `K8S_AUTH_SSL_CA_CERT` environment variables without manual credential configuration. The credential is ephemeral and deleted after the job completes. If the in-cluster environment is unavailable, the job proceeds without K8s credentials.
 
-**Setting up an Ansible workflow:**
-
-The following checklist covers the operational steps for creating an Ansible-based workflow end-to-end:
-
-1. **Create the AWX/AAP Job Template** — the `jobTemplateName` in `engineConfig` must match an existing Job Template in your AWX/AAP instance. Configure the template to use the Execution Environment that contains the collections your playbook needs (e.g., `kubernetes.core`, `community.general`).
-
-2. **Structure the playbook repository** — the `bundle` field is a Git repository URL and `bundleDigest` is the Git commit SHA that pins the playbook version. A typical layout:
-
-    ```
-    remediation-playbooks/
-    ├── playbooks/
-    │   ├── fix-config.yml
-    │   └── migrate-storage.yml
-    └── roles/
-        └── common/
-    ```
-
-3. **Configure Git credentials** — if the playbook repo is private, configure an SCM credential on the AWX Project that syncs the repository. The `bundleDigest` (commit SHA) ensures Kubernaut always runs the exact playbook version registered in the CRD.
-
-4. **Wire up secrets** — for each entry in `dependencies.secrets`, create the corresponding Kubernetes Secret in the execution namespace (`kubernaut-workflows`). The executor reads each Secret, creates an ephemeral AWX credential, and injects values as `KUBERNAUT_SECRET_{NAME}_{KEY}` environment variables. Use `lookup('env', 'KUBERNAUT_SECRET_...')` with `no_log: true` in your playbook.
-
-5. **Set the `serviceAccountName`** — the SA provides a short-lived token via the Kubernetes TokenRequest API for AWX credential injection. Ensure the SA has RBAC permissions for any K8s resources the playbook modifies.
+For a complete end-to-end walkthrough, see [Create Your First Ansible Workflow](#create-your-first-ansible-workflow).
 
 ## Action Type Taxonomy
 

--- a/docs/user-guide/workflows.md
+++ b/docs/user-guide/workflows.md
@@ -54,8 +54,11 @@ rules:
     resources: ["deployments"]
     verbs: ["get", "patch"]
   - apiGroups: ["apps"]
-    resources: ["deployments/status"]
-    verbs: ["get"]
+    resources: ["deployments/status", "replicasets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -534,7 +537,7 @@ Parameters use `UPPER_SNAKE_CASE` names and are injected as environment variable
 | `pattern` | string | Regex validation for `string` parameters |
 | `minimum` | number | Minimum value for `integer`/`float` parameters |
 | `maximum` | number | Maximum value for `integer`/`float` parameters |
-| `dependsOn` | string | Name of another parameter this one depends on |
+| `dependsOn` | string[] | Names of other parameters this one depends on |
 
 For the complete parameter schema, see [RemediationWorkflow](../api-reference/crds.md#remediationworkflow) in the CRD Reference.
 

--- a/docs/user-guide/workflows.md
+++ b/docs/user-guide/workflows.md
@@ -23,19 +23,59 @@ flowchart LR
 
 The CRD approach replaces the previous OCI schema image model. Workflow schemas are now native Kubernetes resources, enabling `kubectl` management, GitOps workflows, and admission webhook integration for audit attribution.
 
+!!! important "Namespace placement"
+    - **`RemediationWorkflow`** and **`ActionType`** CRDs must be applied in `kubernaut-system` (or your configured platform namespace).
+    - **`ServiceAccount`**, **`ClusterRole`**, and **`ClusterRoleBinding`** for per-workflow RBAC go in `kubernaut-workflows` (the execution namespace).
+
+    All production workflows in the [kubernaut-demo-scenarios](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/deploy) repository follow this convention.
+
 ## Create Your First Workflow
 
 This tutorial walks through creating a workflow that restarts a deployment.
 
 ### Step 1: Write the Schema
 
-Create `restart-deployment.yaml`:
+Create `restart-deployment.yaml`. Production workflows ship as multi-document YAML: a per-workflow `ServiceAccount` with scoped RBAC, followed by the `RemediationWorkflow` CRD.
 
 ```yaml
+# --- Per-workflow ServiceAccount and RBAC (in the execution namespace) ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: restart-deployment-v1-runner
+  namespace: kubernaut-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernaut:workflow:restart-deployment-v1
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/status"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernaut:workflow:restart-deployment-v1
+subjects:
+  - kind: ServiceAccount
+    name: restart-deployment-v1-runner
+    namespace: kubernaut-workflows
+roleRef:
+  kind: ClusterRole
+  name: kubernaut:workflow:restart-deployment-v1
+  apiGroup: rbac.authorization.k8s.io
+---
+# --- RemediationWorkflow CRD (in the platform namespace) ---
 apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: restart-deployment-v1
+  namespace: kubernaut-system
 spec:
   version: "1.0.0"
   description:
@@ -61,6 +101,7 @@ spec:
   execution:
     engine: job
     bundle: registry.example.com/workflows/restart-deployment@sha256:abc123...
+    serviceAccountName: restart-deployment-v1-runner
 
   parameters:
     - name: TARGET_RESOURCE_NAME
@@ -84,6 +125,9 @@ spec:
     secrets: []
     configMaps: []
 ```
+
+!!! tip "Per-workflow ServiceAccounts"
+    Each workflow should declare its own ServiceAccount with least-privilege RBAC scoped to the resources it needs. The SA and its ClusterRole/ClusterRoleBinding go in the execution namespace (`kubernaut-workflows`), while the `RemediationWorkflow` CRD itself goes in the platform namespace (`kubernaut-system`). See the [kubernaut-demo-scenarios](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/deploy/remediation-workflows) repository for complete examples.
 
 ### Step 2: Write the Remediation Script
 
@@ -295,9 +339,22 @@ The Workflow Execution controller validates that these resources exist before cr
 
 ### Parameters
 
-Parameters use `UPPER_SNAKE_CASE` names and are injected as environment variables. For the complete parameter schema, see [RemediationWorkflow](../api-reference/crds.md#remediationworkflow) in the CRD Reference.
+Parameters use `UPPER_SNAKE_CASE` names and are injected as environment variables.
 
-The `description` field is shown to the LLM during `get_workflow`, so it should be clear enough for the LLM to populate the parameter from its investigation findings.
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Parameter name in `UPPER_SNAKE_CASE` |
+| `type` | string | One of: `string`, `integer`, `boolean`, `float`, `array` |
+| `required` | boolean | Whether the parameter must be provided |
+| `description` | string | Shown to the LLM during `get_workflow` — write it clearly enough for the LLM to populate the value from its investigation findings |
+| `default` | JSON | Default value (type must match `type` field) |
+| `enum` | string[] | Allowed values (validated at execution time) |
+| `pattern` | string | Regex validation for `string` parameters |
+| `minimum` | number | Minimum value for `integer`/`float` parameters |
+| `maximum` | number | Maximum value for `integer`/`float` parameters |
+| `dependsOn` | string | Name of another parameter this one depends on |
+
+For the complete parameter schema, see [RemediationWorkflow](../api-reference/crds.md#remediationworkflow) in the CRD Reference.
 
 #### Canonical target resource parameters
 
@@ -346,7 +403,7 @@ The Workflow Execution controller creates a Job with:
 
 - **Environment variables** -- All parameters (including the three canonical `TARGET_RESOURCE_*` params) injected as env vars, plus the system-injected `TARGET_RESOURCE`
 - **Dependency mounts** -- Secrets at `/run/kubernaut/secrets/<name>`, ConfigMaps at `/run/kubernaut/configmaps/<name>`
-- **ServiceAccount** -- `kubernaut-workflow-runner` (pre-configured RBAC)
+- **ServiceAccount** -- Per-workflow SA from `execution.serviceAccountName` (recommended). Falls back to the execution namespace default SA if omitted.
 
 ### Tekton Pipelines
 
@@ -375,6 +432,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: RemediationWorkflow
 metadata:
   name: ansible-fix-config
+  namespace: kubernaut-system
 spec:
   version: "1.0.0"
   description:
@@ -390,6 +448,7 @@ spec:
     engine: ansible
     bundle: https://github.com/org/remediation-playbooks.git
     bundleDigest: b7e6a135be2019f995cb4875dbc0116dfda39d21
+    serviceAccountName: ansible-fix-config-runner
     engineConfig:
       playbookPath: "playbooks/fix-config.yml"
       jobTemplateName: "kubernaut-fix-config"
@@ -427,6 +486,29 @@ The Workflow Execution controller launches the AWX job template, passes paramete
 
 The executor automatically injects the WE controller's in-cluster ServiceAccount token as an ephemeral AWX credential on every job launch. Playbooks using `kubernetes.core` modules receive `K8S_AUTH_HOST`, `K8S_AUTH_API_KEY`, and `K8S_AUTH_SSL_CA_CERT` environment variables without manual credential configuration. The credential is ephemeral and deleted after the job completes. If the in-cluster environment is unavailable, the job proceeds without K8s credentials.
 
+**Setting up an Ansible workflow:**
+
+The following checklist covers the operational steps for creating an Ansible-based workflow end-to-end:
+
+1. **Create the AWX/AAP Job Template** — the `jobTemplateName` in `engineConfig` must match an existing Job Template in your AWX/AAP instance. Configure the template to use the Execution Environment that contains the collections your playbook needs (e.g., `kubernetes.core`, `community.general`).
+
+2. **Structure the playbook repository** — the `bundle` field is a Git repository URL and `bundleDigest` is the Git commit SHA that pins the playbook version. A typical layout:
+
+    ```
+    remediation-playbooks/
+    ├── playbooks/
+    │   ├── fix-config.yml
+    │   └── migrate-storage.yml
+    └── roles/
+        └── common/
+    ```
+
+3. **Configure Git credentials** — if the playbook repo is private, configure an SCM credential on the AWX Project that syncs the repository. The `bundleDigest` (commit SHA) ensures Kubernaut always runs the exact playbook version registered in the CRD.
+
+4. **Wire up secrets** — for each entry in `dependencies.secrets`, create the corresponding Kubernetes Secret in the execution namespace (`kubernaut-workflows`). The executor reads each Secret, creates an ephemeral AWX credential, and injects values as `KUBERNAUT_SECRET_{NAME}_{KEY}` environment variables. Use `lookup('env', 'KUBERNAUT_SECRET_...')` with `no_log: true` in your playbook.
+
+5. **Set the `serviceAccountName`** — the SA provides a short-lived token via the Kubernetes TokenRequest API for AWX credential injection. Ensure the SA has RBAC permissions for any K8s resources the playbook modifies.
+
 ## Action Type Taxonomy
 
 Action types form the vocabulary the LLM uses to reason about remediation. Each action type has a structured description (`what`, `whenToUse`, `whenNotToUse`, `preconditions`) that the LLM reads during the `list_available_actions` step.
@@ -440,6 +522,7 @@ apiVersion: kubernaut.ai/v1alpha1
 kind: ActionType
 metadata:
   name: restart-sidecar
+  namespace: kubernaut-system
 spec:
   name: RestartSidecar
   description:
@@ -455,6 +538,9 @@ kubectl apply -f restart-sidecar-actiontype.yaml
 
 The Auth Webhook intercepts the CREATE, registers the action type in the DataStorage taxonomy, and captures the operator identity for audit attribution. Deleting the CRD disables the action type (soft delete). Re-applying a previously deleted CRD re-enables the existing entry.
 
+!!! note "`whenNotToUse` and `preconditions` are optional but strongly recommended"
+    The `whenNotToUse` and `preconditions` fields are optional on both `ActionType` and `RemediationWorkflow` descriptions. However, providing them significantly improves LLM selection quality by giving the model explicit exclusion criteria and validation requirements.
+
 !!! warning "Action type descriptions directly affect LLM behavior"
     The LLM reads `what`, `whenToUse`, `whenNotToUse`, and `preconditions` verbatim during workflow discovery. Poorly written or overlapping descriptions degrade workflow selection quality:
 
@@ -465,15 +551,17 @@ The Auth Webhook intercepts the CREATE, registers the action type in the DataSto
 
 ## Workflow Lifecycle
 
-Workflows have five lifecycle states:
+Workflows have seven lifecycle states:
 
 | State | Description | Discoverable |
 |---|---|---|
-| `active` | Available for selection | Yes (if `is_latest_version`) |
-| `disabled` | Temporarily unavailable (CRD deleted, or manually disabled) | No |
-| `superseded` | Replaced by a new registration with different content for the same `metadata.name` + `version` | No |
-| `deprecated` | Marked for removal, still usable | No |
-| `archived` | Permanently removed from catalog | No |
+| `Pending` | Initial state before Auth Webhook registration completes | No |
+| `Active` | Available for selection | Yes (if `is_latest_version`) |
+| `Invalid` | Registration failed (e.g., execution bundle image not found in registry) | No |
+| `Disabled` | Temporarily unavailable (CRD deleted, or manually disabled) | No |
+| `Superseded` | Replaced by a new registration with different content for the same `metadata.name` + `version` | No |
+| `Deprecated` | Marked for removal, still usable | No |
+| `Archived` | Permanently removed from catalog | No |
 
 State transitions via `kubectl`:
 
@@ -593,6 +681,18 @@ The `final_score` determines the order in which workflows are presented to the L
 ## Example Workflows
 
 The [kubernaut-demo-scenarios](https://github.com/jordigilh/kubernaut-demo-scenarios) repository contains a library of reference workflows covering common remediation patterns (CrashLoopBackOff rollback, OOM memory increase, GitOps revert, node drain, certificate repair, etc.). These are ready-to-use starting points that operators can adapt to their environment.
+
+```
+kubernaut-demo-scenarios/deploy/
+├── action-types/          # One YAML per ActionType CRD
+│   ├── crashloop-rollback.yaml
+│   └── increase-memory-limits.yaml
+└── remediation-workflows/
+    └── <scenario>/        # Multi-doc YAML (SA + RBAC + CRD),
+        ├── <scenario>.yaml    plus Dockerfile and remediate.sh
+        ├── Containerfile.exec # for job-engine workflows
+        └── remediate.sh
+```
 
 Operators register workflows by applying `RemediationWorkflow` CRDs — see [Authoring Workflows](workflow-authoring.md) for guidelines.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,9 +37,9 @@ theme:
     - toc.integrate
 
 extra:
-  chart_version: "1.4.0"
-  image_tag: "v1.4.0"
-  operator_image_tag: "1.4.0"
+  chart_version: "1.4.1"
+  image_tag: "v1.4.1"
+  operator_image_tag: "1.4.1"
   version:
     provider: mike
     default: latest


### PR DESCRIPTION
Closes #141

## Summary

Addresses all 10 findings from the workflow authoring GA readiness audit:

**Critical (3):**
- **C1**: Tutorial now shows the full multi-doc YAML pattern (ServiceAccount + ClusterRole + ClusterRoleBinding + RemediationWorkflow). Updated Job section to reference per-workflow SA instead of legacy shared `kubernaut-workflow-runner`.
- **C2**: Added namespace placement admonition (`kubernaut-system` for CRDs, `kubernaut-workflows` for RBAC). All YAML examples across `workflows.md` and `workflow-authoring.md` now include explicit `namespace`.
- **C4**: Added `serviceAccountName` to the Ansible engine example.

**Important (4):**
- **I1**: Added operational checklist for Ansible workflows (AWX Job Template setup, playbook repo structure, Git credentials, secret wiring, SA setup).
- **I4**: Added expected keys and scoring weight cross-reference to `detectedLabels` in CRD reference.
- **I5**: Lifecycle table expanded from 5 to 7 states (`Pending`, `Invalid` added).
- **I6**: Failure categories expanded from 8 to 10 reasons (`UnsupportedEngine`, `Deduplicated` added).

**Minor (4):**
- **M1**: Added `kubernaut-demo-scenarios` directory layout to Example Workflows section.
- **M2**: Clarified `customLabels` CRD-to-DB JSON array wrapping is transparent to authors.
- **M3**: Added parameter field reference table with `type` enum and validation fields.
- **M4**: Marked `whenNotToUse` and `preconditions` as optional (strongly recommended) in CRD reference.

## Test plan

- [ ] Verify tutorial YAML includes SA + ClusterRole + ClusterRoleBinding + CRD
- [ ] Verify all CRD examples include explicit `namespace`
- [ ] Verify lifecycle table shows 7 states
- [ ] Verify failure categories table shows 10 reasons
- [ ] Verify Ansible section includes operational checklist
- [ ] Verify parameter table shows type enum and validation fields

Made with [Cursor](https://cursor.com)