### PR TITLE
docs: rewrite disconnected install for OLM-first deployment (v1.5.0-rc2)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -58,7 +58,7 @@ jobs:
             VERSION="v1.5"
           fi
 
-          if [ "$VERSION" = "v1.5" ]; then
+          if [ "$VERSION" = "v1.4" ]; then
             mike deploy --push --update-aliases "$VERSION" latest
           else
             mike deploy --push "$VERSION"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  KUBERNAUT_RELEASE: v1.4.1
+  KUBERNAUT_RELEASE: v1.5.0-rc2
 
 jobs:
   deploy:
@@ -55,10 +55,10 @@ jobs:
         run: |
           VERSION="${{ github.event.inputs.version }}"
           if [ -z "$VERSION" ]; then
-            VERSION="v1.4"
+            VERSION="v1.5"
           fi
 
-          if [ "$VERSION" = "v1.4" ]; then
+          if [ "$VERSION" = "v1.5" ]; then
             mike deploy --push --update-aliases "$VERSION" latest
           else
             mike deploy --push "$VERSION"

--- a/docs/getting-started/architecture-overview.md
+++ b/docs/getting-started/architecture-overview.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-Kubernaut is a microservices platform with 10 services that communicate through Kubernetes Custom Resources (CRDs). This page provides a high-level view of how the services work together.
+Kubernaut is a microservices platform with 11 services (v1.5+; 10 in v1.4) that communicate through Kubernetes Custom Resources (CRDs). This page provides a high-level view of how the services work together.
 
 ## System Diagram
 
