### PR TITLE
fix: pin markdown <3.10 to fix CI deploy failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ mkdocs-material==9.7.5
 mkdocs-macros-plugin==1.5.0
 mike==2.1.4
 pymdown-extensions==10.21
+pygments>=2.19,<2.21
+markdown>=3.7,<3.10


### PR DESCRIPTION
## Summary

- Pin `markdown>=3.7,<3.10` and `pygments>=2.19,<2.21` in requirements.txt
- Markdown 3.10.x changes code fence processing, causing `pymdownx.highlight` to pass `filename=None` to Pygments' `HtmlFormatter`, which crashes with `'NoneType' object has no attribute 'replace'`
- Fixes the deploy failure on main ([run 26200462393](https://github.com/jordigilh/kubernaut-docs/actions/runs/26200462393))

## Test plan

- [ ] CI deploy workflow passes after merge

Made with [Cursor](https://cursor.com)