### PR TITLE
docs: fix service configuration reference against v1.4.1 chart

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -107,7 +107,7 @@ This section walks you through installing Kubernaut using the Helm chart for dev
   - Alert resolution checks (AlertManager API)
   - Metrics scraping for all Kubernaut services (all pods expose `/metrics`)
 
-Prometheus and AlertManager integration is disabled by default. To enable effectiveness assessments based on alert resolution and metric queries, set `effectivenessmonitor.external.prometheusEnabled=true` and `effectivenessmonitor.external.alertManagerEnabled=true`.
+Prometheus and AlertManager integration is disabled by default. To enable effectiveness assessments based on alert resolution and metric queries, set `monitoring.prometheus.enabled=true` and `monitoring.alertManager.enabled=true`.
 
 ## Infrastructure Setup
 
@@ -146,8 +146,8 @@ Kubernaut integrates with Prometheus and AlertManager at two levels:
 
 | Service | Default URL | Override |
 |---|---|---|
-| Prometheus | `http://kube-prometheus-stack-prometheus.monitoring.svc:9090` | `effectivenessmonitor.external.prometheusUrl` |
-| AlertManager | `http://kube-prometheus-stack-alertmanager.monitoring.svc:9093` | `effectivenessmonitor.external.alertManagerUrl` |
+| Prometheus | (set via `monitoring.prometheus.url`) | `monitoring.prometheus.url` |
+| AlertManager | (set via `monitoring.alertManager.url`) | `monitoring.alertManager.url` |
 
 **2. AlertManager sends alerts to Gateway** -- The Gateway authenticates every signal ingestion request using Kubernetes TokenReview + SubjectAccessReview (SAR). AlertManager must include a bearer token in its webhook requests. See [Signal Source Authentication](#signal-source-authentication) below for the full configuration.
 
@@ -360,7 +360,7 @@ helm install kubernaut oci://quay.io/kubernaut-ai/charts/kubernaut \
   --namespace kubernaut-system \
   --set-file kubernautAgent.sdkConfigContent=my-sdk-config.yaml \
   --set-file aianalysis.policies.content=my-approval.rego \
-  --set-file signalprocessing.policy=my-policy.rego
+  --set-file signalprocessing.policies.content=my-policy.rego
 ```
 
 See the [sdk-config.yaml.example](https://github.com/jordigilh/kubernaut-demo-scenarios/blob/main/helm/sdk-config.yaml.example) for a reference SDK config covering Vertex AI, Anthropic, OpenAI, and local models.

--- a/docs/user-guide/configmap-kubernaut-agent.md
+++ b/docs/user-guide/configmap-kubernaut-agent.md
@@ -195,22 +195,25 @@ Empirical testing shows that loading a single unused toolset (Prometheus, 123 to
 ### Example: Minimal SDK Config (No Optional Toolsets)
 
 ```yaml
-llm:
-  provider: openai
-  model: gpt-4o
-  temperature: 0.5
+ai:
+  llm:
+    provider: openai
+    model: gpt-4o
+    temperature: 0.5
 
-toolsets: {}
+integrations:
+  toolsets: {}
 ```
 
 Enable Prometheus only when investigating metric-driven alerts:
 
 ```yaml
-toolsets:
-  prometheus/metrics:
-    enabled: true
-    config:
-      prometheus_url: "http://kube-prometheus-stack-prometheus.monitoring.svc:9090"
+integrations:
+  toolsets:
+    prometheus/metrics:
+      enabled: true
+      config:
+        prometheusUrl: "http://kube-prometheus-stack-prometheus.monitoring.svc:9090"
 ```
 
 !!! note "Automatic toolset selection"
@@ -221,11 +224,12 @@ toolsets:
 ### OpenAI
 
 ```yaml
-llm:
-  provider: openai
-  model: gpt-4o
-  temperature: 0.7
-  timeout_seconds: 120
+ai:
+  llm:
+    provider: openai
+    model: gpt-4o
+    temperature: 0.7
+    timeoutSeconds: 120
 ```
 
 Secret: `kubectl create secret generic llm-credentials --from-literal=OPENAI_API_KEY=sk-...`
@@ -233,10 +237,11 @@ Secret: `kubectl create secret generic llm-credentials --from-literal=OPENAI_API
 ### OpenAI-Compatible (vLLM, LocalAI, TGI)
 
 ```yaml
-llm:
-  provider: openai
-  model: gpt-4o
-  endpoint: http://vllm.internal.svc:8000
+ai:
+  llm:
+    provider: openai
+    model: gpt-4o
+    endpoint: http://vllm.internal.svc:8000
 ```
 
 Set the `endpoint` to the server origin **without** `/v1` — the agent appends `/v1` automatically.
@@ -244,12 +249,13 @@ Set the `endpoint` to the server origin **without** `/v1` — the agent appends 
 ### Azure OpenAI
 
 ```yaml
-llm:
-  provider: azure
-  model: gpt-4o
-  endpoint: https://my-resource.openai.azure.com/
-  azure_api_version: "2024-02-15-preview"
-  timeout_seconds: 120
+ai:
+  llm:
+    provider: azure
+    model: gpt-4o
+    endpoint: https://my-resource.openai.azure.com/
+    azureApiVersion: "2024-02-15-preview"
+    timeoutSeconds: 120
 ```
 
 Secret: `kubectl create secret generic llm-credentials --from-literal=AZURE_API_KEY=...`
@@ -257,12 +263,13 @@ Secret: `kubectl create secret generic llm-credentials --from-literal=AZURE_API_
 ### Google Vertex AI (Gemini)
 
 ```yaml
-llm:
-  provider: vertex
-  model: gemini-2.5-pro
-  vertex_project: my-project-id
-  vertex_location: us-central1
-  timeout_seconds: 180
+ai:
+  llm:
+    provider: vertex
+    model: gemini-2.5-pro
+    vertexProject: my-project-id
+    vertexLocation: us-central1
+    timeoutSeconds: 180
 ```
 
 Secret: `kubectl create secret generic llm-credentials --from-file=application_default_credentials.json=service-account-key.json -n kubernaut-system`
@@ -272,12 +279,13 @@ The agent auto-detects `application_default_credentials.json` in the mounted sec
 ### Claude on Vertex AI
 
 ```yaml
-llm:
-  provider: vertex_ai
-  model: claude-sonnet-4-20250514
-  vertex_project: my-project-id
-  vertex_location: us-east5
-  timeout_seconds: 180
+ai:
+  llm:
+    provider: vertex_ai
+    model: claude-sonnet-4-20250514
+    vertexProject: my-project-id
+    vertexLocation: us-east5
+    timeoutSeconds: 180
 ```
 
 Uses the Anthropic Go SDK directly (not LangChainGo). Requires Vertex AI Model Garden access.
@@ -285,10 +293,11 @@ Uses the Anthropic Go SDK directly (not LangChainGo). Requires Vertex AI Model G
 ### Anthropic (Direct)
 
 ```yaml
-llm:
-  provider: anthropic
-  model: claude-sonnet-4-20250514
-  timeout_seconds: 180
+ai:
+  llm:
+    provider: anthropic
+    model: claude-sonnet-4-20250514
+    timeoutSeconds: 180
 ```
 
 Secret: `kubectl create secret generic llm-credentials --from-literal=ANTHROPIC_API_KEY=...`
@@ -296,10 +305,11 @@ Secret: `kubectl create secret generic llm-credentials --from-literal=ANTHROPIC_
 ### Ollama (Local / Air-Gapped)
 
 ```yaml
-llm:
-  provider: ollama
-  model: llama3
-  endpoint: http://ollama.internal.svc:11434
+ai:
+  llm:
+    provider: ollama
+    model: llama3
+    endpoint: http://ollama.internal.svc:11434
 ```
 
 Recommended for disconnected/air-gapped environments. See [Disconnected Installation](../operations/disconnected-install.md) for setup guidance.

--- a/docs/user-guide/configmap-policies.md
+++ b/docs/user-guide/configmap-policies.md
@@ -8,7 +8,7 @@ The SignalProcessing controller uses a single Rego policy file (`policy.rego`) f
 |---|---|
 | ConfigMap name | `signalprocessing-policy` (Rego) + `signalprocessing-proactive-signal-mappings` (optional, YAML) |
 | Mount path | `/etc/signalprocessing/policy.rego` (Rego) + `/etc/signalprocessing/proactive-signal-mappings.yaml` (mappings) |
-| Required | Yes -- chart fails at install if neither `signalprocessing.policy` nor `signalprocessing.existingPolicyConfigMap` is set |
+| Required | Yes -- chart fails at install if neither `signalprocessing.policies.content` nor `signalprocessing.policies.existingConfigMap` is set |
 
 ## Provisioning
 
@@ -18,7 +18,7 @@ Provide a single `.rego` file directly:
 
 ```bash
 helm install kubernaut charts/kubernaut/ \
-  --set-file signalprocessing.policy=my-policy.rego \
+  --set-file signalprocessing.policies.content=my-policy.rego \
   ...
 ```
 
@@ -32,7 +32,7 @@ kubectl create configmap signalprocessing-policy \
   -n kubernaut-system
 
 helm install kubernaut charts/kubernaut/ \
-  --set signalprocessing.existingPolicyConfigMap=signalprocessing-policy \
+  --set signalprocessing.policies.existingConfigMap=signalprocessing-policy \
   ...
 ```
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -103,6 +103,9 @@ Image paths are constructed as `{registry}{separator}{namespace}{separator}{serv
 | `gateway.config.server.maxConcurrentRequests` | Maximum concurrent request processing | `100` |
 | `gateway.config.server.readTimeout` | HTTP read timeout | `30s` |
 | `gateway.config.server.writeTimeout` | HTTP write timeout | `30s` |
+| `gateway.config.server.k8sRequestTimeout` | Timeout for Kubernetes API requests (TokenReview, SAR) | `15s` |
+| `gateway.config.middleware.trustedProxyCIDRs` | Trusted proxy CIDRs for `X-Forwarded-For` extraction. Empty = fail-closed (proxy headers never trusted). | `[]` |
+| `gateway.config.cors.allowedOrigins` | CORS allowed origins. Gateway is an M2M API; the default rejects all browser clients. | `https://no-browser-clients.invalid` |
 | `gateway.config.deduplication.cooldownPeriod` | Signal deduplication cooldown | `5m` |
 | `gateway.auth.signalSources` | External signal sources requiring RBAC | `[]` |
 
@@ -195,22 +198,25 @@ All controllers (`aianalysis`, `signalprocessing`, `remediationorchestrator`, `w
 
 ### EffectivenessMonitor
 
-Beginning with **v1.4**, Prometheus and AlertManager knobs are flattened into a single Helm subtree: **`effectivenessmonitor.monitoring`**, replacing **`effectivenessmonitor.external.*`** (see the introductory **v1.4 configuration highlights** callout).
-
 | Parameter | Description | Default |
 |---|---|---|
 | `effectivenessmonitor.config.assessment.stabilizationWindow` | EM-internal stabilization window (logged at startup). **Note:** the actual stabilization delay enforced by the EM reconciler is read from `EA.spec.config.stabilizationWindow`, which is set by the RO (default `5m` via `remediationorchestrator.config.effectivenessAssessment.stabilizationWindow`). | `30s` |
-| `effectivenessmonitor.config.assessment.validityWindow` | Time window for assessment validity | `300s` |
-| `effectivenessmonitor.config.assessment.maxConcurrentReconciles` | Maximum concurrent EA reconciliations | `5` |
-| `effectivenessmonitor.external.prometheusUrl` | Prometheus URL | `http://kube-prometheus-stack-prometheus.monitoring.svc:9090` |
-| `effectivenessmonitor.external.prometheusEnabled` | Enable Prometheus integration | `false` |
-| `effectivenessmonitor.external.alertManagerUrl` | AlertManager URL | `http://kube-prometheus-stack-alertmanager.monitoring.svc:9093` |
-| `effectivenessmonitor.external.alertManagerEnabled` | Enable AlertManager integration | `false` |
-| `effectivenessmonitor.external.connectionTimeout` | HTTP client timeout for Prometheus/AlertManager connections | `10s` |
-| `effectivenessmonitor.external.prometheusLookback` | Duration before EA creation to query Prometheus for baseline metrics. Min: `1m`. | `30m` |
-| `effectivenessmonitor.external.scrapeInterval` | Prometheus scrape interval used to derive requeue timing for metric assessment. Min: `5s`. | `60s` |
-| `effectivenessmonitor.external.tlsCaFile` | Path to PEM CA bundle for HTTPS connections to Prometheus/AlertManager. On OCP with `ocpMonitoringRbac`, set to `/etc/ssl/em/service-ca.crt` (auto-mounted). | `""` |
-| `effectivenessmonitor.external.ocpMonitoringRbac` | Create `cluster-monitoring-view` ClusterRoleBinding and (when `alertManagerEnabled`) a ClusterRole granting `monitoring.coreos.com/alertmanagers/api` access for OCP's `kube-rbac-proxy`. Also sets `IS_OPENSHIFT` env and auto-configures TLS CA trust via a service-CA ConfigMap. | `false` |
+| `effectivenessmonitor.config.assessment.validityWindow` | Time window for assessment validity | `120s` |
+
+Prometheus and AlertManager endpoints are configured via the **unified `monitoring` block** (see [Monitoring](#monitoring) below), not under `effectivenessmonitor`. The chart propagates `monitoring.*` values to both the EffectivenessMonitor and Kubernaut Agent.
+
+### Monitoring
+
+Beginning with **v1.4**, Prometheus and AlertManager connection settings are configured via a **top-level `monitoring` block** — a single source of truth propagated to both the EffectivenessMonitor and Kubernaut Agent.
+
+| Parameter | Description | Default |
+|---|---|---|
+| `monitoring.prometheus.enabled` | Enable Prometheus integration | `false` |
+| `monitoring.prometheus.url` | Prometheus URL | `""` |
+| `monitoring.prometheus.tlsCaFile` | Path to PEM CA bundle for HTTPS connections to Prometheus | `""` |
+| `monitoring.alertManager.enabled` | Enable AlertManager integration | `false` |
+| `monitoring.alertManager.url` | AlertManager URL | `""` |
+| `monitoring.alertManager.tlsCaFile` | Path to PEM CA bundle for HTTPS connections to AlertManager | `""` |
 
 ### AIAnalysis
 
@@ -228,12 +234,12 @@ One of `policies.content` or `policies.existingConfigMap` **must** be provided; 
 | Parameter | Description | Default |
 |---|---|---|
 | `signalprocessing.replicas` | Number of replicas | `1` |
-| `signalprocessing.policy` | Unified Rego policy content (via `--set-file`). Chart creates `signalprocessing-policy` ConfigMap. | `""` |
-| `signalprocessing.existingPolicyConfigMap` | Pre-existing ConfigMap name for the unified Rego policy. Takes priority over `policy`. | `""` |
+| `signalprocessing.policies.content` | Unified Rego policy content (via `--set-file`). Chart creates `signalprocessing-policy` ConfigMap. | `""` |
+| `signalprocessing.policies.existingConfigMap` | Pre-existing ConfigMap name for the unified Rego policy. Takes priority over `policies.content`. | `""` |
 | `signalprocessing.proactiveSignalMappings.content` | Proactive signal mappings YAML (via `--set-file`). Chart creates ConfigMap. | `""` |
 | `signalprocessing.proactiveSignalMappings.existingConfigMap` | Pre-existing ConfigMap name for proactive signal mappings. | `""` |
 
-One of `policy` or `existingPolicyConfigMap` **must** be provided; the chart fails at install if neither is set. The policy file is a single `.rego` file (not a YAML bundle) containing all classification rules under `package signalprocessing`. Proactive signal mappings are optional and injected separately. See [SignalProcessing Rego Policies](configmap-policies.md) for the policy structure and customization guide.
+One of `policies.content` or `policies.existingConfigMap` **must** be provided; the chart fails at install if neither is set. The policy file is a single `.rego` file (not a YAML bundle) containing all classification rules under `package signalprocessing`. Proactive signal mappings are optional and injected separately. See [SignalProcessing Rego Policies](configmap-policies.md) for the policy structure and customization guide.
 
 ### PostgreSQL
 
@@ -362,6 +368,26 @@ Individual `RemediationRequest` resources can override timeouts via `spec.timeou
 
 These settings prevent remediation storms and avoid repeating failed approaches.
 
+### Async Propagation Delays
+
+| Parameter | Default | Description |
+|---|---|---|
+| `remediationorchestrator.config.asyncPropagation.gitOpsSyncDelay` | `3m` | Wait time for GitOps (ArgoCD/Flux) to sync before effectiveness assessment |
+| `remediationorchestrator.config.asyncPropagation.operatorReconcileDelay` | `1m` | Wait time for operator-managed resources to reconcile |
+| `remediationorchestrator.config.asyncPropagation.proactiveAlertDelay` | `5m` | Wait time for proactive alert resolution before assessment |
+
+### Notification Settings
+
+| Parameter | Default | Description |
+|---|---|---|
+| `remediationorchestrator.config.notifications.notifySelfResolved` | `false` | Emit a notification when a remediation self-resolves (alert clears before execution) |
+
+### CRD Retention
+
+| Parameter | Default | Description |
+|---|---|---|
+| `remediationorchestrator.config.retention.period` | `24h` | Time-to-live for completed RemediationRequest CRDs before automatic cleanup |
+
 ## Execution Namespace
 
 Workflow Jobs and Tekton PipelineRuns execute in a dedicated namespace, separate from the target resource's namespace. This creates a security boundary.
@@ -370,6 +396,7 @@ Workflow Jobs and Tekton PipelineRuns execute in a dedicated namespace, separate
 |---|---|---|
 | `workflowexecution.workflowNamespace` | `kubernaut-workflows` | Namespace for workflow execution |
 | `workflowexecution.config.execution.cooldownPeriod` | `1m` | Cooldown between executions |
+| `workflowexecution.config.tekton.enabled` | `nil` | Tekton Pipelines engine toggle. `nil` or `true` = auto-discover Tekton CRDs at startup; `false` = disable Tekton engine. |
 
 The `kubernaut-workflow-runner` ServiceAccount has pre-configured RBAC to read and patch resources across namespaces. See [Security & RBAC -- Workflow Execution](../architecture/security-rbac.md#workflow-execution) for the full permission list.
 
@@ -465,15 +492,6 @@ Kubernaut configures **inter-service TLS** (REST between components) and **admis
 ### Inter-service TLS (Helm)
 
 These values control mTLS and HTTPS for internal service-to-service calls (for example, Gateway → DataStorage). When the server finds TLS material under `tls.interService.certDir`, the primary API port (**8080**) uses HTTPS; health (**8081**) and metrics (**9090**) stay plain HTTP.
-
-!!! note "TLS Security Profiles (v1.4)"
-    The `tls.profile` field (v1.4) selects a built-in cipher/protocol profile applied to all inter-service listeners:
-
-    | Profile | TLS Versions | Description |
-    |---|---|---|
-    | **Modern** | TLS 1.3 only | Strictest — recommended for new deployments |
-    | **Intermediate** (default) | TLS 1.2–1.3 | Balanced — compatible with most clients |
-    | **Old** | TLS 1.0–1.3 | Legacy — use only for backward-compatible environments |
 
 | Parameter | Description | Default |
 |---|---|---|

--- a/docs/user-guide/policies.md
+++ b/docs/user-guide/policies.md
@@ -300,7 +300,7 @@ See the [Rego Reference](rego-reference.md#ai-analysis-approval-policy) for the 
 
 | Policy | Provisioning |
 |---|---|
-| SP unified policy (`policy.rego`) | User-provided via `--set-file signalprocessing.policy=...` or `existingPolicyConfigMap` |
+| SP unified policy (`policy.rego`) | User-provided via `--set-file signalprocessing.policies.content=...` or `policies.existingConfigMap` |
 | SP proactive signal mappings | User-provided via `--set-file signalprocessing.proactiveSignalMappings.content=...` or `existingConfigMap` |
 | AA approval | User-provided via `--set-file aianalysis.policies.content=...` or `existingConfigMap` |
 


### PR DESCRIPTION
## Summary

Cross-reference audit of all per-service configuration documentation against the actual `charts/kubernaut/values.yaml` in v1.4.1. Fixes 10 findings that affect user install workflows.

**High severity (break user installs):**
- **F1+F8**: Replace stale `effectivenessmonitor.external.*` Helm paths with the actual `monitoring.*` top-level block in `configuration.md` and `installation.md`
- **F2**: Fix `signalprocessing.policy` → `signalprocessing.policies.content` and `signalprocessing.existingPolicyConfigMap` → `signalprocessing.policies.existingConfigMap` across 4 files
- **F3+F12**: Rewrite all KA SDK provider/toolset examples from snake_case flat layout to v1.4 camelCase three-domain structure (`ai.llm.timeoutSeconds`, `integrations.toolsets`, etc.)

**Medium severity:**
- **F5**: Fix EM `validityWindow` default from `300s` to `120s`
- **F6**: Add undocumented RO config sub-blocks (`asyncPropagation`, `notifications`, `retention`)
- **F7**: Remove phantom `tls.profile` section (not implemented in chart)

**Low severity:**
- **F9**: Add Gateway `k8sRequestTimeout`, `trustedProxyCIDRs`, `cors.allowedOrigins`
- **F11**: Add WorkflowExecution Tekton engine toggle note

## Out of scope (v1.5-only)

The following findings are tracked in a separate issue for the v1.5 docs milestone:
- **F4**: API Frontend service documentation (does not exist in v1.4.1)
- **F10**: DataStorage advanced config fields (`server`, `redis`, `retention` sub-blocks -- v1.5 additions)

## Files changed

| File | Findings |
|---|---|
| `docs/user-guide/configuration.md` | F1, F5, F6, F7, F9, F11 |
| `docs/user-guide/configmap-kubernaut-agent.md` | F3, F12 |
| `docs/user-guide/configmap-policies.md` | F2 |
| `docs/user-guide/policies.md` | F2 |
| `docs/getting-started/installation.md` | F2, F8 |

## Test plan

- [ ] Verify `mkdocs build` succeeds without warnings
- [ ] Spot-check that all Helm value paths match `charts/kubernaut/values.yaml` at tag `v1.4.1`
- [ ] Confirm no broken internal links


Made with [Cursor](https://cursor.com)