@@ -100,7 +100,7 @@ For a detailed breakdown of all sub-phases and tools, see the [Architecture: Inv
 
 ## Services
 
-Kubernaut runs **10 services**: 6 CRD controllers, 2 stateless HTTP services, 1 admission webhook, and 1 Go API service.
+Kubernaut runs **11 services** (v1.5+): 6 CRD controllers, 2 stateless HTTP services, 1 admission webhook, 1 Go API service, and the API Frontend.
 
 ### CRD Controllers
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,7 +14,7 @@ Kubernaut offers two deployment methods:
 
 ## Kubernaut Operator (Production)
 
-The Kubernaut Operator manages the full lifecycle of the Kubernaut platform on OpenShift: secret validation, database migrations, CRD installation, deployment of all 10 microservices, RBAC, NetworkPolicies, OCP Routes, and status reporting. It is a singleton — one `Kubernaut` CR named `kubernaut` per cluster.
+The Kubernaut Operator manages the full lifecycle of the Kubernaut platform on OpenShift: secret validation, database migrations, CRD installation, deployment of all 11 microservices (v1.5+; 10 in v1.4), RBAC, NetworkPolicies, OCP Routes, and status reporting. It is a singleton — one `Kubernaut` CR named `kubernaut` per cluster.
 
 ### Installation
 
@@ -66,7 +66,7 @@ spec:
 - Validates BYO PostgreSQL and Valkey secrets before deployment
 - Runs embedded database schema migrations
 - Installs and upgrades the 9 Kubernaut workload CRDs
-- Deploys all 10 microservices with RBAC, ConfigMaps, PDBs, admission webhooks, and NetworkPolicies
+- Deploys all 11 microservices (v1.5+; 10 in v1.4) with RBAC, ConfigMaps, PDBs, admission webhooks, and NetworkPolicies
 - Configures OCP Routes and service-serving CA TLS
 - Reports per-service readiness status on the `Kubernaut` CR
 - Cleans up cluster-scoped RBAC and workflow namespace on CR deletion (workload CRDs are retained by design)

--- a/docs/operations/disconnected-install.md
+++ b/docs/operations/disconnected-install.md
@@ -1,54 +1,354 @@
 # Disconnected (Air-Gapped) Installation
 
-Install Kubernaut on a disconnected OpenShift cluster by mirroring all container images to a private registry and layering the `values-airgap.yaml` Helm overlay. The chart deploys ~12 microservices plus PostgreSQL, Valkey, and several hook Jobs -- all of which require pre-mirrored images.
+Kubernaut supports two deployment methods for disconnected OpenShift clusters. The **Kubernaut Operator** (OLM) is the production method; the **Helm chart** is available for development and testing only.
+
+| Method | Mirroring | Image redirection | Install |
+|---|---|---|---|
+| **Operator (OLM)** | `oc-mirror` reads the operator catalog and discovers all images automatically from `relatedImages` | IDMS/ICSP — transparent CRI-O rewrite, no application-level changes | OperatorHub / `Subscription` CR |
+| **Helm chart** | Manual `ImageSetConfiguration` listing every image | `values-airgap.yaml` overlay overriding image refs | `helm install` with layered overlays |
+
+!!! warning "Production deployments"
+    The Kubernaut Operator is the only supported production deployment method for disconnected environments. The Helm chart path is retained for development and testing only.
 
 ## Prerequisites
 
 | Requirement | Details |
-|-------------|---------|
-| **Bastion host** | A machine with access to both the public internet and your mirror registry. Used to run `oc mirror`. |
+|---|---|
+| **Bastion host** | A machine with access to both the public internet and your mirror registry. Used to run `oc-mirror`. |
 | **Mirror registry** | A container registry accessible from the disconnected cluster (Quay, Harbor, Nexus, or the OCP integrated registry). |
-| **`oc` CLI + `oc mirror` plugin** | OpenShift CLI 4.13+. Install the mirror plugin per [OCP documentation](https://docs.openshift.com/container-platform/latest/installing/disconnected_install/installing-mirroring-disconnected.html). |
-| **`helm` CLI** | Helm 3.12 or later. |
+| **`oc` CLI + `oc-mirror` v2** | OpenShift CLI 4.18+. `oc-mirror` v1 is deprecated as of OCP 4.18; use v2. Install per [OCP documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/disconnected_environments/installing-mirroring-disconnected). |
 | **Cluster admin access** | `cluster-admin` privileges on the target disconnected cluster. |
-| **Kubernaut chart source** | A clone of [github.com/jordigilh/kubernaut](https://github.com/jordigilh/kubernaut) on the bastion host. |
+| **PostgreSQL 15+** | **BYO** — the operator does not deploy a database. Provide connection details via `spec.postgresql` in the Kubernaut CR. |
+| **Valkey / Redis 7+** | **BYO** — provide connection details via `spec.valkey` in the Kubernaut CR. |
 
 !!! info "LLM endpoint"
     The Kubernaut Agent requires an LLM. In a disconnected environment, deploy a locally hosted LLM accessible from inside the cluster — either **Ollama** or any **OpenAI-compatible endpoint** (vLLM, LocalAI, TGI). Configure the endpoint in your SDK config file (see [Kubernaut Agent SDK Config](../user-guide/configmap-kubernaut-agent.md)). LangChainGo subprocess mode (`local`) is explicitly not supported for security reasons.
 
 ---
 
-## Step 1: Identify all images
+## Operator (OLM) — Production
 
-### Kubernaut service images
+The operator catalog contains the bundle metadata (CSV, CRDs) and declares every operand image in `relatedImages`. The `oc-mirror` tool reads the catalog, discovers all images, and mirrors them in one pass. On the disconnected cluster, an `ImageDigestMirrorSet` (IDMS) transparently redirects image pulls from the source registries to your mirror at the CRI-O level.
+
+### Images
+
+The operator catalog embeds references to all required images. You do **not** need to maintain a manual image list — `oc-mirror` discovers them automatically from the CSV `relatedImages` section.
+
+For reference, the full set (17 images) is:
+
+| Layer | Image | Purpose |
+|---|---|---|
+| **Catalog** | `quay.io/kubernaut-ai/kubernaut-operator-catalog:v{{ image_tag }}` | OLM index — makes the operator visible in OperatorHub |
+| **Bundle** | `quay.io/kubernaut-ai/kubernaut-operator-bundle:v{{ image_tag }}` | CSV + CRDs + metadata for a specific version |
+| **Operator** | `quay.io/kubernaut-ai/kubernaut-operator@sha256:...` | Controller manager binary |
+| **Operands** | | |
+| | `quay.io/kubernaut-ai/gateway` | Signal ingestion webhook |
+| | `quay.io/kubernaut-ai/datastorage` | Audit trail and workflow catalog persistence |
+| | `quay.io/kubernaut-ai/aianalysis` | Root cause analysis controller |
+| | `quay.io/kubernaut-ai/signalprocessing` | Signal deduplication and enrichment |
+| | `quay.io/kubernaut-ai/remediationorchestrator` | Remediation workflow orchestration |
+| | `quay.io/kubernaut-ai/workflowexecution` | Job / Tekton execution engine |
+| | `quay.io/kubernaut-ai/notification` | Notification delivery (Slack, Teams, PagerDuty) |
+| | `quay.io/kubernaut-ai/effectivenessmonitor` | Post-remediation effectiveness verification |
+| | `quay.io/kubernaut-ai/kubernautagent` | LLM integration service |
+| | `quay.io/kubernaut-ai/authwebhook` | Admission controller for CRD authorization |
+| | `quay.io/kubernaut-ai/apifrontend` | API Frontend service (new in v1.5) |
+| | `quay.io/kubernaut-ai/db-migrate` | Database schema migration |
+| **Init images** | | |
+| | `registry.redhat.io/rhel10/postgresql-16` | PostgreSQL client for init containers |
+| | `registry.access.redhat.com/ubi10/ubi-minimal` | Minimal UBI for init containers |
+
+### Step 1: Create the ImageSetConfiguration
+
+On the bastion host, create an `ImageSetConfiguration` referencing the operator catalog:
+
+```yaml
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+storageConfig:
+  local:
+    path: ./kubernaut-mirror
+mirror:
+  operators:
+    - catalog: quay.io/kubernaut-ai/kubernaut-operator-catalog:v{{ image_tag }}
+      packages:
+        - name: kubernaut-operator
+          channels:
+            - name: alpha
+```
+
+This is all you need. `oc-mirror` reads the catalog index, finds the bundle for the specified channel, parses the CSV, and discovers every image from `relatedImages` and the operator deployment spec automatically.
+
+### Step 2: Mirror images
+
+From the bastion host:
+
+```bash
+oc-mirror --config imageset-config.yaml \
+  docker://<mirror-registry>
+```
+
+Replace `<mirror-registry>` with your private registry hostname (e.g., `mirror.corp.example.com:5000`).
+
+`oc-mirror` v2 supports three workflows depending on your network topology:
+
+| Workflow | Use case |
+|---|---|
+| `mirrorToMirror` (default) | Bastion has access to both internet and mirror registry |
+| `mirrorToDisk` + `diskToMirror` | Bastion has internet only; transfer archive to disconnected side via removable media |
+
+For the two-step workflow:
+
+```bash
+# On bastion (internet access):
+oc-mirror --config imageset-config.yaml \
+  file://kubernaut-archive
+
+# Transfer kubernaut-archive/ to disconnected side, then:
+oc-mirror --from kubernaut-archive \
+  docker://<mirror-registry>
+```
+
+### Step 3: Apply mirroring artifacts
+
+`oc-mirror` generates IDMS (or ICSP for OCP < 4.13) and CatalogSource manifests in the results directory:
+
+```bash
+oc apply -f oc-mirror-workspace/results-*/
+```
+
+This creates:
+
+- An `ImageDigestMirrorSet` that tells CRI-O to redirect pulls from `quay.io/kubernaut-ai/*` and `registry.redhat.io/*` to your mirror registry
+- A `CatalogSource` pointing at the mirrored operator catalog in your internal registry
+
+!!! note
+    IDMS only redirects **digest-based** image references. All images in the operator CSV use `@sha256:` digests, so this works transparently.
+
+### Step 4: Configure the global pull secret
+
+Add your mirror registry credentials so every node can pull from it:
+
+```bash
+# Export current pull secret
+oc get secret/pull-secret -n openshift-config \
+  -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d > pull-secret.json
+
+# Add mirror registry credentials
+oc registry login --registry=<mirror-registry> \
+  --auth-basic=<username>:<password> \
+  --to=pull-secret.json
+
+# Update the cluster
+oc set data secret/pull-secret -n openshift-config \
+  --from-file=.dockerconfigjson=pull-secret.json
+```
+
+!!! warning
+    Updating the global pull secret triggers a rolling restart of all nodes via the Machine Config Operator. This can take 15--30 minutes depending on cluster size.
+
+### Step 5: Install the operator
+
+The operator now appears in OperatorHub. Install it the same way as on a connected cluster:
+
+**Option A: OpenShift Console**
+
+Navigate to **Operators > OperatorHub**, search for "Kubernaut", and click **Install**. Select the target namespace and approval strategy.
+
+**Option B: CLI**
+
+```bash
+# Create the operator namespace
+oc create namespace kubernaut
+
+# Create the OperatorGroup
+cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kubernaut-operator
+  namespace: kubernaut
+spec:
+  targetNamespaces:
+    - kubernaut
+EOF
+
+# Create the Subscription
+cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubernaut-operator
+  namespace: kubernaut
+spec:
+  channel: alpha
+  name: kubernaut-operator
+  source: cs-kubernaut-operator-catalog
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+EOF
+```
+
+!!! tip
+    The `source` name matches the CatalogSource created by `oc-mirror`. Check the exact name with `oc get catalogsource -n openshift-marketplace`.
+
+Wait for the operator to reach `Succeeded`:
+
+```bash
+oc get csv -n kubernaut -w
+```
+
+### Step 6: Provision secrets and create the Kubernaut CR
+
+Pre-create the required secrets for your BYO PostgreSQL, Valkey, and LLM:
+
+```bash
+oc create namespace kubernaut-system
+
+# PostgreSQL connection
+oc create secret generic kubernaut-postgresql \
+  --from-literal=username=slm_user \
+  --from-literal=password=<your-pg-password> \
+  --from-literal=db-secrets.yaml="$(printf 'username: slm_user\npassword: %s' "<your-pg-password>")" \
+  -n kubernaut-system
+
+# Valkey connection
+oc create secret generic kubernaut-valkey \
+  --from-literal=valkey-secrets.yaml="$(printf 'password: %s' "<your-valkey-password>")" \
+  -n kubernaut-system
+
+# LLM credentials (for local LLM, the key may be a placeholder)
+oc create secret generic kubernaut-llm \
+  --from-literal=OPENAI_API_KEY=<your-local-llm-key> \
+  -n kubernaut-system
+```
+
+Create the Kubernaut CR:
+
+```yaml
+apiVersion: kubernaut.ai/v1alpha1
+kind: Kubernaut
+metadata:
+  name: kubernaut
+  namespace: kubernaut-system
+spec:
+  postgresql:
+    host: postgres.database.svc.cluster.local
+    secretName: kubernaut-postgresql
+  valkey:
+    host: valkey.cache.svc.cluster.local
+    secretName: kubernaut-valkey
+  kubernautAgent:
+    llm:
+      provider: openai
+      model: llama3
+      endpoint: http://ollama.internal.svc:11434
+      credentialsSecretName: kubernaut-llm
+```
+
+No image overrides are needed — the operator reads `RELATED_IMAGE_*` env vars set by OLM, and IDMS transparently redirects them to the mirror registry.
+
+!!! note "PostgreSQL TLS"
+    The default `sslMode` is `verify-full` (v1.5+). If your PostgreSQL instance does not use TLS, set `spec.postgresql.sslMode: disable` in the CR.
+
+### Per-component image overrides (optional)
+
+If you need to override individual component images without cluster-wide IDMS (e.g., testing a custom build), use `spec.image.overrides` in the Kubernaut CR:
+
+```yaml
+spec:
+  image:
+    overrides:
+      gateway: "<mirror-registry>/kubernaut-ai/gateway@sha256:..."
+      datastorage: "<mirror-registry>/kubernaut-ai/datastorage@sha256:..."
+      apifrontend: "<mirror-registry>/kubernaut-ai/apifrontend@sha256:..."
+```
+
+The operator resolves images in this order:
+
+1. `spec.image.overrides[componentName]` — CR-level override (highest priority)
+2. `RELATED_IMAGE_<SUFFIX>` env var — set by OLM, rewritten by IDMS
+3. Error if neither is set
+
+### Step 7: Verify the installation
+
+```bash
+# Operator status
+oc get csv -n kubernaut
+
+# Kubernaut CR status
+oc get kubernaut -n kubernaut-system
+
+# All pods should be Running
+oc get pods -n kubernaut-system
+```
+
+If any pod is stuck in `ImagePullBackOff`:
+
+```bash
+oc describe pod <pod-name> -n kubernaut-system | grep -A5 "Events:"
+```
+
+Common causes:
+
+- Image not mirrored — re-run `oc-mirror`
+- Mirror credentials missing from global pull secret — re-run [Step 4](#step-4-configure-the-global-pull-secret)
+- IDMS not applied — check `oc get imagedigestmirrorset`
+
+Verify the actual image reference a pod is using:
+
+```bash
+oc get pod <pod-name> -n kubernaut-system \
+  -o jsonpath='{.spec.containers[0].image}'
+```
+
+---
+
+## Helm Chart — Development/Testing Only
+
+!!! warning
+    The Helm chart is intended for development and testing only. For production disconnected deployments, use the [Operator (OLM)](#operator-olm-production) method above.
+
+The Helm-based airgap flow requires manually listing all images, mirroring them, and overriding image references via `values-airgap.yaml`. This section is retained for environments where OLM is not available.
+
+### Prerequisites (Helm)
+
+| Requirement | Details |
+|---|---|
+| **`helm` CLI** | Helm 3.12 or later |
+| **Kubernaut chart source** | A clone of [github.com/jordigilh/kubernaut](https://github.com/jordigilh/kubernaut) on the bastion host |
+
+### Step 1: Identify all images
+
+#### Kubernaut service images
 
 All published under `quay.io/kubernaut-ai/` with a tag matching the chart version:
 
 | Image | Description |
-|-------|-------------|
+|---|---|
 | `quay.io/kubernaut-ai/gateway` | Signal ingestion webhook |
 | `quay.io/kubernaut-ai/datastorage` | Audit trail and workflow catalog persistence |
 | `quay.io/kubernaut-ai/aianalysis` | Root cause analysis controller |
 | `quay.io/kubernaut-ai/signalprocessing` | Signal deduplication and enrichment |
 | `quay.io/kubernaut-ai/remediationorchestrator` | Remediation workflow orchestration |
 | `quay.io/kubernaut-ai/workflowexecution` | Job / Tekton execution engine |
-| `quay.io/kubernaut-ai/notification` | Notification delivery (Slack, console) |
+| `quay.io/kubernaut-ai/notification` | Notification delivery (Slack, Teams, PagerDuty) |
 | `quay.io/kubernaut-ai/effectivenessmonitor` | Post-remediation effectiveness verification |
-| `quay.io/kubernaut-ai/kubernaut-agent` | LLM integration service |
+| `quay.io/kubernaut-ai/kubernautagent` | LLM integration service |
 | `quay.io/kubernaut-ai/authwebhook` | Admission controller for CRD authorization |
+| `quay.io/kubernaut-ai/apifrontend` | API Frontend service (new in v1.5) |
 | `quay.io/kubernaut-ai/db-migrate` | Database schema migration (pre-upgrade hook) |
 | `quay.io/kubernaut-ai/must-gather` | Diagnostic data collection for support |
 
-### Infrastructure images
+#### Infrastructure images
 
 | Image | Description |
-|-------|-------------|
+|---|---|
 | `registry.redhat.io/rhel10/postgresql-16` | PostgreSQL 16 (Red Hat RHEL10) |
 | `registry.redhat.io/rhel10/valkey-8` | Valkey 8 (Red Hat RHEL10) |
 | `registry.redhat.io/openshift4/ose-cli-rhel9:v4.17` | OCP CLI for TLS certificate hook Jobs |
-| `quay.io/kubernaut-ai/db-migrate:{{ image_tag }}` | Database migrations (goose + psql on UBI9) |
 
-### Automated image list
+#### Automated image list
 
 Use the included script to extract the exact images from the chart templates:
 
@@ -58,15 +358,9 @@ Use the included script to extract the exact images from the chart templates:
   -f charts/kubernaut/values-ocp.yaml
 ```
 
-This outputs one image per line -- the authoritative list of everything to mirror.
+### Step 2: Mirror images
 
----
-
-## Step 2: Mirror images to your registry
-
-### 2a. Prepare the ImageSetConfiguration
-
-Copy the template and replace the version placeholder:
+Prepare the `ImageSetConfiguration`:
 
 ```bash
 cp hack/airgap/imageset-config.yaml.tmpl imageset-config.yaml
@@ -85,23 +379,19 @@ mirror:
   additionalImages:
     - name: quay.io/kubernaut-ai/gateway:{{ image_tag }}
     - name: quay.io/kubernaut-ai/datastorage:{{ image_tag }}
-    # ... all 10 Kubernaut services ...
+    # ... all Kubernaut services ...
     - name: quay.io/kubernaut-ai/db-migrate:{{ image_tag }}
     - name: registry.redhat.io/rhel10/postgresql-16
     - name: registry.redhat.io/rhel10/valkey-8
     - name: registry.redhat.io/openshift4/ose-cli-rhel9:v4.17
 ```
 
-### 2b. Run oc mirror
-
-From the bastion host:
+Run the mirror:
 
 ```bash
 oc mirror --config=imageset-config.yaml \
   docker://<mirror-registry>
 ```
-
-Replace `<mirror-registry>` with your private registry hostname (e.g., `mirror.corp.example.com:5000`). Multi-architecture manifests (amd64 + arm64) are handled automatically.
 
 !!! tip "Alternative: skopeo"
     For individual images (nested registry):
@@ -110,14 +400,6 @@ Replace `<mirror-registry>` with your private registry hostname (e.g., `mirror.c
     skopeo copy \
       docker://quay.io/kubernaut-ai/gateway:{{ image_tag }} \
       docker://harbor.corp/kubernaut-ai/gateway:{{ image_tag }}
-    ```
-
-    For flat registries (quay.io, Docker Hub) use dash-joined names:
-
-    ```bash
-    skopeo copy \
-      docker://quay.io/kubernaut-ai/gateway:{{ image_tag }} \
-      docker://quay.io/myorg/kubernaut-ai-gateway:{{ image_tag }}
     ```
 
     `oc mirror` is preferred because it processes all images in one pass and preserves multi-arch manifests.
@@ -131,51 +413,17 @@ Replace `<mirror-registry>` with your private registry hostname (e.g., `mirror.c
       docker://<ocp-registry>/kubernaut-system/kubernaut-ai-gateway:{{ image_tag }}
     ```
 
-    This limitation does not affect `oc mirror`, which handles the OCP registry natively.
+### Step 3: Configure the global pull secret
 
----
+Same as the operator path — see [Step 4 above](#step-4-configure-the-global-pull-secret).
 
-## Step 3: Configure the global pull secret
+### Step 4: Install with Helm
 
-Add your mirror registry credentials to the OCP global pull secret so every node can pull from it.
-
-### 3a. Export the current pull secret
-
-```bash
-oc get secret/pull-secret -n openshift-config \
-  -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d > pull-secret.json
-```
-
-### 3b. Add mirror registry credentials
-
-```bash
-oc registry login --registry=<mirror-registry> \
-  --auth-basic=<username>:<password> \
-  --to=pull-secret.json
-```
-
-### 3c. Update the cluster
-
-```bash
-oc set data secret/pull-secret -n openshift-config \
-  --from-file=.dockerconfigjson=pull-secret.json
-```
-
-!!! warning
-    Updating the global pull secret triggers a rolling restart of all nodes via the Machine Config Operator. This can take 15-30 minutes depending on cluster size.
-
----
-
-## Step 4: Install the Kubernaut Helm chart
-
-### 4a. Provision secrets
-
-All database, cache, and LLM credentials must be pre-created before install. The chart validates their presence at template time.
+#### Provision secrets
 
 ```bash
 kubectl create namespace kubernaut-system
 
-# PostgreSQL + DataStorage (consolidated secret)
 PG_PASSWORD=$(openssl rand -base64 24)
 kubectl create secret generic postgresql-secret \
   --from-literal=POSTGRES_USER=slm_user \
@@ -184,12 +432,10 @@ kubectl create secret generic postgresql-secret \
   --from-literal=db-secrets.yaml="$(printf 'username: slm_user\npassword: %s' "$PG_PASSWORD")" \
   -n kubernaut-system
 
-# Valkey
 kubectl create secret generic valkey-secret \
   --from-literal=valkey-secrets.yaml="$(printf 'password: %s' "$(openssl rand -base64 24)")" \
   -n kubernaut-system
 
-# LLM credentials
 kubectl create secret generic llm-credentials \
   --from-literal=OPENAI_API_KEY=<your-local-llm-key> \
   -n kubernaut-system
@@ -197,9 +443,9 @@ kubectl create secret generic llm-credentials \
 
 See the [secret provisioning](../getting-started/installation.md#2-provision-secrets) reference for the full secret schema.
 
-### 4b. Edit the air-gap overlay
+#### Edit the air-gap overlay
 
-Replace every `<mirror-registry>` placeholder in `values-airgap.yaml` with your actual registry hostname:
+Replace every `<mirror-registry>` placeholder in `values-airgap.yaml`:
 
 ```bash
 sed -i 's/<mirror-registry>/mirror.corp.example.com:5000/g' \
@@ -226,224 +472,135 @@ hooks:
     image: <mirror-registry>/openshift4/ose-cli-rhel9:v4.17
 ```
 
-The `db-migrate` image tag is derived from `global.image.*`, so no separate override is needed.
-
 The `separator` field controls how the namespace is joined to the service name:
 
 | Separator | Result for gateway | Compatible registries |
-|-----------|-------------------|----------------------|
+|---|---|---|
 | `/` (default) | `<mirror>/kubernaut-ai/gateway:tag` | Harbor, Artifactory, generic Docker v2 |
 | `-` | `<mirror>/kubernaut-ai-gateway:tag` | quay.io, Docker Hub, OCP internal |
 
-### 4c. Install with layered overlays
+#### Install
 
-The two overlay files must be layered on top of the base `values.yaml` in this order:
+The two overlay files must be layered in this order:
 
 | Order | File | Purpose |
-|-------|------|---------|
+|---|---|---|
 | 1 | `values-ocp.yaml` | Red Hat images, OCP monitoring endpoints |
 | 2 | `values-airgap.yaml` | Overrides all image refs to point at your mirror registry |
 
 !!! important "Layering order"
-    `values-airgap.yaml` **must** come after `values-ocp.yaml`. It overrides the `registry.redhat.io` image references with your mirror registry. The `postgresql.variant: ocp` setting from `values-ocp.yaml` is preserved, ensuring correct PostgreSQL environment variable names and data directory paths.
+    `values-airgap.yaml` **must** come after `values-ocp.yaml`. It overrides the `registry.redhat.io` image references with your mirror registry.
 
 Prepare your SDK config file with the local LLM endpoint (see [Kubernaut Agent SDK Config](../user-guide/configmap-kubernaut-agent.md)):
 
 ```yaml
-# my-sdk-config.yaml — Ollama example
+# my-sdk-config.yaml
 llm:
   provider: ollama
   model: llama3
   endpoint: http://ollama.internal.svc:11434
 ```
 
-Alternatively, for an OpenAI-compatible server:
-
-```yaml
-# my-sdk-config.yaml — OpenAI-compatible example
-llm:
-  provider: openai
-  model: gpt-4o
-  endpoint: http://vllm.internal.svc:8000
-```
-
-**Nested registry** (Harbor, Artifactory):
+Install:
 
 ```bash
 helm install kubernaut charts/kubernaut/ \
   --namespace kubernaut-system \
   -f charts/kubernaut/values-ocp.yaml \
   -f charts/kubernaut/values-airgap.yaml \
-  --set global.image.registry=harbor.corp \
   --set-file kubernautAgent.sdkConfigContent=my-sdk-config.yaml
 ```
 
-**Flat registry** (quay.io, OCP internal):
-
-```bash
-helm install kubernaut charts/kubernaut/ \
-  --namespace kubernaut-system \
-  -f charts/kubernaut/values-ocp.yaml \
-  -f charts/kubernaut/values-airgap.yaml \
-  --set global.image.registry=quay.io/myorg \
-  --set global.image.separator=- \
-  --set-file kubernautAgent.sdkConfigContent=my-sdk-config.yaml
-```
-
-If you used custom secret names in step 4a, add the corresponding `--set` flags:
-
-```bash
-  --set postgresql.auth.existingSecret=<your-pg-secret-name> \
-  --set valkey.existingSecret=<your-valkey-secret-name>
-```
-
----
-
-## Step 5: Verify the installation
-
-### Pod status
+### Step 5: Verify
 
 ```bash
 kubectl get pods -n kubernaut-system
 ```
 
-All pods should reach `1/1 Running` within a few minutes.
+All pods should reach `1/1 Running` within a few minutes. If any pod is stuck in `ImagePullBackOff`, see [Troubleshooting](#troubleshooting).
+
+---
+
+## Troubleshooting
 
 ### Image pull errors
 
 If any pod is stuck in `ImagePullBackOff` or `ErrImagePull`:
 
 ```bash
-kubectl describe pod <pod-name> -n kubernaut-system | grep -A5 "Events:"
+oc describe pod <pod-name> -n kubernaut-system | grep -A5 "Events:"
 ```
 
 Common causes:
 
-- Image not mirrored -- re-run `oc mirror`
-- Mirror credentials missing from global pull secret -- re-run [Step 3](#step-3-configure-the-global-pull-secret)
-- Typo in registry hostname in `values-airgap.yaml`
+- Image not mirrored — re-run `oc-mirror`
+- Mirror credentials missing from global pull secret
+- IDMS not applied (operator path) or typo in `values-airgap.yaml` (Helm path)
 
-Verify the actual image reference a pod is using:
+Verify the actual image reference:
 
 ```bash
-kubectl get pod <pod-name> -n kubernaut-system \
+oc get pod <pod-name> -n kubernaut-system \
   -o jsonpath='{.spec.containers[0].image}'
 ```
 
-### Migration Job
-
-The database migration runs as a post-install Helm hook:
+### Verifying IDMS is active (operator path)
 
 ```bash
-kubectl get jobs -n kubernaut-system | grep migration
+oc get imagedigestmirrorset
+oc get imagedigestmirrorset kubernaut-mirror -o yaml
 ```
 
-The job should show `1/1` completions. If it failed:
+Verify CRI-O is applying the redirect:
 
 ```bash
-kubectl logs job/<release-name>-db-migration -n kubernaut-system
-```
-
-### Service health
-
-```bash
-kubectl port-forward -n kubernaut-system svc/kubernaut-agent 8081:8081
-curl -s http://localhost:8081/healthz | jq '.'
-```
-
----
-
-## Optional: ImageDigestMirrorSet (IDMS)
-
-As an alternative to `values-airgap.yaml`, an `ImageDigestMirrorSet` configures OCP to transparently redirect image pulls from source registries to your mirror at the CRI-O level. This is useful when multiple applications in the cluster pull from the same source registries.
-
-!!! note
-    IDMS requires OCP 4.13+. For older versions, use the deprecated `ImageContentSourcePolicy` (ICSP) with the same mirror mappings.
-
-```yaml
-apiVersion: config.openshift.io/v1
-kind: ImageDigestMirrorSet
-metadata:
-  name: kubernaut-mirror
-spec:
-  imageDigestMirrors:
-    - source: quay.io/kubernaut-ai
-      mirrors:
-        - <mirror-registry>/kubernaut-ai   # nested; or <mirror-registry> for flat naming
-    - source: registry.redhat.io
-      mirrors:
-        - <mirror-registry>
-```
-
-```bash
-oc apply -f idms-kubernaut.yaml
-```
-
-When using IDMS, install with just `values-ocp.yaml` (no `values-airgap.yaml`). However, IDMS only redirects **digest-based** references -- not tags. To use digest references with the chart, set `global.image.digest`:
-
-```bash
-helm install kubernaut charts/kubernaut/ \
-  --namespace kubernaut-system \
-  -f charts/kubernaut/values-ocp.yaml \
-  --set global.image.digest=sha256:<digest> \
-  --set-file kubernautAgent.sdkConfigContent=my-sdk-config.yaml
-```
-
-!!! tip "Recommendation"
-    For most disconnected installs, `values-airgap.yaml` (direct mirror pull) is simpler and more predictable than IDMS. Use IDMS when you have cluster-wide registry redirection policies already in place.
-
----
-
-## Troubleshooting
-
-### TLS certificate hook fails
-
-The `tls-cert-gen` Job uses `ose-cli-rhel9` to generate self-signed certificates. If this image wasn't mirrored, pods that depend on TLS (e.g., authwebhook) won't start.
-
-Mirror `registry.redhat.io/openshift4/ose-cli-rhel9:v4.17` and retry:
-
-```bash
-helm upgrade kubernaut charts/kubernaut/ \
-  --namespace kubernaut-system \
-  -f charts/kubernaut/values-ocp.yaml \
-  -f charts/kubernaut/values-airgap.yaml \
-  --set-file kubernautAgent.sdkConfigContent=my-sdk-config.yaml
+oc debug node/<node-name> -- chroot /host crictl pull quay.io/kubernaut-ai/gateway@sha256:<digest> 2>&1
 ```
 
 ### Migration Job fails connecting to PostgreSQL
 
-If the `db-migration` Job logs show `pg_isready` failures or `goose` connection refused errors, the PostgreSQL pod likely hasn't started. Check whether its image was mirrored:
+If the db-migration Job logs show connection errors, check that your BYO PostgreSQL is reachable from the cluster and the secret credentials are correct:
 
 ```bash
-kubectl get pod -l app=postgresql -n kubernaut-system
+oc logs job/db-migration -n kubernaut-system
 ```
-
-If the PostgreSQL pod is in `ImagePullBackOff`, mirror `registry.redhat.io/rhel10/postgresql-16` and delete the failed Job so the next `helm upgrade` recreates it.
 
 ### Verifying mirror registry contents
 
 ```bash
-# Nested registry (separator="/"):
 skopeo list-tags docker://<mirror-registry>/kubernaut-ai/gateway
 skopeo inspect docker://<mirror-registry>/kubernaut-ai/gateway:{{ image_tag }}
-
-# Flat registry (separator="-"):
-skopeo list-tags docker://<mirror-registry>/kubernaut-ai-gateway
-skopeo inspect docker://<mirror-registry>/kubernaut-ai-gateway:{{ image_tag }}
 ```
 
 ---
 
 ## Summary
 
+### Operator (Production)
+
 ```mermaid
 flowchart LR
-    A["Bastion host"] -->|"oc mirror"| B["Mirror registry"]
+    A["Bastion host"] -->|"oc-mirror<br/>(catalog + relatedImages)"| B["Mirror registry"]
+    B -->|"IDMS + CatalogSource"| C["OCP cluster"]
+    C -->|"OperatorHub install<br/>+ Kubernaut CR"| D["Kubernaut running"]
+```
+
+1. **Mirror** the operator catalog — `oc-mirror` discovers and mirrors all 17 images automatically
+2. **Apply** the generated IDMS and CatalogSource on the disconnected cluster
+3. **Configure** the global pull secret with mirror registry credentials
+4. **Install** the operator from OperatorHub and create the Kubernaut CR
+5. **Verify** pods are running and pulling from the mirror registry
+
+### Helm (Dev/Testing)
+
+```mermaid
+flowchart LR
+    A["Bastion host"] -->|"oc mirror<br/>(manual image list)"| B["Mirror registry"]
     B -->|"global pull secret"| C["OCP cluster"]
     C -->|"helm install<br/>values-airgap.yaml"| D["Kubernaut running"]
 ```
 
-1. **Mirror** all images from public registries to your private mirror using `oc mirror`
-2. **Configure** the OCP global pull secret with mirror registry credentials
-3. **Install** the chart layering `values-ocp.yaml` + `values-airgap.yaml` with `--set-file` for mandatory configs
+1. **Mirror** all images using a manually maintained `ImageSetConfiguration`
+2. **Configure** the global pull secret with mirror registry credentials
+3. **Install** the chart layering `values-ocp.yaml` + `values-airgap.yaml`
 4. **Verify** pods are running and pulling from the correct registry

--- a/docs/operations/disconnected-install.md
+++ b/docs/operations/disconnected-install.md
@@ -38,8 +38,8 @@ For reference, the full set (17 images) is:
 
 | Layer | Image | Purpose |
 |---|---|---|
-| **Catalog** | `quay.io/kubernaut-ai/kubernaut-operator-catalog:v{{ image_tag }}` | OLM index — makes the operator visible in OperatorHub |
-| **Bundle** | `quay.io/kubernaut-ai/kubernaut-operator-bundle:v{{ image_tag }}` | CSV + CRDs + metadata for a specific version |
+| **Catalog** | `quay.io/kubernaut-ai/kubernaut-operator-catalog@sha256:...` | OLM index — makes the operator visible in OperatorHub |
+| **Bundle** | `quay.io/kubernaut-ai/kubernaut-operator-bundle@sha256:...` | CSV + CRDs + metadata for a specific version |
 | **Operator** | `quay.io/kubernaut-ai/kubernaut-operator@sha256:...` | Controller manager binary |
 | **Operands** | | |
 | | `quay.io/kubernaut-ai/gateway` | Signal ingestion webhook |
@@ -58,26 +58,20 @@ For reference, the full set (17 images) is:
 | | `registry.redhat.io/rhel10/postgresql-16` | PostgreSQL client for init containers |
 | | `registry.access.redhat.com/ubi10/ubi-minimal` | Minimal UBI for init containers |
 
-### Step 1: Create the ImageSetConfiguration
+### Step 1: Get the ImageSetConfiguration
 
-On the bastion host, create an `ImageSetConfiguration` referencing the operator catalog:
+The operator repository provides a ready-to-use `ImageSetConfiguration` with all images pinned by digest at [`hack/airgap/imageset-config.yaml`](https://github.com/jordigilh/kubernaut-operator/blob/main/hack/airgap/imageset-config.yaml). Download it to the bastion host:
 
-```yaml
-kind: ImageSetConfiguration
-apiVersion: mirror.openshift.io/v2alpha1
-storageConfig:
-  local:
-    path: ./kubernaut-mirror
-mirror:
-  operators:
-    - catalog: quay.io/kubernaut-ai/kubernaut-operator-catalog:v{{ image_tag }}
-      packages:
-        - name: kubernaut-operator
-          channels:
-            - name: alpha
+```bash
+curl -fsSL \
+  https://raw.githubusercontent.com/jordigilh/kubernaut-operator/main/hack/airgap/imageset-config.yaml \
+  -o imageset-config.yaml
 ```
 
-This is all you need. `oc-mirror` reads the catalog index, finds the bundle for the specified channel, parses the CSV, and discovers every image from `relatedImages` and the operator deployment spec automatically.
+The manifest references the operator catalog and all operand images by `@sha256:` digest, which is required for IDMS redirection. `oc-mirror` reads the catalog index, finds the bundle for the specified channel, parses the CSV, and discovers every image from `relatedImages` automatically.
+
+!!! tip "Why digests instead of tags?"
+    IDMS only redirects **digest-based** image references — not tags. The operator CSV `relatedImages` already pins all operand images by digest. Using the upstream manifest ensures your mirror contains the exact images the operator expects, and IDMS can redirect them transparently.
 
 ### Step 2: Mirror images
 

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -15,6 +15,7 @@ In **v1.3**, the Kubernaut Agent metrics were renamed from the legacy `holmesgpt
 | **Gateway** | `GET /healthz` | `GET /readyz` | **8081** (plain HTTP) | Ingestion API on **8080** |
 | **DataStorage** | `GET /healthz` | `GET /readyz` | **8081** (plain HTTP) | Readiness checks PostgreSQL; REST API on **8080** |
 | **Kubernaut Agent** | `GET /healthz` | `GET /readyz` | **8081** (plain HTTP) | Readiness includes LLM connectivity |
+| **API Frontend** | `GET /healthz` | `GET /readyz` | **8081** (plain HTTP) | API on **8443**, metrics on **9090** (v1.5+) |
 | **Auth Webhook** | `GET /healthz` | `GET /readyz` | **8081** (plain HTTP) | Service **443** → targetPort **9443** for admission |
 
 ## Scrape Configuration
@@ -127,6 +128,16 @@ scrape_configs:
 | `datastorage_audit_lag_seconds` | Histogram | `service` | Lag between event occurrence and write |
 | `datastorage_dlq_warning` | Gauge | `stream` | DLQ at 80% capacity (1 = warning) |
 | `datastorage_dlq_critical` | Gauge | `stream` | DLQ at 90% capacity (1 = critical) |
+
+## API Frontend Metrics (v1.5+)
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `af_tool_calls_total` | Counter | `tool`, `status` | MCP/A2A tool invocations by tool name and outcome |
+| `af_a2a_tasks_total` | Counter | `task_type`, `status` | A2A task executions by type and outcome |
+| `af_session_active` | Gauge | -- | Currently active API sessions |
+| `af_session_duration_seconds` | Histogram | -- | Session duration from connect to disconnect |
+| `af_http_request_duration_seconds` | Histogram | `endpoint`, `method`, `status` | HTTP request duration |
 
 ## Kubernaut Agent Metrics
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -122,6 +122,33 @@ Image paths are constructed as `{registry}{separator}{namespace}{separator}{serv
 | `datastorage.resources` | CPU/memory requests and limits | See `values.yaml` |
 | `datastorage.service.type` | Kubernetes Service type | `ClusterIP` |
 
+#### DataStorage Server Config (v1.5+)
+
+| Parameter | Description | Default |
+|---|---|---|
+| `datastorage.config.server.maxBodySize` | Maximum request body size in bytes | `5242880` (5 MiB) |
+| `datastorage.config.server.corsAllowedOrigins` | CORS allowed origins for browser-based access (e.g., Backstage console) | `[]` |
+| `datastorage.config.server.signerCertDir` | Directory containing the certificate used to sign audit events | `/etc/certs` |
+
+#### DataStorage Redis Config (v1.5+)
+
+| Parameter | Description | Default |
+|---|---|---|
+| `datastorage.config.redis.dlqMaxLen` | Dead letter queue MAXLEN bound | `10000` |
+| `datastorage.config.redis.tls.enabled` | Enable TLS for Redis/Valkey connections | `false` |
+| `datastorage.config.redis.tls.certFile` | Client TLS certificate file path | `""` |
+| `datastorage.config.redis.tls.keyFile` | Client TLS key file path | `""` |
+| `datastorage.config.redis.tls.caFile` | CA certificate file path for server verification | `""` |
+
+#### DataStorage Retention Config (v1.5+)
+
+| Parameter | Description | Default |
+|---|---|---|
+| `datastorage.config.retention.enabled` | Enable automatic data retention cleanup | `true` |
+| `datastorage.config.retention.interval` | How often the retention job runs | `24h` |
+| `datastorage.config.retention.batchSize` | Number of rows processed per retention batch | `1000` |
+| `datastorage.config.retention.defaultDays` | Default retention period in days | `2555` (~7 years) |
+
 ### Kubernaut Agent (LLM integration)
 
 | Parameter | Description | Default |
@@ -171,6 +198,27 @@ notification:
       secretName: slack-webhook
       secretKey: webhook-url
 ```
+
+### API Frontend (v1.5+)
+
+The API Frontend service provides the REST API surface for external integrations, MCP/A2A agent protocols, and the Backstage console. It is always deployed starting in v1.5.
+
+| Parameter | Description | Default |
+|---|---|---|
+| `apifrontend.enabled` | Enable API Frontend deployment | `true` |
+| `apifrontend.replicas` | Number of replicas | `1` |
+| `apifrontend.logging.level` | Log level | `INFO` |
+| `apifrontend.config.server.httpPort` | Primary API port | `8443` |
+| `apifrontend.config.server.metricsPort` | Prometheus metrics port | `9090` |
+| `apifrontend.config.server.healthPort` | Health check port | `8081` |
+| `apifrontend.config.session.disconnectTTL` | TTL before disconnected sessions are cleaned up | `10m` |
+| `apifrontend.config.session.retentionTTL` | How long completed sessions are retained | `720h` |
+| `apifrontend.config.severityTriage.cacheTTLSeconds` | Severity triage cache TTL | `30` |
+| `apifrontend.config.severityTriage.llmConfidence` | LLM confidence threshold for severity triage | `0.7` |
+| `apifrontend.resources.requests.memory` | Memory request | `64Mi` |
+| `apifrontend.resources.requests.cpu` | CPU request | `50m` |
+| `apifrontend.resources.limits.memory` | Memory limit | `256Mi` |
+| `apifrontend.resources.limits.cpu` | CPU limit | `500m` |
 
 ### Controllers (Common Parameters)
 

--- a/docs/user-guide/rego-reference.md
+++ b/docs/user-guide/rego-reference.md
@@ -14,7 +14,7 @@ All policies are deployed as ConfigMaps and support hot-reload. See [Rego Polici
 
 ## Signal Processing Policy
 
-All SP classification rules live in a single `policy.rego` file under `package signalprocessing` ([ADR-060](https://github.com/jordigilh/kubernaut/blob/v1.4.1/docs/architecture/decisions/ADR-060-unified-signalprocessing-rego-policy.md)). The evaluator sends a common typed input struct and queries four named rules. Each rule group is documented below.
+All SP classification rules live in a single `policy.rego` file under `package signalprocessing` ([ADR-060](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc2/docs/architecture/decisions/ADR-060-unified-signalprocessing-rego-policy.md)). The evaluator sends a common typed input struct and queries four named rules. Each rule group is documented below.
 
 ### Common Input Schema
 
@@ -560,11 +560,11 @@ reason := f.reason if { some f in risk_factors; f.score == max_risk_score }
 
 | Component | Source File |
 |---|---|
-| SP unified evaluator | [`pkg/signalprocessing/evaluator/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.4.1/pkg/signalprocessing/evaluator/evaluator.go) |
-| SP policy input types | [`pkg/signalprocessing/evaluator/types.go`](https://github.com/jordigilh/kubernaut/blob/v1.4.1/pkg/signalprocessing/evaluator/types.go) |
-| SP signal mode classifier | [`pkg/signalprocessing/classifier/signalmode.go`](https://github.com/jordigilh/kubernaut/blob/v1.4.1/pkg/signalprocessing/classifier/signalmode.go) |
-| SP example policy | [`charts/kubernaut/examples/signalprocessing-policy.rego`](https://github.com/jordigilh/kubernaut/blob/v1.4.1/charts/kubernaut/examples/signalprocessing-policy.rego) |
-| SP deploy policies | [`deploy/signalprocessing/policies/`](https://github.com/jordigilh/kubernaut/tree/v1.4.1/deploy/signalprocessing/policies) |
-| AA approval evaluator | [`pkg/aianalysis/rego/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.4.1/pkg/aianalysis/rego/evaluator.go) |
-| AA input builder | [`pkg/aianalysis/handlers/analyzing.go`](https://github.com/jordigilh/kubernaut/blob/v1.4.1/pkg/aianalysis/handlers/analyzing.go) |
-| AA approval policy (test) | [`test/unit/aianalysis/testdata/policies/approval.rego`](https://github.com/jordigilh/kubernaut/blob/v1.4.1/test/unit/aianalysis/testdata/policies/approval.rego) |
+| SP unified evaluator | [`pkg/signalprocessing/evaluator/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc2/pkg/signalprocessing/evaluator/evaluator.go) |
+| SP policy input types | [`pkg/signalprocessing/evaluator/types.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc2/pkg/signalprocessing/evaluator/types.go) |
+| SP signal mode classifier | [`pkg/signalprocessing/classifier/signalmode.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc2/pkg/signalprocessing/classifier/signalmode.go) |
+| SP example policy | [`charts/kubernaut/examples/signalprocessing-policy.rego`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc2/charts/kubernaut/examples/signalprocessing-policy.rego) |
+| SP deploy policies | [`deploy/signalprocessing/policies/`](https://github.com/jordigilh/kubernaut/tree/v1.5.0-rc2/deploy/signalprocessing/policies) |
+| AA approval evaluator | [`pkg/aianalysis/rego/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc2/pkg/aianalysis/rego/evaluator.go) |
+| AA input builder | [`pkg/aianalysis/handlers/analyzing.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc2/pkg/aianalysis/handlers/analyzing.go) |
+| AA approval policy (test) | [`test/unit/aianalysis/testdata/policies/approval.rego`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc2/test/unit/aianalysis/testdata/policies/approval.rego) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,9 +37,9 @@ theme:
     - toc.integrate
 
 extra:
-  chart_version: "1.4.1"
-  image_tag: "v1.4.1"
-  operator_image_tag: "1.4.1"
+  chart_version: "1.5.0-rc2"
+  image_tag: "v1.5.0-rc2"
+  operator_image_tag: "1.5.0-rc2"
   version:
     provider: mike
     default: latest


### PR DESCRIPTION
Closes #149

## Summary

- Rewrite `docs/operations/disconnected-install.md` to make the **Kubernaut Operator (OLM)** the primary production method for disconnected environments
- Complete 7-step OLM flow: `ImageSetConfiguration` with operator catalog, `oc-mirror` v2, IDMS/CatalogSource, OperatorHub install, Kubernaut CR
- Add `apifrontend` to image tables (new in v1.5)
- Add `spec.image.overrides` escape hatch for per-component image redirection without IDMS
- PostgreSQL `sslMode` defaults to `verify-full` (v1.5) — no explicit field in CR example
- Demote Helm chart to dev/testing appendix with warning
- Bump all version references to `v1.5.0-rc2` (CI, mkdocs macros, rego source links)

## Test plan

- [ ] Published page shows OLM as primary method (not Helm)
- [ ] Image table includes `apifrontend` (17 total)
- [ ] Kubernaut CR example omits `sslMode` (default is `verify-full`)
- [ ] `ImageSetConfiguration` references `v1.5.0-rc2` catalog tag
- [ ] v1.5 preview is accessible at `/v1.5/operations/disconnected-install/`

Made with [Cursor](https://cursor.com)