### PR TITLE
docs: v1.5 GA readiness — all documentation gaps from audit

### DIFF
--- a/docs/api-reference/apifrontend-api.md
+++ b/docs/api-reference/apifrontend-api.md
@@ -66,7 +66,7 @@ Returns `501` when MCP is disabled in the AF configuration.
 }
 ```
 
-The AF proxies tool calls to the Kubernaut Agent's MCP server, where the 3 interactive tools (`kubernaut_investigate`, `kubernaut_select_workflow`, `kubernaut_complete_no_action`) are registered.
+The AF runs its own MCP server with **23 `kubernaut_*` tools** (see [A2A tools](#a2a-json-rpc-20) for the full list). Each tool dispatches to its backend: K8s API (CRD operations), KA REST (autonomous investigation), KA MCP (workflow selection/discovery and interactive session lifecycle), DataStorage (analytics), or local (presentation). The Kubernaut Agent runs a separate MCP server at `/api/v1/mcp` with 3 interactive-mode tools (`kubernaut_investigate`, `kubernaut_select_workflow`, `kubernaut_complete_no_action`) for direct client connections.
 
 ### A2A JSON-RPC 2.0
 
@@ -76,16 +76,30 @@ POST /a2a/invoke
 
 Agent-to-Agent protocol endpoint accepting JSON-RPC 2.0 messages. Supported methods include `message/send`. Requires Bearer JWT authentication.
 
-The A2A agent uses **18 SAR-gated Google ADK tools** organized in four domains:
+The A2A agent uses **23 SAR-gated `kubernaut_*` tools** exposed on the MCP endpoint, organized in six domains:
 
-| Domain | Tools |
+| Domain | Tools | Backend |
+|---|---|---|
+| **CRD operations** | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_approve`, `kubernaut_cancel_remediation`, `kubernaut_watch`, `kubernaut_list_approval_requests`, `kubernaut_get_approval_request` | K8s API (AF SA) |
+| **Autonomous investigation** | `kubernaut_start_investigation`, `kubernaut_poll_investigation`, `kubernaut_stream_investigation` | KA REST |
+| **Interactive session lifecycle** | `kubernaut_takeover`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect` | KA MCP |
+| **Workflow** | `kubernaut_discover_workflows`, `kubernaut_select_workflow` | KA MCP |
+| **Data & history** | `kubernaut_list_workflows`, `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail` | DataStorage REST |
+| **Presentation** | `kubernaut_present_decision` | Local |
+
+The `kubernaut_*` investigation tools dispatch to the Kubernaut Agent (`kubernaut_start_investigation`/`kubernaut_poll_investigation` via KA REST; `kubernaut_select_workflow`/`kubernaut_discover_workflows` via KA MCP). The `kubernaut_*` CRD tools operate on RemediationRequest and RemediationApprovalRequest resources via the Kubernetes API using the AF ServiceAccount ([unified SA model](../architecture/security-rbac.md#unified-sa-model)). The `kubernaut_*` data tools query DataStorage. `kubernaut_present_decision` is handled locally by the AF.
+
+The AF's LLM agent also uses **5 internal tools** that are not exposed via MCP — they run inside the AF's own agent loop for cluster inspection and RR creation:
+
+| Tool | Purpose |
 |---|---|
-| **Remediation lifecycle** | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_approve`, `kubernaut_cancel_remediation`, `kubernaut_watch` |
-| **Investigation** | `kubernaut_start_investigation`, `kubernaut_poll_investigation`, `kubernaut_select_workflow`, `kubernaut_present_decision` |
-| **Data & history** | `kubernaut_list_workflows`, `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail` |
-| **Cluster context** | `kubectl_get`, `kubectl_list`, `kubectl_list_events`, `af_check_existing_rr`, `af_create_rr` |
+| `kubectl_get` | Get any namespaced K8s resource by kind/name/namespace (Secret `.data` redacted) |
+| `kubectl_list` | List namespaced K8s resources with optional label selector (Secret `.data` redacted) |
+| `kubectl_list_events` | List K8s events with reason/object filters |
+| `af_check_existing_rr` | Check for duplicate RemediationRequest before creation |
+| `af_create_rr` | Create RemediationRequest CRD; triggers deferred `InvestigationSession` CRD materialization |
 
-The `kubernaut_*` investigation tools proxy to the Kubernaut Agent (via REST or MCP). The `kubernaut_*` CRD tools operate on RemediationRequest resources via the Kubernetes API. The `kubectl_*` cluster context tools query any namespaced Kubernetes resource using the authenticated user's identity (via impersonation or [OIDC-direct mode](../architecture/security-rbac.md#oidc-direct-mode-eliminating-impersonation-v15)) with dynamic kind-to-GVR resolution via `RESTMapper`. Secret `.data` fields are redacted before returning to the LLM. The `kubernaut_*` data tools query DataStorage. The AF also uses internal orchestration tools (`kubernaut_discover_workflows`, `kubernaut_stream_investigation`) that are not SAR-gated — they are invoked by the AF's own agent loop, not exposed directly to A2A callers.
+All internal tools use the AF ServiceAccount ([unified SA model](../architecture/security-rbac.md#unified-sa-model)) and are SAR-gated on the A2A path via the same `newRBACGuard()` as MCP tools.
 
 ### Agent Card Discovery
 
@@ -120,7 +134,7 @@ The AF emits **14 audit events** to DataStorage (PR #1191 shared AuditStore norm
 | **User decisions** | `user.decision` |
 | **Severity triage** | `severity_triage.completed`, `severity_triage.failed` |
 | **Session lifecycle** | `session.completed` (includes `duration_ms`) |
-| **Auth** | `impersonation.created`, `jwt.delegation` |
+| **Auth** | `jwt.delegation` |
 | **MCP** | `mcp.session_init` (deduplicated per `Mcp-Session-Id`) |
 | **Resilience** | `circuitbreaker.trip` |
 | **Triage** | `triage.started`, `triage.completed` |

--- a/docs/api-reference/apifrontend-api.md
+++ b/docs/api-reference/apifrontend-api.md
@@ -76,6 +76,17 @@ POST /a2a/invoke
 
 Agent-to-Agent protocol endpoint accepting JSON-RPC 2.0 messages. Supported methods include `message/send`. Requires Bearer JWT authentication.
 
+The A2A agent uses **19 SAR-gated Google ADK tools** organized in four domains:
+
+| Domain | Tools |
+|---|---|
+| **Remediation lifecycle** | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_approve`, `kubernaut_cancel_remediation`, `kubernaut_watch` |
+| **Investigation** | `kubernaut_start_investigation`, `kubernaut_poll_investigation`, `kubernaut_select_workflow`, `kubernaut_present_decision` |
+| **Data & history** | `kubernaut_list_workflows`, `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail` |
+| **Cluster context** | `af_list_events`, `af_get_pods`, `af_get_workloads`, `af_resolve_owner`, `af_check_existing_rr`, `af_create_rr` |
+
+The `kubernaut_*` investigation tools proxy to the Kubernaut Agent (via REST or MCP). The `kubernaut_*` CRD tools operate on RemediationRequest resources via the Kubernetes API. The `af_*` cluster context tools query the Kubernetes API using the authenticated user's identity (via impersonation or [OIDC-direct mode](../architecture/security-rbac.md#oidc-direct-mode-eliminating-impersonation-v15)). The `kubernaut_*` data tools query DataStorage. The AF also uses internal orchestration tools (`kubernaut_discover_workflows`, `kubernaut_stream_investigation`) that are not SAR-gated — they are invoked by the AF's own agent loop, not exposed directly to A2A callers.
+
 ### Agent Card Discovery
 
 ```
@@ -100,12 +111,21 @@ All AF metrics use the `af_` namespace. See [Monitoring: API Frontend Metrics](.
 
 ## Audit Events
 
-The AF emits audit events to DataStorage for significant operations. Audit event support was wired in PR #1191 (shared AuditStore normalization) and PR #1192 (14 production audit events).
+The AF emits **14 audit events** to DataStorage (PR #1191 shared AuditStore normalization, PR #1192 production wiring). All events use the `apifrontend.*` prefix.
 
-!!! note "Audit event names are approximate"
-    Exact event type names should be verified against the DataStorage OpenAPI spec (`api/datastorage/openapi/`). The categories below reflect the scope of the implementation.
+| Category | Events |
+|---|---|
+| **Remediation** | `rr.created`, `rr.deduplicated` |
+| **KA delegation** | `ka.delegated`, `ka.result_received` |
+| **User decisions** | `user.decision` |
+| **Severity triage** | `severity_triage.completed`, `severity_triage.failed` |
+| **Session lifecycle** | `session.completed` (includes `duration_ms`) |
+| **Auth** | `impersonation.created`, `jwt.delegation` |
+| **MCP** | `mcp.session_init` (deduplicated per `Mcp-Session-Id`) |
+| **Resilience** | `circuitbreaker.trip` |
+| **Triage** | `triage.started`, `triage.completed` |
 
-Audit coverage includes: tool invocations, authorization decisions, session lifecycle events (create, reconnect, takeover, abandon, drain), and A2A task lifecycle.
+See [Audit Pipeline: Emitting Services](../architecture/audit-pipeline.md#emitting-services) for the full cross-service audit reference.
 
 ## Error Responses
 

--- a/docs/api-reference/apifrontend-api.md
+++ b/docs/api-reference/apifrontend-api.md
@@ -76,16 +76,16 @@ POST /a2a/invoke
 
 Agent-to-Agent protocol endpoint accepting JSON-RPC 2.0 messages. Supported methods include `message/send`. Requires Bearer JWT authentication.
 
-The A2A agent uses **19 SAR-gated Google ADK tools** organized in four domains:
+The A2A agent uses **18 SAR-gated Google ADK tools** organized in four domains:
 
 | Domain | Tools |
 |---|---|
 | **Remediation lifecycle** | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_approve`, `kubernaut_cancel_remediation`, `kubernaut_watch` |
 | **Investigation** | `kubernaut_start_investigation`, `kubernaut_poll_investigation`, `kubernaut_select_workflow`, `kubernaut_present_decision` |
 | **Data & history** | `kubernaut_list_workflows`, `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail` |
-| **Cluster context** | `af_list_events`, `af_get_pods`, `af_get_workloads`, `af_resolve_owner`, `af_check_existing_rr`, `af_create_rr` |
+| **Cluster context** | `kubectl_get`, `kubectl_list`, `kubectl_list_events`, `af_check_existing_rr`, `af_create_rr` |
 
-The `kubernaut_*` investigation tools proxy to the Kubernaut Agent (via REST or MCP). The `kubernaut_*` CRD tools operate on RemediationRequest resources via the Kubernetes API. The `af_*` cluster context tools query the Kubernetes API using the authenticated user's identity (via impersonation or [OIDC-direct mode](../architecture/security-rbac.md#oidc-direct-mode-eliminating-impersonation-v15)). The `kubernaut_*` data tools query DataStorage. The AF also uses internal orchestration tools (`kubernaut_discover_workflows`, `kubernaut_stream_investigation`) that are not SAR-gated — they are invoked by the AF's own agent loop, not exposed directly to A2A callers.
+The `kubernaut_*` investigation tools proxy to the Kubernaut Agent (via REST or MCP). The `kubernaut_*` CRD tools operate on RemediationRequest resources via the Kubernetes API. The `kubectl_*` cluster context tools query any namespaced Kubernetes resource using the authenticated user's identity (via impersonation or [OIDC-direct mode](../architecture/security-rbac.md#oidc-direct-mode-eliminating-impersonation-v15)) with dynamic kind-to-GVR resolution via `RESTMapper`. Secret `.data` fields are redacted before returning to the LLM. The `kubernaut_*` data tools query DataStorage. The AF also uses internal orchestration tools (`kubernaut_discover_workflows`, `kubernaut_stream_investigation`) that are not SAR-gated — they are invoked by the AF's own agent loop, not exposed directly to A2A callers.
 
 ### Agent Card Discovery
 

--- a/docs/api-reference/apifrontend-api.md
+++ b/docs/api-reference/apifrontend-api.md
@@ -20,7 +20,7 @@ All protocol endpoints require a valid OIDC/OAuth2 bearer token:
 Authorization: Bearer <jwt-token>
 ```
 
-The AF validates tokens via JWKS from the configured OIDC provider and extracts user identity from JWT claims.
+The AF validates tokens via JWKS from the configured OIDC provider and extracts user identity from JWT claims. Tool invocations are authorized via **Kubernetes SubjectAccessReview** — see [Security & RBAC: Tool Authorization](../architecture/security-rbac.md#tool-authorization-v15) for the SAR model and per-persona ClusterRoles.
 
 ## Protocol Endpoints
 

--- a/docs/api-reference/apifrontend-api.md
+++ b/docs/api-reference/apifrontend-api.md
@@ -66,7 +66,7 @@ Returns `501` when MCP is disabled in the AF configuration.
 }
 ```
 
-The AF runs its own MCP server with **23 `kubernaut_*` tools** (see [A2A tools](#a2a-json-rpc-20) for the full list). Each tool dispatches to its backend: K8s API (CRD operations), KA REST (autonomous investigation), KA MCP (workflow selection/discovery and interactive session lifecycle), DataStorage (analytics), or local (presentation). The Kubernaut Agent runs a separate MCP server at `/api/v1/mcp` with 3 interactive-mode tools (`kubernaut_investigate`, `kubernaut_select_workflow`, `kubernaut_complete_no_action`) for direct client connections.
+The AF runs its own MCP server with **23 `kubernaut_*` MCP tools** (see [A2A tools](#a2a-json-rpc-20) for the full list). Each tool dispatches to its backend: K8s API (CRD operations), KA REST (autonomous investigation), KA MCP (workflow selection/discovery and interactive session lifecycle), DataStorage (analytics), or local (presentation). The Kubernaut Agent runs a separate MCP server at `/api/v1/mcp` with 3 interactive-mode tools (`kubernaut_investigate`, `kubernaut_select_workflow`, `kubernaut_complete_no_action`) for direct client connections.
 
 ### A2A JSON-RPC 2.0
 
@@ -76,7 +76,7 @@ POST /a2a/invoke
 
 Agent-to-Agent protocol endpoint accepting JSON-RPC 2.0 messages. Supported methods include `message/send`. Requires Bearer JWT authentication.
 
-The A2A agent uses **23 SAR-gated `kubernaut_*` tools** exposed on the MCP endpoint, organized in six domains:
+The A2A agent uses **23 SAR-gated `kubernaut_*` MCP tools** exposed on the MCP endpoint, organized in six domains:
 
 | Domain | Tools | Backend |
 |---|---|---|
@@ -86,6 +86,9 @@ The A2A agent uses **23 SAR-gated `kubernaut_*` tools** exposed on the MCP endpo
 | **Workflow** | `kubernaut_discover_workflows`, `kubernaut_select_workflow` | KA MCP |
 | **Data & history** | `kubernaut_list_workflows`, `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail` | DataStorage REST |
 | **Presentation** | `kubernaut_present_decision` | Local |
+
+!!! note "Upstream Helm gap ([#1239](https://github.com/jordigilh/kubernaut/issues/1239))"
+    `kubernaut_list_approval_requests` and `kubernaut_get_approval_request` are not yet in the Helm `values.yaml` persona definitions. They belong in the `remediation-approver` persona per [#1235](https://github.com/jordigilh/kubernaut/issues/1235). The documentation reflects the intended design. See [per-persona ClusterRoles](../architecture/security-rbac.md#per-persona-clusterroles).
 
 The `kubernaut_*` investigation tools dispatch to the Kubernaut Agent (`kubernaut_start_investigation`/`kubernaut_poll_investigation` via KA REST; `kubernaut_select_workflow`/`kubernaut_discover_workflows` via KA MCP). The `kubernaut_*` CRD tools operate on RemediationRequest and RemediationApprovalRequest resources via the Kubernetes API using the AF ServiceAccount ([unified SA model](../architecture/security-rbac.md#unified-sa-model)). The `kubernaut_*` data tools query DataStorage. `kubernaut_present_decision` is handled locally by the AF.
 

--- a/docs/api-reference/apifrontend-api.md
+++ b/docs/api-reference/apifrontend-api.md
@@ -2,7 +2,7 @@
 
 !!! warning "This page is under active development for v1.5 GA"
 
-The API Frontend (AF) is the unified external gateway introduced in v1.5. It exposes MCP, A2A, and REST protocols for operators, AI agents, and the Backstage console.
+The API Frontend (AF) is the unified external gateway introduced in v1.5. It exposes MCP Streamable HTTP and A2A JSON-RPC protocols for operators, AI agents, and the Backstage console.
 
 ## Base URL
 
@@ -14,117 +14,67 @@ External clients connect via the cluster ingress or OpenShift Route configured f
 
 ## Authentication
 
-All requests require a valid OIDC/OAuth2 bearer token:
+All protocol endpoints require a valid OIDC/OAuth2 bearer token:
 
 ```
 Authorization: Bearer <jwt-token>
 ```
 
-The AF validates tokens via the configured OIDC provider (DEX, Keycloak) and extracts user identity from JWT claims.
+The AF validates tokens via JWKS from the configured OIDC provider and extracts user identity from JWT claims.
 
-## Authorization
+## Protocol Endpoints
 
-Every MCP tool call is authorized via Kubernetes **SubjectAccessReview (SAR)**:
+The AF exposes two protocol endpoints that proxy to backend services:
 
-- **Resource**: `tools/<tool-name>`
-- **API Group**: `kubernaut.ai`
-- **Verb**: `use`
-
-Authorization is **fail-closed** — if the SAR API is unreachable, the tool call is denied. Results are cached with a configurable TTL (default 30s).
-
-See [Security & RBAC: Tool Authorization](../architecture/security-rbac.md#tool-authorization-v15) for ClusterRole definitions and binding examples.
-
-## MCP Endpoints
-
-### Tool Invocation
+### MCP Streamable HTTP
 
 ```
-POST /mcp/tools/{tool_name}
+POST /mcp
 ```
 
-Invokes an MCP tool. The AF performs SAR authorization, then proxies the call to the appropriate backend service (Kubernaut Agent or DataStorage).
+Model Context Protocol endpoint using Streamable HTTP transport (spec 2025-03-26). Accepts JSON-RPC 2.0 requests for `initialize`, `tools/list`, `tools/call`, and other MCP methods. The `Accept` header determines the response format:
 
-**Request**: Tool-specific JSON payload
+- `application/json` — synchronous JSON response
+- `text/event-stream` — SSE streaming response (for long-running tool calls)
 
-**Response**: `200 OK` — Tool result
+Returns `501` when MCP is disabled in the AF configuration.
+
+**Example — list available tools:**
 
 ```json
 {
-  "result": { ... },
-  "metadata": {
-    "tool": "kubernaut_investigate",
-    "duration_ms": 1250
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/list"
+}
+```
+
+**Example — invoke a tool:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "kubernaut_investigate",
+    "arguments": {
+      "rr_id": "rr-b83e19d4a7f1-5c2d09ae",
+      "action": "start"
+    }
   }
 }
 ```
 
-### Tool Discovery
+The AF proxies tool calls to the Kubernaut Agent's MCP server, where the 3 interactive tools (`kubernaut_investigate`, `kubernaut_select_workflow`, `kubernaut_complete_no_action`) are registered.
+
+### A2A JSON-RPC 2.0
 
 ```
-GET /mcp/tools
+POST /a2a/invoke
 ```
 
-Returns the list of available MCP tools with their schemas. Filtered by the caller's SAR permissions — only tools the user is authorized to invoke are returned.
-
-**Response**: `200 OK`
-
-```json
-{
-  "tools": [
-    {
-      "name": "kubernaut_investigate",
-      "description": "Start, reconnect to, check status of, or complete an investigation",
-      "input_schema": { ... }
-    }
-  ]
-}
-```
-
-## SSE Streaming
-
-### Subscribe to Investigation Stream
-
-```
-GET /mcp/stream/{session_id}
-```
-
-Opens a Server-Sent Events connection for real-time investigation output.
-
-**Event types**:
-
-| Event | Data | Description |
-|---|---|---|
-| `token` | `{"text": "..."}` | LLM output token |
-| `tool_call` | `{"tool": "...", "args": {...}}` | Tool invocation by the LLM |
-| `tool_result` | `{"tool": "...", "result": {...}}` | Tool result returned to the LLM |
-| `phase` | `{"phase": "rca_complete"}` | Investigation phase transition |
-| `keepalive` | `{}` | Connection keepalive ping |
-| `error` | `{"message": "..."}` | Stream error |
-| `done` | `{"session_id": "..."}` | Investigation complete |
-
-**Example SSE stream**:
-
-```
-event: token
-data: {"text": "Checking pod logs for "}
-
-event: token
-data: {"text": "checkout-service..."}
-
-event: tool_call
-data: {"tool": "kubectl_logs", "args": {"pod": "checkout-service-7b4d9", "namespace": "production"}}
-
-event: tool_result
-data: {"tool": "kubectl_logs", "result": {"truncated": true, "lines": 50}}
-
-event: phase
-data: {"phase": "rca_complete"}
-
-event: done
-data: {"session_id": "sess-a1b2c3d4"}
-```
-
-## A2A Endpoints
+Agent-to-Agent protocol endpoint accepting JSON-RPC 2.0 messages. Supported methods include `message/send`. Requires Bearer JWT authentication.
 
 ### Agent Card Discovery
 
@@ -132,74 +82,43 @@ data: {"session_id": "sess-a1b2c3d4"}
 GET /.well-known/agent-card.json
 ```
 
-Returns the A2A agent card for protocol discovery.
+Returns the A2A agent card for protocol discovery. Unauthenticated callers receive a shell card (metadata only, empty skills array). Authenticated callers receive the full card including available skills scoped to their RBAC role.
 
-### Task Submission
+## Operational Endpoints
 
-```
-POST /a2a/tasks
-```
-
-Submits an A2A task. The AF creates an `InvestigationSession` CRD linking the A2A task ID to remediation context.
-
-## Session Management
-
-### List Active Sessions
-
-```
-GET /api/v1/sessions
-```
-
-Returns active MCP/A2A sessions for the authenticated user.
-
-### Get Session
-
-```
-GET /api/v1/sessions/{session_id}
-```
-
-Returns session details including state, user, and linked investigation.
-
-## Audit Events
-
-The AF emits audit events to DataStorage for all significant operations:
-
-| Event Type | Trigger |
-|---|---|
-| `af.tool.invoked` | MCP tool call executed |
-| `af.tool.denied` | SAR denied a tool call |
-| `af.session.created` | New interactive session started |
-| `af.session.reconnected` | User reconnected to existing session |
-| `af.session.takeover` | Session taken over by different user (SEC-TAKEOVER-001) |
-| `af.session.abandoned` | Session abandoned due to takeover or timeout |
-| `af.session.completed` | Session completed normally |
-| `af.session.drained` | Session drained during pod shutdown |
-| `af.a2a.task.created` | A2A task submitted |
-
-## Health and Metrics
+### Health Probes
 
 | Method | Port | Path | Description |
 |---|---|---|---|
-| `GET` | 8081 | `/healthz` | Liveness |
-| `GET` | 8081 | `/readyz` | Readiness (checks OIDC provider, KA connectivity) |
-| `GET` | 9090 | `/metrics` | Prometheus metrics |
-| HTTPS | 8443 | `/mcp/*`, `/a2a/*`, `/api/*` | Primary API |
+| `GET` | 8081 | `/healthz` | Liveness — returns `ok` when the process is alive |
+| `GET` | 8081 | `/readyz` | Readiness — checks JWKS loaded and dependencies reachable; returns `503` during drain |
+| `GET` | 9090 | `/metrics` | Prometheus metrics in OpenMetrics format |
 
-See [Monitoring: API Frontend Metrics](../operations/monitoring.md#api-frontend-metrics-v15) for the full metrics reference.
+### Metrics
+
+All AF metrics use the `af_` namespace. See [Monitoring: API Frontend Metrics](../operations/monitoring.md#api-frontend-metrics-v15) for the full reference.
+
+## Audit Events
+
+The AF emits audit events to DataStorage for significant operations. Audit event support was wired in PR #1191 (shared AuditStore normalization) and PR #1192 (14 production audit events).
+
+!!! note "Audit event names are approximate"
+    Exact event type names should be verified against the DataStorage OpenAPI spec (`api/datastorage/openapi/`). The categories below reflect the scope of the implementation.
+
+Audit coverage includes: tool invocations, authorization decisions, session lifecycle events (create, reconnect, takeover, abandon, drain), and A2A task lifecycle.
 
 ## Error Responses
 
-All error responses use [RFC 7807 Problem Details](index.md#error-responses-rfc-7807) format.
+All error responses use [RFC 7807 Problem Details](index.md#error-responses-rfc-7807) format with `Content-Type: application/problem+json`.
 
-**Example** (SAR denied):
+**Example** (service not ready):
 
 ```json
 {
-  "type": "https://kubernaut.ai/problems/forbidden",
-  "title": "Forbidden",
-  "detail": "User 'developer@example.com' is not authorized to invoke tool 'kubernaut_investigate'",
-  "status": 403,
-  "instance": "/mcp/tools/kubernaut_investigate"
+  "type": "https://kubernaut.ai/problems/service-unavailable",
+  "title": "Service Unavailable",
+  "detail": "Service is draining — not accepting new requests",
+  "status": 503
 }
 ```
 
@@ -207,4 +126,4 @@ All error responses use [RFC 7807 Problem Details](index.md#error-responses-rfc-
 
 - [API Frontend Architecture](../architecture/apifrontend.md) — Design and session lifecycle
 - [Interactive Sessions](../user-guide/interactive-sessions.md) — Operator guide for MCP sessions
-- [Security & RBAC: Tool Authorization](../architecture/security-rbac.md#tool-authorization-v15) — SAR model and ClusterRoles
+- [Security & RBAC: Tool Authorization](../architecture/security-rbac.md#tool-authorization-v15) — RBAC model for tool access

--- a/docs/api-reference/apifrontend-api.md
+++ b/docs/api-reference/apifrontend-api.md
@@ -1,0 +1,210 @@
+# API Frontend API
+
+!!! warning "This page is under active development for v1.5 GA"
+
+The API Frontend (AF) is the unified external gateway introduced in v1.5. It exposes MCP, A2A, and REST protocols for operators, AI agents, and the Backstage console.
+
+## Base URL
+
+```
+https://kubernaut-apifrontend.kubernaut-system.svc.cluster.local:8443
+```
+
+External clients connect via the cluster ingress or OpenShift Route configured for the API Frontend.
+
+## Authentication
+
+All requests require a valid OIDC/OAuth2 bearer token:
+
+```
+Authorization: Bearer <jwt-token>
+```
+
+The AF validates tokens via the configured OIDC provider (DEX, Keycloak) and extracts user identity from JWT claims.
+
+## Authorization
+
+Every MCP tool call is authorized via Kubernetes **SubjectAccessReview (SAR)**:
+
+- **Resource**: `tools/<tool-name>`
+- **API Group**: `kubernaut.ai`
+- **Verb**: `use`
+
+Authorization is **fail-closed** — if the SAR API is unreachable, the tool call is denied. Results are cached with a configurable TTL (default 30s).
+
+See [Security & RBAC: Tool Authorization](../architecture/security-rbac.md#tool-authorization-v15) for ClusterRole definitions and binding examples.
+
+## MCP Endpoints
+
+### Tool Invocation
+
+```
+POST /mcp/tools/{tool_name}
+```
+
+Invokes an MCP tool. The AF performs SAR authorization, then proxies the call to the appropriate backend service (Kubernaut Agent or DataStorage).
+
+**Request**: Tool-specific JSON payload
+
+**Response**: `200 OK` — Tool result
+
+```json
+{
+  "result": { ... },
+  "metadata": {
+    "tool": "kubernaut_investigate",
+    "duration_ms": 1250
+  }
+}
+```
+
+### Tool Discovery
+
+```
+GET /mcp/tools
+```
+
+Returns the list of available MCP tools with their schemas. Filtered by the caller's SAR permissions — only tools the user is authorized to invoke are returned.
+
+**Response**: `200 OK`
+
+```json
+{
+  "tools": [
+    {
+      "name": "kubernaut_investigate",
+      "description": "Start, reconnect to, check status of, or complete an investigation",
+      "input_schema": { ... }
+    }
+  ]
+}
+```
+
+## SSE Streaming
+
+### Subscribe to Investigation Stream
+
+```
+GET /mcp/stream/{session_id}
+```
+
+Opens a Server-Sent Events connection for real-time investigation output.
+
+**Event types**:
+
+| Event | Data | Description |
+|---|---|---|
+| `token` | `{"text": "..."}` | LLM output token |
+| `tool_call` | `{"tool": "...", "args": {...}}` | Tool invocation by the LLM |
+| `tool_result` | `{"tool": "...", "result": {...}}` | Tool result returned to the LLM |
+| `phase` | `{"phase": "rca_complete"}` | Investigation phase transition |
+| `keepalive` | `{}` | Connection keepalive ping |
+| `error` | `{"message": "..."}` | Stream error |
+| `done` | `{"session_id": "..."}` | Investigation complete |
+
+**Example SSE stream**:
+
+```
+event: token
+data: {"text": "Checking pod logs for "}
+
+event: token
+data: {"text": "checkout-service..."}
+
+event: tool_call
+data: {"tool": "kubectl_logs", "args": {"pod": "checkout-service-7b4d9", "namespace": "production"}}
+
+event: tool_result
+data: {"tool": "kubectl_logs", "result": {"truncated": true, "lines": 50}}
+
+event: phase
+data: {"phase": "rca_complete"}
+
+event: done
+data: {"session_id": "sess-a1b2c3d4"}
+```
+
+## A2A Endpoints
+
+### Agent Card Discovery
+
+```
+GET /.well-known/agent-card.json
+```
+
+Returns the A2A agent card for protocol discovery.
+
+### Task Submission
+
+```
+POST /a2a/tasks
+```
+
+Submits an A2A task. The AF creates an `InvestigationSession` CRD linking the A2A task ID to remediation context.
+
+## Session Management
+
+### List Active Sessions
+
+```
+GET /api/v1/sessions
+```
+
+Returns active MCP/A2A sessions for the authenticated user.
+
+### Get Session
+
+```
+GET /api/v1/sessions/{session_id}
+```
+
+Returns session details including state, user, and linked investigation.
+
+## Audit Events
+
+The AF emits audit events to DataStorage for all significant operations:
+
+| Event Type | Trigger |
+|---|---|
+| `af.tool.invoked` | MCP tool call executed |
+| `af.tool.denied` | SAR denied a tool call |
+| `af.session.created` | New interactive session started |
+| `af.session.reconnected` | User reconnected to existing session |
+| `af.session.takeover` | Session taken over by different user (SEC-TAKEOVER-001) |
+| `af.session.abandoned` | Session abandoned due to takeover or timeout |
+| `af.session.completed` | Session completed normally |
+| `af.session.drained` | Session drained during pod shutdown |
+| `af.a2a.task.created` | A2A task submitted |
+
+## Health and Metrics
+
+| Method | Port | Path | Description |
+|---|---|---|---|
+| `GET` | 8081 | `/healthz` | Liveness |
+| `GET` | 8081 | `/readyz` | Readiness (checks OIDC provider, KA connectivity) |
+| `GET` | 9090 | `/metrics` | Prometheus metrics |
+| HTTPS | 8443 | `/mcp/*`, `/a2a/*`, `/api/*` | Primary API |
+
+See [Monitoring: API Frontend Metrics](../operations/monitoring.md#api-frontend-metrics-v15) for the full metrics reference.
+
+## Error Responses
+
+All error responses use [RFC 7807 Problem Details](index.md#error-responses-rfc-7807) format.
+
+**Example** (SAR denied):
+
+```json
+{
+  "type": "https://kubernaut.ai/problems/forbidden",
+  "title": "Forbidden",
+  "detail": "User 'developer@example.com' is not authorized to invoke tool 'kubernaut_investigate'",
+  "status": 403,
+  "instance": "/mcp/tools/kubernaut_investigate"
+}
+```
+
+## Next Steps
+
+- [API Frontend Architecture](../architecture/apifrontend.md) — Design and session lifecycle
+- [Interactive Sessions](../user-guide/interactive-sessions.md) — Operator guide for MCP sessions
+- [Security & RBAC: Tool Authorization](../architecture/security-rbac.md#tool-authorization-v15) — SAR model and ClusterRoles

--- a/docs/api-reference/datastorage-api.md
+++ b/docs/api-reference/datastorage-api.md
@@ -25,7 +25,7 @@ https://data-storage-service.kubernaut-system.svc.cluster.local:8080
 |---|---|---|
 | `POST` | `/api/v1/audit/events` | Store a single audit event |
 | `POST` | `/api/v1/audit/events/batch` | Store a batch of audit events |
-| `GET` | `/api/v1/audit/events` | Query audit events (with filters) |
+| `GET` | `/api/v1/audit/events` | Query audit events (with filters, including JSONB `detail_key`/`detail_value` for correlation — PR #1201) |
 | `POST` | `/api/v1/audit/notifications` | Store a notification audit event |
 
 ### Remediation Reconstruction

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -1,6 +1,6 @@
 # API Reference
 
-- **[Custom Resources (CRDs)](crds.md)** — Spec, status, and phase definitions for all 9 CRD types. Documents the full spec and status schema for each CRD in the remediation pipeline.
+- **[Custom Resources (CRDs)](crds.md)** — Spec, status, and phase definitions for all 10 CRD types (v1.5+). Documents the full spec and status schema for each CRD in the remediation pipeline.
 - **[Operator CR](operator-cr.md)** — API reference for the `Kubernaut` CR (`kubernaut.ai/v1alpha1`) used by the Kubernaut Operator. Documents all spec fields, type definitions, status, and RBAC resources.
 - **[DataStorage API](datastorage-api.md)** — REST API for audit events, workflow catalog, and reconstruction. REST endpoints for querying audit data, workflow catalog, and reconstruction.
 - **[Kubernaut Agent](kubernaut-agent-api.md)** — Session-based async API for LLM-powered root cause analysis. Documents endpoints for LLM-driven investigation, infrastructure label detection, and workflow discovery.

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -4,10 +4,11 @@
 - **[Operator CR](operator-cr.md)** — API reference for the `Kubernaut` CR (`kubernaut.ai/v1alpha1`) used by the Kubernaut Operator. Documents all spec fields, type definitions, status, and RBAC resources.
 - **[DataStorage API](datastorage-api.md)** — REST API for audit events, workflow catalog, and reconstruction. REST endpoints for querying audit data, workflow catalog, and reconstruction.
 - **[Kubernaut Agent](kubernaut-agent-api.md)** — Session-based async API for LLM-powered root cause analysis. Documents endpoints for LLM-driven investigation, infrastructure label detection, and workflow discovery.
+- **[API Frontend](apifrontend-api.md)** — MCP/A2A/REST gateway for external clients (v1.5+). Documents MCP tool endpoints, SSE streaming, session management, and SAR authorization.
 
 ## Error Responses (RFC 7807)
 
-All Kubernaut HTTP APIs return errors in [RFC 7807 Problem Details](https://datatracker.ietf.org/doc/html/rfc7807) format. This applies to the Gateway signal ingestion endpoint, the DataStorage REST API, and Kubernaut Agent.
+All Kubernaut HTTP APIs return errors in [RFC 7807 Problem Details](https://datatracker.ietf.org/doc/html/rfc7807) format. This applies to the Gateway signal ingestion endpoint, the DataStorage REST API, Kubernaut Agent, and the API Frontend.
 
 **Content-Type**: `application/problem+json`
 

--- a/docs/api-reference/kubernaut-agent-api.md
+++ b/docs/api-reference/kubernaut-agent-api.md
@@ -149,104 +149,41 @@ All error responses (4xx, 5xx) use [RFC 7807 Problem Details](index.md#error-res
 }
 ```
 
-## Interactive Session Endpoints (v1.5+)
+## Interactive MCP Mode (v1.5+)
 
-v1.5 adds interactive MCP session support to Kubernaut Agent, consumed by the API Frontend. These endpoints power the [interactive sessions](../user-guide/interactive-sessions.md) feature.
+v1.5 adds interactive MCP session support to the Kubernaut Agent. Interactive tools are **not exposed as REST endpoints** — they are registered on the go-sdk MCP server (`internal/kubernautagent/mcp/`) and accessed via MCP Streamable HTTP through the API Frontend's `POST /mcp` endpoint.
 
-### Start Interactive Investigation
+The existing REST API is unchanged. The MCP server runs alongside it, registering 3 tools:
 
-```
-POST /api/v1/interactive/investigate
-```
+| MCP Tool | Description |
+|---|---|
+| `kubernaut_investigate` | 8-action tool: start, message, complete, cancel, takeover, status, reconnect, discover_workflows |
+| `kubernaut_select_workflow` | Select a workflow from discovery results; triggers enrichment and catalog lookup |
+| `kubernaut_complete_no_action` | Close investigation without selecting a workflow |
 
-Starts an interactive investigation session with Lease-based distributed locking.
+See [Interactive Sessions](../user-guide/interactive-sessions.md) for the full tool schemas and operator guide.
 
-**Request**:
+### SSE Streaming
 
-```json
-{
-  "action": "start",
-  "signal_name": "PodCrashLoopBackOff",
-  "namespace": "production",
-  "resource_kind": "Deployment",
-  "resource_name": "checkout-service",
-  "user_id": "sre@example.com"
-}
-```
-
-**Response**: `200 OK` — Session created with Lease
-
-```json
-{
-  "session_id": "sess-a1b2c3d4",
-  "status": "investigating",
-  "lease_name": "kubernaut-session-sess-a1b2c3d4"
-}
-```
-
-### Reconnect to Session
+The existing REST endpoint supports real-time streaming for interactive sessions:
 
 ```
-POST /api/v1/interactive/investigate
+GET /api/v1/incident/session/{session_id}/stream
 ```
 
-Reconnect to an existing session (same user) or trigger takeover (different user).
+The API Frontend subscribes to this SSE stream and relays events to MCP clients.
 
-**Request**:
+### Additional REST Endpoints (v1.5)
 
-```json
-{
-  "action": "reconnect",
-  "session_id": "sess-a1b2c3d4",
-  "user_id": "sre@example.com"
-}
-```
-
-### Discover Workflows
-
-```
-POST /api/v1/interactive/discover
-```
-
-After RCA completes, returns matching workflows with LLM-populated parameters.
-
-**Response**: `200 OK`
-
-```json
-{
-  "session_id": "sess-a1b2c3d4",
-  "alternatives": [
-    {
-      "workflow_id": "restart-and-patch-memory",
-      "description": "Bump memory limit + rolling restart",
-      "confidence": 0.91,
-      "risk": "low",
-      "parameters": { "memory_limit": "768Mi" }
-    }
-  ]
-}
-```
-
-### Select Workflow
-
-```
-POST /api/v1/interactive/select
-```
-
-Operator selects a workflow from the discovery results. Parameters are validated against the workflow schema with LLM self-correction on validation failure.
-
-### Stream Investigation (SSE)
-
-```
-GET /api/v1/interactive/stream/{session_id}
-```
-
-Server-Sent Events stream of real-time investigation output. See [API Frontend API: SSE Streaming](apifrontend-api.md#sse-streaming) for event types.
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/v1/incident/session/{session_id}/cancel` | Cancel an investigation session |
+| `GET` | `/api/v1/incident/session/{session_id}/snapshot` | Get a point-in-time session snapshot |
 
 ## Session Management
 
 - **Autonomous sessions** are stored **in-memory** in the Kubernaut Agent pod. If the pod restarts, sessions are lost — the AI Analysis controller handles this by regenerating sessions (up to 5 attempts).
-- **Interactive sessions** (v1.5+) use **Kubernetes Leases** for distributed locking. Orphaned Leases are reclaimed on startup via `ReconcileOrphanedLeases`. The `SessionDrainer` gracefully drains active sessions on pod shutdown.
+- **Interactive sessions** (v1.5+) use **Kubernetes Leases** (prefix: `kubernaut-interactive-`) for distributed locking. The `LeaseSessionManager` handles session creation, takeover (SEC-TAKEOVER-001), and TTL enforcement. Orphaned Leases are reclaimed on startup. The `SessionDrainer` gracefully drains active sessions on pod shutdown (BR-OPS-013).
 - Session results are available until the pod restarts or the session is garbage-collected
 
 ## LLM Providers

--- a/docs/api-reference/kubernaut-agent-api.md
+++ b/docs/api-reference/kubernaut-agent-api.md
@@ -149,10 +149,104 @@ All error responses (4xx, 5xx) use [RFC 7807 Problem Details](index.md#error-res
 }
 ```
 
+## Interactive Session Endpoints (v1.5+)
+
+v1.5 adds interactive MCP session support to Kubernaut Agent, consumed by the API Frontend. These endpoints power the [interactive sessions](../user-guide/interactive-sessions.md) feature.
+
+### Start Interactive Investigation
+
+```
+POST /api/v1/interactive/investigate
+```
+
+Starts an interactive investigation session with Lease-based distributed locking.
+
+**Request**:
+
+```json
+{
+  "action": "start",
+  "signal_name": "PodCrashLoopBackOff",
+  "namespace": "production",
+  "resource_kind": "Deployment",
+  "resource_name": "checkout-service",
+  "user_id": "sre@example.com"
+}
+```
+
+**Response**: `200 OK` — Session created with Lease
+
+```json
+{
+  "session_id": "sess-a1b2c3d4",
+  "status": "investigating",
+  "lease_name": "kubernaut-session-sess-a1b2c3d4"
+}
+```
+
+### Reconnect to Session
+
+```
+POST /api/v1/interactive/investigate
+```
+
+Reconnect to an existing session (same user) or trigger takeover (different user).
+
+**Request**:
+
+```json
+{
+  "action": "reconnect",
+  "session_id": "sess-a1b2c3d4",
+  "user_id": "sre@example.com"
+}
+```
+
+### Discover Workflows
+
+```
+POST /api/v1/interactive/discover
+```
+
+After RCA completes, returns matching workflows with LLM-populated parameters.
+
+**Response**: `200 OK`
+
+```json
+{
+  "session_id": "sess-a1b2c3d4",
+  "alternatives": [
+    {
+      "workflow_id": "restart-and-patch-memory",
+      "description": "Bump memory limit + rolling restart",
+      "confidence": 0.91,
+      "risk": "low",
+      "parameters": { "memory_limit": "768Mi" }
+    }
+  ]
+}
+```
+
+### Select Workflow
+
+```
+POST /api/v1/interactive/select
+```
+
+Operator selects a workflow from the discovery results. Parameters are validated against the workflow schema with LLM self-correction on validation failure.
+
+### Stream Investigation (SSE)
+
+```
+GET /api/v1/interactive/stream/{session_id}
+```
+
+Server-Sent Events stream of real-time investigation output. See [API Frontend API: SSE Streaming](apifrontend-api.md#sse-streaming) for event types.
+
 ## Session Management
 
-- Sessions are stored **in-memory** in the Kubernaut Agent pod
-- If the pod restarts, sessions are lost — the AI Analysis controller handles this by regenerating sessions (up to 5 attempts)
+- **Autonomous sessions** are stored **in-memory** in the Kubernaut Agent pod. If the pod restarts, sessions are lost — the AI Analysis controller handles this by regenerating sessions (up to 5 attempts).
+- **Interactive sessions** (v1.5+) use **Kubernetes Leases** for distributed locking. Orphaned Leases are reclaimed on startup via `ReconcileOrphanedLeases`. The `SessionDrainer` gracefully drains active sessions on pod shutdown.
 - Session results are available until the pod restarts or the session is garbage-collected
 
 ## LLM Providers

--- a/docs/api-reference/mcp-tools.md
+++ b/docs/api-reference/mcp-tools.md
@@ -1,0 +1,676 @@
+# MCP Tool Reference
+
+The API Frontend exposes **23 `kubernaut_*` MCP tools** on its Streamable HTTP endpoint (`POST /mcp`).
+Each tool is SAR-gated via [per-persona ClusterRoles](../architecture/security-rbac.md#per-persona-clusterroles), rate-limited, and audit-logged.
+
+All tools return JSON in MCP `CallToolResult` text content. Default timeout is 30 s (configurable per tool).
+RBAC is fail-closed — SAR errors deny the call.
+
+!!! tip "Building skills on Kubernaut tools"
+    When authoring MCP skills or prompts that call these tools, use the **"When to use"** guidance below each tool to select the right one.
+    Check the [Persona Access Matrix](#persona-access-matrix) to ensure the caller's ClusterRole includes the tool.
+
+---
+
+## RemediationRequest
+
+Backend: **K8s API** (AF ServiceAccount) — operates on `kubernaut.ai/v1alpha1/remediationrequests`.
+
+- **`kubernaut_list_remediations`** — List active and recent remediations with optional filtering
+
+    - `namespace` (`string`) **(required)** — Kubernetes namespace
+    - `phase` (`string`) — Filter by `status.overallPhase` (e.g. `Pending`, `Running`, `Completed`, `Failed`)
+    - `kind` (`string`) — Filter by `spec.targetResource.kind`
+    - `name` (`string`) — Filter by `spec.targetResource.name`
+
+    **When to use:** First step in any remediation workflow — discover what's active before drilling into a specific RR.
+
+    ??? example "Response"
+        ```json
+        {
+          "remediations": [
+            {
+              "id": "prod/oom-fix-abc",
+              "namespace": "prod",
+              "name": "oom-fix-abc",
+              "phase": "Running",
+              "kind": "Deployment",
+              "target": "api-server"
+            }
+          ],
+          "count": 1
+        }
+        ```
+
+    **Personas:** SRE, AI Orchestrator, CI/CD, Observability, L3 Audit
+
+---
+
+- **`kubernaut_get_remediation`** — Get details of a specific remediation
+
+    - `namespace` (`string`) — Remediation namespace
+    - `name` (`string`) — Remediation name
+    - `rr_id` (`string`) — Shorthand `namespace/name`
+
+    Provide `rr_id` **or** both `namespace` + `name`.
+
+    **When to use:** Inspect a known remediation for phase, target resource, and status. Follow up after `kubernaut_list_remediations`.
+
+    ??? example "Response"
+        ```json
+        {
+          "id": "prod/oom-fix-abc",
+          "namespace": "prod",
+          "name": "oom-fix-abc",
+          "phase": "Completed",
+          "kind": "Deployment",
+          "target": "api-server"
+        }
+        ```
+
+    **Personas:** SRE, AI Orchestrator, CI/CD, Observability, L3 Audit
+
+---
+
+- **`kubernaut_cancel_remediation`** — Cancel an active remediation that has not yet reached a terminal state
+
+    - `namespace` (`string`) — Remediation namespace
+    - `name` (`string`) — Remediation name
+    - `rr_id` (`string`) — Shorthand `namespace/name`
+
+    Provide `rr_id` **or** both `namespace` + `name`. Fails if the phase is already terminal (`Completed`, `Failed`, `Cancelled`).
+
+    **When to use:** Abort a remediation that is no longer needed or was started in error. Check phase with `kubernaut_get_remediation` first.
+
+    ??? example "Response"
+        ```json
+        {
+          "status": "Cancelled",
+          "message": "Remediation prod/oom-fix-abc cancelled"
+        }
+        ```
+
+    **Personas:** SRE
+
+---
+
+- **`kubernaut_watch`** — Stream live status updates for a remediation and its related resources
+
+    - `namespace` (`string`) **(required)** — Remediation namespace
+    - `name` (`string`) **(required)** — Remediation name
+
+    Blocks until terminal phase, context cancellation, or internal 10-minute cap.
+
+    **When to use:** Stay in the remediation journey — call after `kubernaut_select_workflow` to see phase transitions in real time (`Pending` → `Approved` → `Running` → `Completed`/`Failed`).
+
+    ??? example "Response"
+        ```json
+        {
+          "events": [
+            {
+              "timestamp": "2026-05-23T18:30:00Z",
+              "resource": "RemediationRequest",
+              "phase": "Running",
+              "message": "Workflow execution started"
+            }
+          ],
+          "status": "completed"
+        }
+        ```
+
+    **Personas:** SRE, AI Orchestrator, CI/CD, Observability, Remediation Approver
+
+---
+
+## RemediationApprovalRequest
+
+Backend: **K8s API** (AF ServiceAccount) — operates on `kubernaut.ai/v1alpha1/remediationapprovalrequests`.
+
+- **`kubernaut_list_approval_requests`** — List approval requests with optional filtering by decision status
+
+    - `namespace` (`string`) **(required)** — Namespace to list RARs in
+    - `decision` (`string`) — Filter: `pending`, `approved`, `rejected`, `expired` (empty = all)
+
+    **When to use:** Discover pending approval requests. First step in the approval UX flow before drilling into a specific RAR.
+
+    ??? example "Response"
+        ```json
+        {
+          "approval_requests": [
+            {
+              "name": "rar-oom-fix-abc",
+              "namespace": "prod",
+              "decision": "Pending",
+              "remediation_request": "oom-fix-abc",
+              "confidence": 0.85,
+              "confidence_level": "High",
+              "time_remaining": "28m",
+              "required_by": "2026-05-23T19:00:00Z"
+            }
+          ],
+          "count": 1
+        }
+        ```
+
+    **Personas:** Remediation Approver
+
+---
+
+- **`kubernaut_get_approval_request`** — Get full details of a specific approval request for review before deciding
+
+    - `namespace` (`string`) — RAR namespace
+    - `name` (`string`) — RAR name
+    - `rar_id` (`string`) — Shorthand `namespace/name`
+
+    Provide `rar_id` **or** both `namespace` + `name`.
+
+    **When to use:** Inspect an RAR's investigation summary, evidence, recommended actions, and alternatives before calling `kubernaut_approve`.
+
+    ??? example "Response"
+        ```json
+        {
+          "name": "rar-oom-fix-abc",
+          "namespace": "prod",
+          "remediation_request": "oom-fix-abc",
+          "ai_analysis": "Memory limit insufficient for traffic spike",
+          "confidence": 0.85,
+          "confidence_level": "High",
+          "investigation_summary": "Root cause: memory limit 256Mi too low...",
+          "why_approval_required": "Confidence below auto-approve threshold",
+          "recommended_workflow": { "name": "adjust-memory-limits", "version": "v2" },
+          "recommended_actions": [
+            { "action": "Increase memory limit to 512Mi", "rationale": "Matches p99 usage" }
+          ],
+          "evidence_collected": [
+            "pod/api-server-xyz OOMKilled",
+            "metrics: mem_usage_p99=480Mi"
+          ],
+          "alternatives_considered": [
+            { "approach": "HPA scale-out", "pros_cons": "Cheaper but doesn't fix root cause" }
+          ],
+          "decision": "Pending",
+          "time_remaining": "28m",
+          "expired": false
+        }
+        ```
+
+    **Personas:** Remediation Approver
+
+---
+
+- **`kubernaut_approve`** — Approve or reject a pending remediation approval request
+
+    - `namespace` (`string`) **(required)** — RAR namespace
+    - `rar_name` (`string`) **(required)** — RemediationApprovalRequest name
+    - `decision` (`string`) **(required)** — `Approved`, `Rejected`, or `Expired`
+    - `reason` (`string`) — Decision rationale (stored as `status.decisionMessage`)
+    - `workflow_override` (`string`) — Override workflow (stored as `status.workflowOverride.workflowName`)
+
+    **When to use:** Final step in the approval flow after reviewing the RAR with `kubernaut_get_approval_request`. Always provide a `reason` for audit trail traceability.
+
+    ??? example "Response"
+        ```json
+        {
+          "status": "Approved",
+          "message": "Remediation approval Approved by alice@corp.com"
+        }
+        ```
+
+    **Personas:** Remediation Approver
+
+---
+
+## Investigation
+
+### Autonomous
+
+Backend: **KA REST** — dispatches to the Kubernaut Agent's REST API.
+
+- **`kubernaut_start_investigation`** — Start an AI-powered investigation, returning a session ID for tracking
+
+    - `namespace` (`string`) **(required)** — Target resource namespace
+    - `name` (`string`) **(required)** — Target resource / RR name
+    - `kind` (`string`) — Target resource kind
+
+    **When to use:** Begin an autonomous investigation. Use the returned `session_id` with `kubernaut_poll_investigation` or `kubernaut_stream_investigation` to track progress.
+
+    ??? example "Response"
+        ```json
+        {
+          "session_id": "sess-abc123",
+          "status": "started",
+          "message": "Investigation started for prod/api-server (session: sess-abc123)"
+        }
+        ```
+
+    **Personas:** SRE, AI Orchestrator
+
+---
+
+- **`kubernaut_poll_investigation`** — Check investigation progress (blocks ~15 s, 5 polls at 3 s intervals)
+
+    - `session_id` (`string`) **(required)** — Investigation session ID
+
+    Re-call if status is `in_progress`.
+
+    **When to use:** Lightweight polling alternative when SSE streaming is unavailable. Prefer `kubernaut_stream_investigation` for real-time narrative.
+
+    ??? example "Response"
+        ```json
+        {
+          "status": "completed",
+          "summary": "Root cause identified: OOMKilled due to memory limit...",
+          "poll_count": 3
+        }
+        ```
+
+    **Personas:** SRE, AI Orchestrator
+
+---
+
+- **`kubernaut_stream_investigation`** — Stream live investigation events in real time (default timeout: 15 min)
+
+    - `session_id` (`string`) **(required)** — Investigation session ID
+
+    Blocks until terminal SSE event or timeout.
+
+    **When to use:** Best experience for interactive users — see the AI agent's reasoning unfold in real time. Use after `kubernaut_start_investigation`.
+
+    ??? example "Response"
+        ```json
+        {
+          "status": "completed",
+          "summary": "Root cause identified: OOMKilled due to memory limit...",
+          "events": [
+            { "type": "progress", "phase": "inspection", "text": "Checking pod status..." },
+            { "type": "progress", "phase": "analysis", "text": "Analyzing resource limits..." }
+          ],
+          "event_log": "Checking pod status...\nAnalyzing resource limits..."
+        }
+        ```
+
+    **Personas:** SRE, AI Orchestrator
+
+---
+
+### Interactive Session Lifecycle
+
+Backend: **KA MCP** — dispatches to the Kubernaut Agent's MCP server (`POST /api/v1/mcp`).
+
+All interactive tools share a common response shape:
+
+```json
+{
+  "session_id": "string (optional)",
+  "status": "string",
+  "message": "string (optional)"
+}
+```
+
+- **`kubernaut_takeover`** — Take over an existing investigation for human-in-the-loop participation
+
+    - `rr_id` (`string`) **(required)** — Remediation request ID (`namespace/name`)
+    - `message` (`string`) — Optional message (max 10 240 chars)
+
+    **When to use:** Join an in-progress autonomous investigation. The AI agent pauses and the session becomes interactive.
+
+    **Personas:** SRE, AI Orchestrator
+
+---
+
+- **`kubernaut_message`** — Send a message to an active investigation session
+
+    - `rr_id` (`string`) **(required)** — Remediation request ID
+    - `message` (`string`) **(required)** — Message content (max 10 240 chars)
+
+    **When to use:** Converse with the AI agent during an interactive session — provide context, ask questions, or steer the investigation.
+
+    **Personas:** SRE, AI Orchestrator
+
+---
+
+- **`kubernaut_complete`** — Complete an investigation session
+
+    - `rr_id` (`string`) **(required)** — Remediation request ID
+    - `message` (`string`) — Optional completion message
+
+    **When to use:** Signal that the investigation is done. If a workflow was selected, this triggers the remediation pipeline.
+
+    **Personas:** SRE, AI Orchestrator
+
+---
+
+- **`kubernaut_cancel`** — Cancel an active investigation session
+
+    - `rr_id` (`string`) **(required)** — Remediation request ID
+    - `message` (`string`) — Optional cancellation reason
+
+    **When to use:** Abort an interactive session that is no longer needed. The session is released and the MCP lease is freed.
+
+    **Personas:** SRE, AI Orchestrator
+
+---
+
+- **`kubernaut_status`** — Get the current status of an investigation session
+
+    - `rr_id` (`string`) **(required)** — Remediation request ID
+
+    **When to use:** Check session state (active, completed, disconnected) before sending a message or reconnecting.
+
+    **Personas:** SRE, AI Orchestrator
+
+---
+
+- **`kubernaut_reconnect`** — Reconnect to a disconnected investigation session
+
+    - `rr_id` (`string`) **(required)** — Remediation request ID
+    - `message` (`string`) — Optional message
+
+    **When to use:** Resume a session after a network disconnect or client restart. Check status with `kubernaut_status` first.
+
+    **Personas:** SRE, AI Orchestrator
+
+---
+
+## Workflow
+
+- **`kubernaut_discover_workflows`** — Discover available workflows with parameter schemas for a remediation
+
+    Backend: **KA MCP**
+
+    - `rr_id` (`string`) **(required)** — Remediation request ID
+    - `workflow_id` (`string`) — Filter to a specific workflow
+    - `kind` (`string`) — Filter by resource kind
+
+    Requires an active investigation session. Triggers LLM-driven workflow discovery based on investigation context. Parameters are pre-populated by the AI agent.
+
+    **When to use:** After the investigation completes and the user asks to fix/remediate — present workflow options with pre-populated parameters. Follow up with `kubernaut_select_workflow`.
+
+    ??? example "Response"
+        ```json
+        {
+          "workflows": [
+            {
+              "workflow_id": "adjust-memory-limits",
+              "name": "Adjust Memory Limits",
+              "description": "Increase container memory limits based on usage analysis",
+              "kind": "Deployment",
+              "parameters": [
+                {
+                  "name": "memory_limit",
+                  "type": "string",
+                  "description": "New memory limit (e.g. 512Mi)",
+                  "required": true,
+                  "default": "512Mi"
+                }
+              ]
+            }
+          ],
+          "count": 1
+        }
+        ```
+
+    **Personas:** SRE, AI Orchestrator
+
+---
+
+- **`kubernaut_select_workflow`** — Select a workflow for execution
+
+    Backend: **KA MCP**
+
+    - `rr_id` (`string`) **(required)** — Remediation request ID
+    - `workflow_id` (`string`) **(required)** — Workflow to select (must be from discovery results)
+    - `kind` (`string`) — Target resource kind
+    - `name` (`string`) — Target resource name
+    - `namespace` (`string`) — Target namespace
+    - `parameters` (`object`) — Workflow parameter values
+
+    Requires a prior `kubernaut_discover_workflows` call — the `workflow_id` must be from the discovery results.
+
+    **When to use:** User has chosen a workflow from the discovery results. This triggers enrichment and creates a RemediationRequest. Follow up with `kubernaut_watch` to track execution.
+
+    ??? example "Response"
+        ```json
+        {
+          "status": "selected",
+          "message": "Workflow adjust-memory-limits selected for prod/api-server"
+        }
+        ```
+
+    **Personas:** SRE, AI Orchestrator
+
+---
+
+- **`kubernaut_list_workflows`** — List available remediation workflows from the catalog
+
+    Backend: **DataStorage**
+
+    - `kind` (`string`) — Filter by resource kind
+
+    **When to use:** Browse the full workflow catalog without an active investigation. Unlike `kubernaut_discover_workflows`, this does not require a session and returns catalog entries without LLM-based recommendations.
+
+    ??? example "Response"
+        ```json
+        {
+          "workflows": [
+            {
+              "id": "adjust-memory-limits",
+              "name": "Adjust Memory Limits",
+              "description": "Increase container memory limits",
+              "kind": "Deployment"
+            }
+          ],
+          "count": 1
+        }
+        ```
+
+    **Personas:** SRE, Observability, L3 Audit
+
+---
+
+## Data & History
+
+Backend: **DataStorage** — queries the Kubernaut DataStorage service.
+
+- **`kubernaut_get_remediation_history`** — Query historical remediations with optional filtering
+
+    - `namespace` (`string`) — Filter by namespace
+    - `kind` (`string`) — Filter by target kind
+    - `name` (`string`) — Filter by target name
+    - `since` (`string`) — Time filter
+
+    **When to use:** Analyze past remediation outcomes for a resource, namespace, or time window. Useful for trend analysis and post-incident reviews.
+
+    ??? example "Response"
+        ```json
+        {
+          "remediations": [
+            {
+              "id": "prod/oom-fix-abc",
+              "namespace": "prod",
+              "phase": "Completed",
+              "created_at": "2026-05-22T14:00:00Z",
+              "workflow": "adjust-memory-limits"
+            }
+          ],
+          "count": 1
+        }
+        ```
+
+    **Personas:** SRE, L3 Audit
+
+---
+
+- **`kubernaut_get_effectiveness`** — Get effectiveness scores and metrics for remediation workflows
+
+    - `workflow_id` (`string`) — Filter by workflow
+    - `namespace` (`string`) — Filter by namespace
+
+    **When to use:** Evaluate how well a workflow performs before recommending it. Compare success rates across workflows or namespaces.
+
+    ??? example "Response"
+        ```json
+        {
+          "workflow_id": "adjust-memory-limits",
+          "success_rate": 0.92,
+          "avg_duration": "4m30s",
+          "sample_size": 24
+        }
+        ```
+
+    **Personas:** SRE, Observability, L3 Audit
+
+---
+
+- **`kubernaut_get_audit_trail`** — Retrieve the audit trail for a remediation, showing all actions and decisions
+
+    - `rr_id` (`string`) **(required)** — Remediation request ID
+    - `event_type` (`string`) — Filter by event type
+
+    **When to use:** Compliance review — trace every action taken on a remediation from signal to completion. Required for L3 audits and post-incident reports.
+
+    ??? example "Response"
+        ```json
+        {
+          "events": [
+            {
+              "timestamp": "2026-05-23T18:30:00Z",
+              "event_type": "tool.executed",
+              "actor": "alice@corp.com",
+              "detail": "kubernaut_approve: Approved"
+            }
+          ],
+          "count": 1
+        }
+        ```
+
+    **Personas:** SRE, L3 Audit
+
+---
+
+## Presentation
+
+- **`kubernaut_present_decision`** — Present investigation results and remediation options to the user for a decision
+
+    Backend: **Local** (no backend call — formats a human-readable decision prompt)
+
+    - `session_id` (`string`) **(required)** — Investigation session ID
+    - `summary` (`string`) **(required)** — Investigation summary / RCA text
+    - `options` (`array`) **(required)** — Workflow choices to present
+        - `options[].workflow_id` (`string`) **(required)** — Workflow identifier
+        - `options[].name` (`string`) **(required)** — Display name
+        - `options[].description` (`string`) **(required)** — Option description
+        - `options[].risk` (`string`) — Risk label
+
+    **When to use:** Called by the AF agent to format investigation results into a structured decision prompt. Typically not called directly by external skills — the AF agent calls it internally after streaming an investigation.
+
+    ??? example "Response"
+        ```json
+        {
+          "presented": true,
+          "message": "Investigation complete.\n\nSummary: Memory limit insufficient...\n\nAvailable actions:\n  1. Adjust Memory Limits (Risk: Low)"
+        }
+        ```
+
+    **Personas:** SRE, AI Orchestrator
+
+---
+
+## Common UX Flows
+
+### Approval flow
+
+```
+kubernaut_list_approval_requests(namespace, decision="pending")
+  → kubernaut_get_approval_request(namespace, name)
+    → kubernaut_approve(namespace, rar_name, decision, reason)
+```
+
+### Autonomous investigation flow
+
+```
+kubernaut_start_investigation(namespace, name)
+  → kubernaut_stream_investigation(session_id)
+    → kubernaut_discover_workflows(rr_id)
+      → kubernaut_select_workflow(rr_id, workflow_id)
+        → kubernaut_watch(namespace, name)
+```
+
+### Interactive investigation flow
+
+```
+kubernaut_list_remediations(namespace)
+  → kubernaut_takeover(rr_id)
+    → kubernaut_message(rr_id, message)  # repeat as needed
+      → kubernaut_discover_workflows(rr_id)
+        → kubernaut_select_workflow(rr_id, workflow_id)
+          → kubernaut_watch(namespace, name)
+```
+
+### Compliance audit flow
+
+```
+kubernaut_list_remediations(namespace)
+  → kubernaut_get_remediation(rr_id)
+    → kubernaut_get_audit_trail(rr_id)
+      → kubernaut_get_effectiveness(workflow_id)
+```
+
+---
+
+## Backend Routing Summary
+
+| Backend | Tools |
+|---------|-------|
+| **K8s API** (AF SA) | `list_remediations`, `get_remediation`, `cancel_remediation`, `watch`, `approve`, `list_approval_requests`, `get_approval_request` |
+| **KA REST** | `start_investigation`, `poll_investigation`, `stream_investigation` |
+| **KA MCP** | `takeover`, `message`, `complete`, `cancel`, `status`, `reconnect`, `discover_workflows`, `select_workflow` |
+| **DataStorage** | `list_workflows`, `get_remediation_history`, `get_effectiveness`, `get_audit_trail` |
+| **Local** | `present_decision` |
+
+---
+
+## Persona Access Matrix
+
+All tool names below are prefixed with `kubernaut_`.
+
+| Tool | SRE | AI Orch. | CI/CD | Obs. | L3 Audit | Approver |
+|------|:---:|:--------:|:-----:|:----:|:--------:|:--------:|
+| `list_remediations` | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | |
+| `get_remediation` | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | |
+| `cancel_remediation` | :material-check: | | | | | |
+| `watch` | :material-check: | :material-check: | :material-check: | :material-check: | | :material-check: |
+| `list_approval_requests` | | | | | | :material-check: |
+| `get_approval_request` | | | | | | :material-check: |
+| `approve` | | | | | | :material-check: |
+| `start_investigation` | :material-check: | :material-check: | | | | |
+| `poll_investigation` | :material-check: | :material-check: | | | | |
+| `stream_investigation` | :material-check: | :material-check: | | | | |
+| `takeover` | :material-check: | :material-check: | | | | |
+| `message` | :material-check: | :material-check: | | | | |
+| `complete` | :material-check: | :material-check: | | | | |
+| `cancel` | :material-check: | :material-check: | | | | |
+| `status` | :material-check: | :material-check: | | | | |
+| `reconnect` | :material-check: | :material-check: | | | | |
+| `discover_workflows` | :material-check: | :material-check: | | | | |
+| `select_workflow` | :material-check: | :material-check: | | | | |
+| `list_workflows` | :material-check: | | | :material-check: | :material-check: | |
+| `get_remediation_history` | :material-check: | | | | :material-check: | |
+| `get_effectiveness` | :material-check: | | | :material-check: | :material-check: | |
+| `get_audit_trail` | :material-check: | | | | :material-check: | |
+| `present_decision` | :material-check: | :material-check: | | | | |
+
+---
+
+## Internal Tools (Not MCP-Exposed)
+
+The AF also uses 5 internal tools that run under the AF pod's own ServiceAccount inside the agent loop.
+These are **not** exposed via MCP/A2A, are **not** SAR-gated, and cannot be called by external clients.
+
+| Tool | Purpose |
+|------|---------|
+| `kubectl_get` | Get any namespaced K8s resource by kind/name/namespace (Secret `.data` redacted) |
+| `kubectl_list` | List namespaced K8s resources with optional label selector (Secret `.data` redacted) |
+| `kubectl_list_events` | List K8s events with reason/object filters |
+| `af_check_existing_rr` | Check for duplicate RemediationRequest before creation |
+| `af_create_rr` | Create a new RemediationRequest CRD |

--- a/docs/api-reference/operator-cr.md
+++ b/docs/api-reference/operator-cr.md
@@ -302,7 +302,7 @@ The operator creates **14** baseline ClusterRoles (namespace-prefixed as `{names
 | `data-storage-auth-middleware` | DataStorage auth | |
 | `data-storage-client` | DataStorage client | |
 | `authwebhook-role` | Auth Webhook | |
-| `apifrontend-role` | API Frontend | v1.5+ — SAR, impersonation, InvestigationSession CRD |
+| `apifrontend-role` | API Frontend | v1.5+ — SAR, InvestigationSession CRD, RR/RAR access, cluster context triage |
 | `alertmanager-view` | Monitoring only | When `spec.monitoring.enabled: true` |
 | `gateway-signal-source` | Monitoring only | When `spec.monitoring.enabled: true` |
 | `kubernaut-tool-sre` | SAR tool persona | v1.5+ — from `spec.apiFrontend.rbac.roleBindings` |

--- a/docs/api-reference/operator-cr.md
+++ b/docs/api-reference/operator-cr.md
@@ -31,8 +31,9 @@ The `Kubernaut` custom resource (`kubernaut.ai/v1alpha1`) is the single deployme
 | `workflowExecution` | [WorkflowExecutionSpec](#workflowexecutionspec) | — | Execution namespace, cooldown, Tekton toggle |
 | `effectivenessMonitor` | EffectivenessMonitorSpec | — | Stabilization/validity windows |
 | `gateway` | [GatewaySpec](#gatewayspec) | — | Route, CORS, trusted proxies, deduplication |
+| `apiFrontend` | [APIFrontendSpec](#apifrontendspec) | enabled | MCP/A2A gateway, OIDC auth, SAR-based tool authorization (v1.5+) |
 | `authWebhook` | AuthWebhookSpec | — | Logging, resources |
-| `dataStorage` | DataStorageSpec | — | Logging, resources |
+| `dataStorage` | [DataStorageSpec](#datastoragespec) | — | Endpoint propagation delay, retention, logging, resources |
 | `networkPolicies` | [NetworkPoliciesSpec](#networkpoliciesspec) | disabled | Kubernetes NetworkPolicy creation |
 
 ---
@@ -46,7 +47,7 @@ The `Kubernaut` custom resource (`kubernaut.ai/v1alpha1`) is the single deployme
 | `host` | string | **yes** | — | PostgreSQL hostname |
 | `port` | int | no | `5432` | PostgreSQL port |
 | `secretName` | string | **yes** | — | Secret containing `username`, `password`, `database` keys |
-| `sslMode` | string | no | — | SSL mode: `disable`, `require`, `verify-ca`, `verify-full` |
+| `sslMode` | string | no | — | SSL mode: `require`, `verify-ca`, `verify-full`. The `disable` value is rejected by CR validation. |
 
 ### ValkeySpec
 
@@ -172,6 +173,91 @@ The `Kubernaut` custom resource (`kubernaut.ai/v1alpha1`) is the single deployme
 | `config.corsAllowedOrigins` | []string | CORS allowed origins |
 | `config.deduplicationCooldown` | string | Signal deduplication cooldown |
 
+### APIFrontendSpec (v1.5+) {: #apifrontendspec }
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `enabled` | *bool | no | `true` | Deploy the API Frontend. Set `false` to skip all AF resources |
+| `auth` | [APIFrontendAuthSpec](#apifrontendauthspec) | no | — | OIDC authentication |
+| `rateLimit` | [APIFrontendRateLimitSpec](#apifrontendratelimitspec) | no | — | Request rate limiting |
+| `shutdown` | [APIFrontendShutdownSpec](#apifrontendshutdownspec) | no | — | Graceful shutdown |
+| `externalURL` | string | no | auto-derived | A2A agent card discovery URL (must be HTTPS when set) |
+| `rbac` | [APIFrontendRBACSpec](#apifrontendrbacspec) | no | — | SAR-based tool authorization and role bindings |
+| `logging` | LoggingSpec | no | — | Log level |
+| `resources` | ResourceRequirements | no | — | CPU/memory requests and limits |
+
+### APIFrontendAuthSpec {: #apifrontendauthspec }
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `issuerURL` | string | — | OIDC issuer URL (e.g., `https://login.kubernaut.ai/realms/kubernaut`) |
+| `audience` | string | `kubernaut-apifrontend` | Expected JWT audience claim |
+| `jwtProviders` | [][JWTProviderSpec](#jwtproviderspec) | — | One or more OIDC JWT providers |
+| `allowInsecureJWKS` | bool | `false` | Permit HTTP JWKS URLs for dev/test. **Must be `false` in production.** |
+
+### JWTProviderSpec {: #jwtproviderspec }
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Human-readable provider name (1–63 chars) |
+| `jwksURL` | string | JWKS endpoint URL. Must use HTTPS unless `allowInsecureJWKS` is true |
+
+### APIFrontendRBACSpec {: #apifrontendrbacspec }
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `sarCacheTTL` | string | `30s` | Cache duration for SAR results (Go duration format) |
+| `roleBindings` | [][ToolRoleBinding](#toolrolebinding) | — | Maps persona-based tool roles to OIDC groups |
+
+### ToolRoleBinding {: #toolrolebinding }
+
+| Field | Type | Description |
+|---|---|---|
+| `role` | string | Persona name. One of: `sre`, `ai-orchestrator`, `cicd`, `observability`, `l3-audit`, `remediation-approver` |
+| `groups` | []string | OIDC group names to bind to this role (min 1) |
+
+**Example:**
+
+```yaml
+spec:
+  apiFrontend:
+    auth:
+      issuerURL: https://dex.kubernaut.svc.cluster.local:5556/dex
+      audience: kubernaut-apifrontend
+    rbac:
+      sarCacheTTL: 30s
+      roleBindings:
+        - role: sre
+          groups: ["sre-team", "platform-eng"]
+        - role: observability
+          groups: ["monitoring-team"]
+        - role: remediation-approver
+          groups: ["change-mgmt"]
+```
+
+### APIFrontendRateLimitSpec {: #apifrontendratelimitspec }
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `ipRequestsPerSec` | *int | `50` | Per-IP requests per second |
+| `userRequestsPerSec` | *int | `20` | Per-user requests per second |
+| `maxConcurrentSessions` | *int | `100` | Maximum concurrent MCP/A2A sessions |
+
+### APIFrontendShutdownSpec {: #apifrontendshutdownspec }
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `drainSeconds` | *int | `15` | Seconds to wait for in-flight requests to drain (0–300) |
+
+### DataStorageSpec {: #datastoragespec }
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `endpointPropagationDelay` | string | `10s` | Delay before newly created endpoints are considered ready |
+| `retention` | RetentionSpec | — | Periodic purge of expired audit events (FedRAMP AU-11) |
+| `logging` | LoggingSpec | — | Log level |
+| `resources` | ResourceRequirements | — | CPU/memory requests and limits |
+
 ### NetworkPoliciesSpec
 
 | Field | Type | Default | Description |
@@ -188,33 +274,41 @@ The `Kubernaut` custom resource (`kubernaut.ai/v1alpha1`) is the single deployme
 | Field | Type | Description |
 |---|---|---|
 | `phase` | KubernautPhase | Current phase: `Validating`, `Migrating`, `Deploying`, `Running`, `Degraded`, `Error` |
-| `conditions` | []metav1.Condition | Standard Kubernetes conditions |
+| `conditions` | []metav1.Condition | Standard Kubernetes conditions (includes `AnsibleReady`, `ToolRBACBound`) |
 | `services` | []ServiceStatus | Per-service readiness (`name`, `ready`, `readyReplicas`, `desiredReplicas`) |
 | `lastMigrationHash` | string | Hash of last successful DB migration |
 | `lastMigrationTime` | metav1.Time | Timestamp of last migration |
 | `boundAdditionalClusterRoles` | []string | Currently bound additional ClusterRoles |
+| `boundToolRoleBindings` | []string | Currently managed tool role binding CRB names (for stale-pruning and finalizer cleanup) |
 
 ---
 
 ## RBAC
 
-The operator creates **13** baseline ClusterRoles (namespace-prefixed as `{namespace}-{base}`), plus **2** monitoring-only ClusterRoles when `spec.monitoring.enabled: true`. See [Security & RBAC](../architecture/security-rbac.md) for the full permission matrix.
+The operator creates **14** baseline ClusterRoles (namespace-prefixed as `{namespace}-{base}`), plus **2** monitoring-only ClusterRoles when `spec.monitoring.enabled: true`, **6** per-persona tool ClusterRoles for SAR authorization, and optionally **1** Ansible ClusterRole. See [Security & RBAC](../architecture/security-rbac.md) for the full permission matrix.
 
-| ClusterRole base name | Component |
-|---|---|
-| `gateway-role` | Gateway |
-| `aianalysis-controller` | AI Analysis |
-| `kubernaut-agent-client` | KA ↔ service access |
-| `kubernaut-agent-investigator` | KA cluster-wide read |
-| `signalprocessing-controller` | Signal Processing |
-| `remediationorchestrator-controller` | Remediation Orchestrator |
-| `workflowexecution-controller` | Workflow Execution |
-| `workflow-runner` | Workflow Runner (Jobs) |
-| `effectivenessmonitor-controller` | Effectiveness Monitor |
-| `notification-controller` | Notification |
-| `data-storage-auth-middleware` | DataStorage auth |
-| `data-storage-client` | DataStorage client |
-| `authwebhook-role` | Auth Webhook |
-| `alertmanager-view` | Monitoring only |
-| `gateway-signal-source` | Monitoring only |
-| `workflowexecution-awx` | Ansible only |
+| ClusterRole base name | Component | Notes |
+|---|---|---|
+| `gateway-role` | Gateway | |
+| `aianalysis-controller` | AI Analysis | |
+| `kubernaut-agent-client` | KA ↔ service access | |
+| `kubernaut-agent-investigator` | KA cluster-wide read | |
+| `signalprocessing-controller` | Signal Processing | |
+| `remediationorchestrator-controller` | Remediation Orchestrator | |
+| `workflowexecution-controller` | Workflow Execution | |
+| `workflow-runner` | Workflow Runner (Jobs) | |
+| `effectivenessmonitor-controller` | Effectiveness Monitor | |
+| `notification-controller` | Notification | |
+| `data-storage-auth-middleware` | DataStorage auth | |
+| `data-storage-client` | DataStorage client | |
+| `authwebhook-role` | Auth Webhook | |
+| `apifrontend-role` | API Frontend | v1.5+ — SAR, impersonation, InvestigationSession CRD |
+| `alertmanager-view` | Monitoring only | When `spec.monitoring.enabled: true` |
+| `gateway-signal-source` | Monitoring only | When `spec.monitoring.enabled: true` |
+| `kubernaut-tool-sre` | SAR tool persona | v1.5+ — from `spec.apiFrontend.rbac.roleBindings` |
+| `kubernaut-tool-ai-orchestrator` | SAR tool persona | v1.5+ |
+| `kubernaut-tool-cicd` | SAR tool persona | v1.5+ |
+| `kubernaut-tool-observability` | SAR tool persona | v1.5+ |
+| `kubernaut-tool-l3-audit` | SAR tool persona | v1.5+ |
+| `kubernaut-tool-remediation-approver` | SAR tool persona | v1.5+ |
+| `workflowexecution-awx` | Ansible only | When `spec.ansible.enabled: true` |

--- a/docs/architecture/apifrontend.md
+++ b/docs/architecture/apifrontend.md
@@ -11,7 +11,7 @@ The AF sits between external clients and the Kubernaut Engine, handling:
 - **Protocol translation** — MCP tool calls and A2A tasks are translated into internal Kubernaut API calls
 - **Authentication** — OIDC/OAuth2 via JWKS validation with JWT claim extraction
 - **Authorization** — Kubernetes-native SAR-based tool authorization (PR #1222); fail-closed with TTL cache
-- **MCP bridge** — Dispatches 23 `kubernaut_*` tools to their backends (K8s API, KA REST, KA MCP, DataStorage) with per-tool routing
+- **MCP bridge** — Dispatches 23 `kubernaut_*` MCP tools to their backends (K8s API, KA REST, KA MCP, DataStorage) with per-tool routing
 - **Streaming** — Relays Server-Sent Events from KA's SSE endpoint to MCP clients
 
 ## Agentic Architecture

--- a/docs/architecture/apifrontend.md
+++ b/docs/architecture/apifrontend.md
@@ -9,10 +9,10 @@ The API Frontend (AF) is the unified external protocol layer introduced in v1.5.
 The AF sits between external clients and the Kubernaut Engine, handling:
 
 - **Protocol translation** — MCP tool calls and A2A tasks are translated into internal Kubernaut API calls
-- **Authentication** — OIDC/OAuth2 via DEX with JWT claim extraction
-- **Authorization** — Kubernetes SAR-based tool-level authorization (replaces file-based RBAC)
-- **Session management** — Lease-based distributed locking for interactive MCP sessions
-- **Streaming** — Server-Sent Events (SSE) for real-time investigation output
+- **Authentication** — OIDC/OAuth2 via JWKS validation with JWT claim extraction
+- **Authorization** — File-based RBAC via `rbac_roles.yaml` (SAR-based authorization [planned](https://github.com/jordigilh/kubernaut/issues/1221))
+- **Session proxy** — MCP tool calls proxied to KA, where Lease-based session management is implemented
+- **Streaming** — Relays Server-Sent Events from KA's SSE endpoint to MCP clients
 
 ## Agentic Architecture
 
@@ -52,7 +52,7 @@ The AF sits between external clients and the Kubernaut Engine, handling:
   <!-- ── API Frontend bar ── -->
   <rect x="16" y="108" width="788" height="56" rx="10" fill="#8B5CF6" stroke="#7C3AED" stroke-width="1.5"/>
   <text x="410" y="134" text-anchor="middle" font-size="16" font-weight="700" fill="white">API Frontend</text>
-  <text x="410" y="152" text-anchor="middle" font-size="10" fill="rgba(255,255,255,0.8)">MCP Bridge · A2A Executor · REST API · SAR Authorizer · Session Manager</text>
+  <text x="410" y="152" text-anchor="middle" font-size="10" fill="rgba(255,255,255,0.8)">MCP Streamable HTTP · A2A JSON-RPC · OIDC Auth · RBAC</text>
 
   <!-- ── Arrows: AF → Engine ── -->
   <line x1="250" y1="164" x2="250" y2="190" stroke="#B0B0B0" stroke-width="1.3"/>
@@ -124,34 +124,40 @@ The AF sits between external clients and the Kubernaut Engine, handling:
 
 ## Session Lifecycle
 
-Interactive MCP sessions use **Kubernetes Leases** for distributed locking. This ensures exactly one active session per investigation, even across KA pod restarts.
+Interactive MCP sessions are managed by the **Kubernaut Agent's MCP layer** (`internal/kubernautagent/mcp/`), not the API Frontend. The AF proxies MCP protocol to KA, which owns session state.
 
 ### Lease-based distributed locking
 
-Each interactive session acquires a Lease in the `kubernaut-system` namespace. The Lease acts as a distributed lock:
+The `LeaseSessionManager` in KA uses Kubernetes coordination/v1 Leases (prefix: `kubernaut-interactive-`) for single-driver guarantee (BR-INTERACTIVE-002):
 
-- **Acquisition** — On `action:start`, KA creates a Lease named after the session ID
-- **Renewal** — Active sessions renew the Lease at regular intervals
-- **Orphan reclamation** — On startup, KA scans for Leases whose holder identity no longer exists and reclaims them (`ReconcileOrphanedLeases`)
-- **Same-user reconnect** — If the same user reconnects to their own session, the existing Lease is reused without interruption
+- **Acquisition** — On `action:start`, KA creates a Lease in `kubernaut-system`
+- **TTL** — Default session TTL is 30 minutes; configurable via `InteractiveConfig.SessionTTL`
+- **Inactivity timeout** — Sessions expire after a configurable period of no activity
+- **Max sessions** — Configurable cap; rejects new sessions when capacity is exhausted (SEC-03)
+- **Orphan reclamation** — On startup, KA scans for Leases whose holder identity no longer exists and reclaims them
+- **Same-user reconnect** — If the same user reconnects, the existing Lease is reused
 
 ### Session takeover (SEC-TAKEOVER-001)
 
 When User B connects to a session owned by User A:
 
-1. User A's investigation is **abandoned** (not completed) — this prevents identity confusion
+1. User A's investigation is **abandoned** (not completed) — prevents identity confusion
 2. The Lease holder is updated to User B
 3. An audit event is emitted recording the takeover
 4. User B starts a fresh investigation in the same session context
 
+### Disconnect handling (DD-INTERACTIVE-002)
+
+The `SessionClosedHandler` monitors MCP connection closures via the `DelegatingEventStore`. On disconnect, it triggers session release and reconstruction.
+
 ### Graceful shutdown — SessionDrainer
 
-When a KA pod receives SIGTERM:
+When a KA pod receives SIGTERM (BR-OPS-013):
 
-1. The `SessionDrainer` marks the pod as draining — no new sessions accepted
-2. Active sessions are given a grace period to complete
-3. Sessions that don't complete within the grace period are abandoned with audit events
-4. Pod terminates only after all sessions are drained or timed out
+1. The `SessionDrainer` notifies all connected MCP clients that the server is shutting down
+2. In-flight tool executions are given time to complete
+3. All active session Leases are released
+4. Pod terminates only after all sessions are drained
 
 ## SSE Streaming
 

--- a/docs/architecture/apifrontend.md
+++ b/docs/architecture/apifrontend.md
@@ -11,7 +11,7 @@ The AF sits between external clients and the Kubernaut Engine, handling:
 - **Protocol translation** — MCP tool calls and A2A tasks are translated into internal Kubernaut API calls
 - **Authentication** — OIDC/OAuth2 via JWKS validation with JWT claim extraction
 - **Authorization** — Kubernetes-native SAR-based tool authorization (PR #1222); fail-closed with TTL cache
-- **Session proxy** — MCP tool calls proxied to KA, where Lease-based session management is implemented
+- **MCP bridge** — Dispatches 23 `kubernaut_*` tools to their backends (K8s API, KA REST, KA MCP, DataStorage) with per-tool routing
 - **Streaming** — Relays Server-Sent Events from KA's SSE endpoint to MCP clients
 
 ## Agentic Architecture
@@ -124,7 +124,10 @@ The AF sits between external clients and the Kubernaut Engine, handling:
 
 ## Session Lifecycle
 
-Interactive MCP sessions are managed by the **Kubernaut Agent's MCP layer** (`internal/kubernautagent/mcp/`), not the API Frontend. The AF proxies MCP protocol to KA, which owns session state.
+Session management spans two layers:
+
+- **KA MCP layer** (`internal/kubernautagent/mcp/`) — Owns interactive investigation state via Lease-based single-driver locking. The AF dispatches interactive tools (`kubernaut_takeover`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect`, `kubernaut_select_workflow`, `kubernaut_discover_workflows`) to KA's MCP server.
+- **AF session layer** (`pkg/apifrontend/session/`) — Manages `InvestigationSession` CRDs with **deferred creation**: the CRD is not created when the A2A session starts, but only when `af_create_rr` succeeds and calls `MaterializeCRD()`. Sessions that never produce a RemediationRequest leave no cluster footprint.
 
 ### Lease-based distributed locking
 

--- a/docs/architecture/apifrontend.md
+++ b/docs/architecture/apifrontend.md
@@ -10,7 +10,7 @@ The AF sits between external clients and the Kubernaut Engine, handling:
 
 - **Protocol translation** — MCP tool calls and A2A tasks are translated into internal Kubernaut API calls
 - **Authentication** — OIDC/OAuth2 via JWKS validation with JWT claim extraction
-- **Authorization** — File-based RBAC via `rbac_roles.yaml` (SAR-based authorization [planned](https://github.com/jordigilh/kubernaut/issues/1221))
+- **Authorization** — Kubernetes-native SAR-based tool authorization (PR #1222); fail-closed with TTL cache
 - **Session proxy** — MCP tool calls proxied to KA, where Lease-based session management is implemented
 - **Streaming** — Relays Server-Sent Events from KA's SSE endpoint to MCP clients
 
@@ -165,18 +165,17 @@ The AF streams investigation output to clients via **Server-Sent Events**:
 
 - Token-by-token output from LLM responses
 - Keepalive pings at regular intervals to maintain the connection
-- Automatic reconnect support — clients can resume from the last received event
 - Investigation progress events (phase transitions, tool calls, results)
 
 ## Integration Points
 
 | Target | Protocol | Purpose |
 |---|---|---|
-| **Kubernaut Agent** | HTTP/REST | Investigation sessions, MCP tool proxying |
+| **Kubernaut Agent** | MCP JSON-RPC + HTTP/REST | MCP tool proxying, SSE streaming |
 | **DataStorage** | HTTP/REST | Workflow catalog, remediation history, audit events |
 | **LLM Provider** | HTTP/REST (via KA) | Severity triage with configurable confidence threshold |
-| **OIDC Provider** | OAuth2/OIDC | User authentication and JWT issuance |
-| **Kubernetes API** | SAR | Tool-level authorization |
+| **OIDC Provider** | OAuth2/OIDC | User authentication via JWKS |
+| **Kubernetes API** | SubjectAccessReview | SAR-based tool authorization (verb `use`, group `kubernaut.ai`, resource `tools`) |
 
 ## Health Checks
 

--- a/docs/architecture/apifrontend.md
+++ b/docs/architecture/apifrontend.md
@@ -1,0 +1,182 @@
+# API Frontend Architecture
+
+!!! warning "This page is under active development for v1.5 GA"
+
+The API Frontend (AF) is the unified external protocol layer introduced in v1.5. It provides MCP, A2A, and REST access to Kubernaut for operators, AI agents, and the Backstage console.
+
+## Overview
+
+The AF sits between external clients and the Kubernaut Engine, handling:
+
+- **Protocol translation** — MCP tool calls and A2A tasks are translated into internal Kubernaut API calls
+- **Authentication** — OIDC/OAuth2 via DEX with JWT claim extraction
+- **Authorization** — Kubernetes SAR-based tool-level authorization (replaces file-based RBAC)
+- **Session management** — Lease-based distributed locking for interactive MCP sessions
+- **Streaming** — Server-Sent Events (SSE) for real-time investigation output
+
+## Agentic Architecture
+
+<div style="max-width:100%;overflow-x:auto;margin:1.5rem 0">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 420" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" style="width:100%;height:auto">
+  <rect width="820" height="420" fill="white"/>
+
+  <!-- ── External Clients row ── -->
+  <text x="410" y="22" text-anchor="middle" font-size="11" font-weight="700" fill="#64748B" letter-spacing="1.5">EXTERNAL CLIENTS</text>
+
+  <rect x="16" y="34" width="186" height="52" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
+  <rect x="16" y="34" width="186" height="5" rx="3" fill="#0891B2"/>
+  <text x="109" y="58" text-anchor="middle" font-size="12" font-weight="700" fill="#1a1a1a">MCP (AI Interface)</text>
+  <text x="109" y="74" text-anchor="middle" font-size="9" fill="#888">Claude, Copilot, custom agents</text>
+
+  <rect x="214" y="34" width="186" height="52" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
+  <rect x="214" y="34" width="186" height="5" rx="3" fill="#0891B2"/>
+  <text x="307" y="58" text-anchor="middle" font-size="12" font-weight="700" fill="#1a1a1a">A2A Agent</text>
+  <text x="307" y="74" text-anchor="middle" font-size="9" fill="#888">Agent-to-Agent protocol</text>
+
+  <rect x="412" y="34" width="186" height="52" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
+  <rect x="412" y="34" width="186" height="5" rx="3" fill="#0891B2"/>
+  <text x="505" y="58" text-anchor="middle" font-size="12" font-weight="700" fill="#1a1a1a">Backstage</text>
+  <text x="505" y="74" text-anchor="middle" font-size="9" fill="#888">Operator console</text>
+
+  <rect x="610" y="34" width="194" height="52" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
+  <rect x="610" y="34" width="194" height="5" rx="3" fill="#0891B2"/>
+  <text x="707" y="58" text-anchor="middle" font-size="12" font-weight="700" fill="#1a1a1a">OIDC / OAuth2</text>
+  <text x="707" y="74" text-anchor="middle" font-size="9" fill="#888">DEX, Keycloak</text>
+
+  <!-- ── Arrows: clients → AF ── -->
+  <line x1="109" y1="86" x2="109" y2="106" stroke="#B0B0B0" stroke-width="1.3"/>
+  <line x1="307" y1="86" x2="307" y2="106" stroke="#B0B0B0" stroke-width="1.3"/>
+  <line x1="505" y1="86" x2="505" y2="106" stroke="#B0B0B0" stroke-width="1.3"/>
+  <line x1="707" y1="86" x2="707" y2="106" stroke="#B0B0B0" stroke-width="1.3"/>
+
+  <!-- ── API Frontend bar ── -->
+  <rect x="16" y="108" width="788" height="56" rx="10" fill="#8B5CF6" stroke="#7C3AED" stroke-width="1.5"/>
+  <text x="410" y="134" text-anchor="middle" font-size="16" font-weight="700" fill="white">API Frontend</text>
+  <text x="410" y="152" text-anchor="middle" font-size="10" fill="rgba(255,255,255,0.8)">MCP Bridge · A2A Executor · REST API · SAR Authorizer · Session Manager</text>
+
+  <!-- ── Arrows: AF → Engine ── -->
+  <line x1="250" y1="164" x2="250" y2="190" stroke="#B0B0B0" stroke-width="1.3"/>
+  <line x1="570" y1="164" x2="570" y2="190" stroke="#B0B0B0" stroke-width="1.3"/>
+
+  <!-- ── Kubernaut Engine container ── -->
+  <rect x="16" y="192" width="788" height="214" rx="12" fill="#0F172A"/>
+  <text x="410" y="216" text-anchor="middle" font-size="13" font-weight="700" fill="rgba(255,255,255,0.9)" letter-spacing="1">KUBERNAUT ENGINE</text>
+
+  <!-- Row 1: Gateway + Remediation Orchestrator -->
+  <rect x="36" y="228" width="160" height="48" rx="8" fill="rgba(255,255,255,0.08)" stroke="rgba(255,255,255,0.15)"/>
+  <rect x="36" y="228" width="160" height="4" rx="2" fill="#0891B2"/>
+  <text x="116" y="252" text-anchor="middle" font-size="11" font-weight="700" fill="white">Gateway</text>
+  <text x="116" y="266" text-anchor="middle" font-size="9" fill="rgba(255,255,255,0.55)">Webhook intake + dedup</text>
+
+  <rect x="216" y="228" width="380" height="48" rx="8" fill="rgba(255,255,255,0.08)" stroke="rgba(255,255,255,0.25)"/>
+  <rect x="216" y="228" width="380" height="4" rx="2" fill="white"/>
+  <text x="406" y="252" text-anchor="middle" font-size="12" font-weight="700" fill="white">Remediation Orchestrator</text>
+  <text x="406" y="266" text-anchor="middle" font-size="9" fill="rgba(255,255,255,0.55)">Owns RR lifecycle — creates child CRDs</text>
+
+  <rect x="616" y="228" width="168" height="48" rx="8" fill="rgba(255,255,255,0.08)" stroke="rgba(255,255,255,0.15)"/>
+  <rect x="616" y="228" width="168" height="4" rx="2" fill="#6366F1"/>
+  <text x="700" y="252" text-anchor="middle" font-size="11" font-weight="700" fill="white">Kubernaut Agent</text>
+  <text x="700" y="266" text-anchor="middle" font-size="9" fill="rgba(255,255,255,0.55)">LLM investigation (Go)</text>
+
+  <!-- Row 2: 5 phase controllers -->
+  <rect x="36" y="290" width="142" height="44" rx="6" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.12)"/>
+  <rect x="36" y="290" width="142" height="3" rx="2" fill="#0891B2"/>
+  <text x="107" y="312" text-anchor="middle" font-size="10" font-weight="600" fill="white">Signal Processing</text>
+  <text x="107" y="325" text-anchor="middle" font-size="8" fill="rgba(255,255,255,0.45)">Rego classification</text>
+
+  <rect x="188" y="290" width="142" height="44" rx="6" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.12)"/>
+  <rect x="188" y="290" width="142" height="3" rx="2" fill="#6366F1"/>
+  <text x="259" y="312" text-anchor="middle" font-size="10" font-weight="600" fill="white">AI Analysis</text>
+  <text x="259" y="325" text-anchor="middle" font-size="8" fill="rgba(255,255,255,0.45)">LLM RCA + selection</text>
+
+  <rect x="340" y="290" width="142" height="44" rx="6" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.12)"/>
+  <rect x="340" y="290" width="142" height="3" rx="2" fill="#D97706"/>
+  <text x="411" y="312" text-anchor="middle" font-size="10" font-weight="600" fill="white">Workflow Exec.</text>
+  <text x="411" y="325" text-anchor="middle" font-size="8" fill="rgba(255,255,255,0.45)">Tekton / Job / Ansible</text>
+
+  <rect x="492" y="290" width="142" height="44" rx="6" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.12)"/>
+  <rect x="492" y="290" width="142" height="3" rx="2" fill="#059669"/>
+  <text x="563" y="312" text-anchor="middle" font-size="10" font-weight="600" fill="white">Effectiveness</text>
+  <text x="563" y="325" text-anchor="middle" font-size="8" fill="rgba(255,255,255,0.45)">Health scoring + drift</text>
+
+  <rect x="644" y="290" width="142" height="44" rx="6" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.12)"/>
+  <rect x="644" y="290" width="142" height="3" rx="2" fill="#DC2626"/>
+  <text x="715" y="312" text-anchor="middle" font-size="10" font-weight="600" fill="white">Notification</text>
+  <text x="715" y="325" text-anchor="middle" font-size="8" fill="rgba(255,255,255,0.45)">Slack / PD / Teams</text>
+
+  <!-- Row 3: Support services -->
+  <rect x="36" y="348" width="240" height="44" rx="6" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.12)"/>
+  <rect x="36" y="348" width="3" height="44" rx="2" fill="#64748B"/>
+  <text x="54" y="370" font-size="10" font-weight="600" fill="white">DataStorage</text>
+  <text x="54" y="383" font-size="8" fill="rgba(255,255,255,0.45)">PostgreSQL + Valkey</text>
+
+  <rect x="290" y="348" width="240" height="44" rx="6" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.12)"/>
+  <rect x="290" y="348" width="3" height="44" rx="2" fill="#64748B"/>
+  <text x="308" y="370" font-size="10" font-weight="600" fill="white">AuthWebhook</text>
+  <text x="308" y="383" font-size="8" fill="rgba(255,255,255,0.45)">RAR override validation</text>
+
+  <rect x="544" y="348" width="240" height="44" rx="6" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.12)"/>
+  <rect x="544" y="348" width="3" height="44" rx="2" fill="#64748B"/>
+  <text x="562" y="370" font-size="10" font-weight="600" fill="white">LLM Provider</text>
+  <text x="562" y="383" font-size="8" fill="rgba(255,255,255,0.45)">OpenAI / Anthropic / Vertex AI</text>
+</svg>
+</div>
+
+## Session Lifecycle
+
+Interactive MCP sessions use **Kubernetes Leases** for distributed locking. This ensures exactly one active session per investigation, even across KA pod restarts.
+
+### Lease-based distributed locking
+
+Each interactive session acquires a Lease in the `kubernaut-system` namespace. The Lease acts as a distributed lock:
+
+- **Acquisition** — On `action:start`, KA creates a Lease named after the session ID
+- **Renewal** — Active sessions renew the Lease at regular intervals
+- **Orphan reclamation** — On startup, KA scans for Leases whose holder identity no longer exists and reclaims them (`ReconcileOrphanedLeases`)
+- **Same-user reconnect** — If the same user reconnects to their own session, the existing Lease is reused without interruption
+
+### Session takeover (SEC-TAKEOVER-001)
+
+When User B connects to a session owned by User A:
+
+1. User A's investigation is **abandoned** (not completed) — this prevents identity confusion
+2. The Lease holder is updated to User B
+3. An audit event is emitted recording the takeover
+4. User B starts a fresh investigation in the same session context
+
+### Graceful shutdown — SessionDrainer
+
+When a KA pod receives SIGTERM:
+
+1. The `SessionDrainer` marks the pod as draining — no new sessions accepted
+2. Active sessions are given a grace period to complete
+3. Sessions that don't complete within the grace period are abandoned with audit events
+4. Pod terminates only after all sessions are drained or timed out
+
+## SSE Streaming
+
+The AF streams investigation output to clients via **Server-Sent Events**:
+
+- Token-by-token output from LLM responses
+- Keepalive pings at regular intervals to maintain the connection
+- Automatic reconnect support — clients can resume from the last received event
+- Investigation progress events (phase transitions, tool calls, results)
+
+## Integration Points
+
+| Target | Protocol | Purpose |
+|---|---|---|
+| **Kubernaut Agent** | HTTP/REST | Investigation sessions, MCP tool proxying |
+| **DataStorage** | HTTP/REST | Workflow catalog, remediation history, audit events |
+| **LLM Provider** | HTTP/REST (via KA) | Severity triage with configurable confidence threshold |
+| **OIDC Provider** | OAuth2/OIDC | User authentication and JWT issuance |
+| **Kubernetes API** | SAR | Tool-level authorization |
+
+## Health Checks
+
+| Probe | Endpoint | Port |
+|---|---|---|
+| Liveness | `GET /healthz` | **8081** (plain HTTP) |
+| Readiness | `GET /readyz` | **8081** (plain HTTP) |
+| Metrics | `/metrics` | **9090** (plain HTTP) |
+| API | HTTPS | **8443** |

--- a/docs/architecture/audit-pipeline.md
+++ b/docs/architecture/audit-pipeline.md
@@ -101,6 +101,9 @@ Every audit event includes:
 | `resource_id` | `string` | Target resource identifier |
 | `correlation_id` | `string` | Links all events for one remediation |
 | `namespace` | `string` | Kubernetes namespace |
+| `actor_ip` | `string` | Client IP address of the actor (v1.5+, AF events) |
+| `target_namespace` | `string` | Namespace of the target K8s resource (v1.5+, AF events) |
+| `target_kind` | `string` | Kind of the target K8s resource (v1.5+, AF events) |
 | `event_data` | `JSONB` | Service-specific payload |
 | `event_hash` | `string` | SHA256 hash chain for integrity |
 | `previous_event_hash` | `string` | Previous event's hash |
@@ -141,7 +144,7 @@ All 11 Go services (`cmd/*/main.go`: Gateway, Signal Processing, AI Analysis, Re
 | **Effectiveness Monitor** | `effectiveness.*` | `health.assessed`, `hash.computed`, `alert.assessed`, `metrics.assessed`, `assessment.completed` |
 | **Auth Webhook** | `webhook.*`, `remediationworkflow.*`, `actiontype.*` | `remediationapprovalrequest.decided`, `remediationrequest.timeout_modified`, `notification.cancelled`, `remediationworkflow.admitted.create`, `remediationworkflow.admitted.delete`, `remediationworkflow.admitted.denied`, `actiontype.admitted.create`, `actiontype.admitted.update`, `actiontype.admitted.delete`, `actiontype.denied.create`, `actiontype.denied.update`, `actiontype.denied.delete` |
 | **DataStorage** | `datastorage.*`, `workflow.catalog.*` | `workflow.created`, `workflow.updated`, `actiontype.created`, `actiontype.updated`, `actiontype.disabled`, `actiontype.reenabled`, `actiontype.disable_denied`, `workflow.catalog.actions_listed`, `workflow.catalog.workflows_listed`, `workflow.catalog.workflow_retrieved`, `workflow.catalog.selection_validated` |
-| **API Frontend** | `apifrontend.*` | `rr.created`, `rr.deduplicated`, `ka.delegated`, `ka.result_received`, `user.decision`, `severity_triage.completed`, `severity_triage.failed`, `session.completed`, `impersonation.created`, `jwt.delegation`, `mcp.session_init`, `circuitbreaker.trip`, `triage.started`, `triage.completed` |
+| **API Frontend** | `apifrontend.*` | `rr.created`, `rr.deduplicated`, `ka.delegated`, `ka.result_received`, `user.decision`, `severity_triage.completed`, `severity_triage.failed`, `session.completed`, `jwt.delegation`, `mcp.session_init`, `circuitbreaker.trip`, `triage.started`, `triage.completed` |
 
 ## Operator Attribution
 

--- a/docs/architecture/audit-pipeline.md
+++ b/docs/architecture/audit-pipeline.md
@@ -127,7 +127,7 @@ All audit events for a single remediation share a `correlation_id` set to the `R
 
 ## Emitting Services
 
-All 10 Go services (`cmd/*/main.go`: Gateway, Signal Processing, AI Analysis, Remediation Orchestrator, Workflow Execution, Effectiveness Monitor, Notification, Auth Webhook, DataStorage, Kubernaut Agent) emit audit events:
+All 11 Go services (`cmd/*/main.go`: Gateway, Signal Processing, AI Analysis, Remediation Orchestrator, Workflow Execution, Effectiveness Monitor, Notification, Auth Webhook, DataStorage, Kubernaut Agent, API Frontend) emit audit events:
 
 | Service | Event Prefix | Key Events |
 |---|---|---|
@@ -141,6 +141,7 @@ All 10 Go services (`cmd/*/main.go`: Gateway, Signal Processing, AI Analysis, Re
 | **Effectiveness Monitor** | `effectiveness.*` | `health.assessed`, `hash.computed`, `alert.assessed`, `metrics.assessed`, `assessment.completed` |
 | **Auth Webhook** | `webhook.*`, `remediationworkflow.*`, `actiontype.*` | `remediationapprovalrequest.decided`, `remediationrequest.timeout_modified`, `notification.cancelled`, `remediationworkflow.admitted.create`, `remediationworkflow.admitted.delete`, `remediationworkflow.admitted.denied`, `actiontype.admitted.create`, `actiontype.admitted.update`, `actiontype.admitted.delete`, `actiontype.denied.create`, `actiontype.denied.update`, `actiontype.denied.delete` |
 | **DataStorage** | `datastorage.*`, `workflow.catalog.*` | `workflow.created`, `workflow.updated`, `actiontype.created`, `actiontype.updated`, `actiontype.disabled`, `actiontype.reenabled`, `actiontype.disable_denied`, `workflow.catalog.actions_listed`, `workflow.catalog.workflows_listed`, `workflow.catalog.workflow_retrieved`, `workflow.catalog.selection_validated` |
+| **API Frontend** | `apifrontend.*` | `rr.created`, `rr.deduplicated`, `ka.delegated`, `ka.result_received`, `user.decision`, `severity_triage.completed`, `severity_triage.failed`, `session.completed`, `impersonation.created`, `jwt.delegation`, `mcp.session_init`, `circuitbreaker.trip`, `triage.started`, `triage.completed` |
 
 ## Operator Attribution
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -67,6 +67,7 @@ Each service has a single responsibility:
 | **Notification** | Multi-channel delivery with routing, retry, circuit breaker | [Notification Pipeline](notification.md) |
 | **Effectiveness Monitor** | Post-remediation health, alert, metrics, and spec hash assessment | [Effectiveness Assessment](effectiveness.md) |
 | **DataStorage** | Persistent storage (audit, workflow catalog, remediation history, effectiveness), workflow scoring | [Data Persistence](data-persistence.md) |
+| **API Frontend** | MCP/A2A/REST gateway, SAR-based tool authorization, session management (v1.5+) | [API Frontend](apifrontend.md) |
 
 ## Service Topology
 
@@ -74,6 +75,10 @@ Each service has a single responsibility:
 graph TB
     subgraph Ingress["Signal Ingestion"]
         GW[Gateway<br/><small>Signals → CRD</small>]
+    end
+
+    subgraph External_API["External API Layer v1.5+"]
+        AF[API Frontend<br/><small>MCP / A2A / REST</small>]
     end
 
     subgraph Core["Core Pipeline"]
@@ -98,6 +103,9 @@ graph TB
         PG[(PostgreSQL)]
         RD[(Valkey)]
     end
+
+    AF -.->|MCP tools| KA
+    AF -.->|history, catalog| DS
 
     GW -->|RemediationRequest| RO
     RO -->|SignalProcessing| SP
@@ -182,7 +190,7 @@ Kubernaut uses a **three-port** split on components that serve both an API and o
 | **8081** | **Health probes only**, always **plain HTTP**: `GET /healthz` (liveness), `GET /readyz` (readiness). The path **`/livez` is not registered** — do not configure probes to use it. |
 | **9090** | **Prometheus metrics**, always **plain HTTP** at `GET /metrics`. |
 
-**Three-port** behavior applies to **Gateway**, **DataStorage**, **Kubernaut Agent**, and the **AIAnalysis** controller. Other controllers (**Remediation Orchestrator**, **Signal Processing**, **Workflow Execution**, **Notification**, **Effectiveness Monitor**) expose **metrics on 9090** as their Service port; they do not use the 8080/8081 API/health split.
+**Three-port** behavior applies to **Gateway**, **DataStorage**, **Kubernaut Agent**, the **AIAnalysis** controller, and the **API Frontend** (v1.5+). Other controllers (**Remediation Orchestrator**, **Signal Processing**, **Workflow Execution**, **Notification**, **Effectiveness Monitor**) expose **metrics on 9090** as their Service port; they do not use the 8080/8081 API/health split.
 
 **Auth Webhook** is an exception: the Service uses **port 443** with **targetPort 9443** for admission traffic; health checks use **8081** (`/healthz`, `/readyz`) like the other Go components.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -80,7 +80,7 @@ graph TB
     end
 
     subgraph External_API["External API Layer v1.5+"]
-        AF[API Frontend<br/><small>MCP / A2A / REST</small>]
+        AF[API Frontend<br/><small>MCP / A2A</small>]
     end
 
     subgraph Core["Core Pipeline"]

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -30,9 +30,11 @@ RemediationRequest (Gateway)
   └─ WorkflowExecution (Orchestrator → WE Controller)
   └─ EffectivenessAssessment (Orchestrator → EM Controller)
   └─ NotificationRequest (Orchestrator → Notification Controller)
+
+InvestigationSession (API Frontend — v1.5+, interactive MCP/A2A sessions)
 ```
 
-All child CRDs have owner references to the parent RR, enabling cascade deletion when the RR is garbage collected. The Orchestrator watches all child CRDs to detect status changes and advance the parent through its [phase state machine](remediation-routing.md#phase-state-machine).
+Pipeline child CRDs have owner references to the parent RR, enabling cascade deletion when the RR is garbage collected. `InvestigationSession` CRDs are created by the API Frontend independently of the Orchestrator pipeline; they also carry an owner reference to the associated RR for cascade cleanup. The Orchestrator watches all child CRDs to detect status changes and advance the parent through its [phase state machine](remediation-routing.md#phase-state-machine).
 
 ??? note "Detailed sub-phase breakdown"
 
@@ -106,6 +108,7 @@ graph TB
 
     AF -.->|MCP tools| KA
     AF -.->|history, catalog| DS
+    AF -->|InvestigationSession| AF
 
     GW -->|RemediationRequest| RO
     RO -->|SignalProcessing| SP
@@ -143,8 +146,9 @@ The complete CRD lifecycle for a single remediation follows the natural flow:
 | 5 | `WorkflowExecution` | Orchestrator | WE Controller | Run remediation workflow |
 | 6 | `EffectivenessAssessment` | Orchestrator | EM Controller | Post-execution verification |
 | 7 | `NotificationRequest` | Orchestrator | NT Controller | Outcome notification |
+| — | `InvestigationSession` | API Frontend | AF (SessionCleanup) | Interactive MCP/A2A session state (v1.5+); deferred — materialized only after RR creation |
 
-Each CRD has its own phase state machine. The Orchestrator monitors child CRD status and advances the parent RR accordingly.
+Each pipeline CRD has its own phase state machine. The Orchestrator monitors child CRD status and advances the parent RR accordingly. The `InvestigationSession` CRD follows its own lifecycle (Active → Disconnected → Completed/TimedOut) managed by the API Frontend's session cleanup reconciler.
 
 ## Namespace Model
 

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -241,7 +241,7 @@ The API Frontend ServiceAccount requires:
 
 | apiGroup | Resources | Verbs | Purpose |
 |---|---|---|---|
-| `apifrontend.kubernaut.ai` | `investigationsessions`, `investigationsessions/status` | get, list, watch, create, update, patch, delete | Session CRD management |
+| `kubernaut.ai` | `investigationsessions`, `investigationsessions/status` | get, list, watch, create, update, patch, delete | Session CRD management (PR #1224) |
 | `kubernaut.ai` | `remediationrequests` | get, list, create | RR access for interactive sessions |
 | `authorization.k8s.io` | `subjectaccessreviews` | create | SAR-based tool authorization |
 | _(core)_ | `users`, `groups`, `serviceaccounts` | impersonate | Triage tool delegation ([#1226](https://github.com/jordigilh/kubernaut/issues/1226) plans OIDC-direct mode to eliminate this) |

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -387,14 +387,14 @@ All 3 AF RBAC code paths (MCP bridge `checkRBAC()`, A2A agent `newRBACGuard()`, 
 
 The Helm chart ships 6 per-persona ClusterRoles via a data-driven template (`apifrontend.config.rbac.personas`):
 
-| ClusterRole | Persona | Tools |
-|---|---|---|
-| `kubernaut-tool-sre` | Full SRE access | All 20 tools |
-| `kubernaut-tool-ai-orchestrator` | Automated agent orchestration | Orchestration + triage + cluster context |
-| `kubernaut-tool-cicd` | CI/CD pipeline integration | list, get, watch |
-| `kubernaut-tool-observability` | Read-only observability | Read-only tools |
-| `kubernaut-tool-l3-audit` | Compliance and auditing | Audit, history, effectiveness |
-| `kubernaut-tool-remediation-approver` | Human approval workflows | Approve + read |
+| ClusterRole | Persona | Tool Count | Tools |
+|---|---|---|---|
+| `kubernaut-tool-sre` | Full SRE access | 19 | All SAR-gated tools |
+| `kubernaut-tool-ai-orchestrator` | Automated agent orchestration | 15 | Remediation lifecycle (5) + investigation (4) + cluster context (6) |
+| `kubernaut-tool-cicd` | CI/CD pipeline integration | 3 | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch` |
+| `kubernaut-tool-observability` | Read-only observability | 8 | list/get/watch + effectiveness + workflows + cluster context (4) |
+| `kubernaut-tool-l3-audit` | Compliance and auditing | 6 | list/get + workflows + history + effectiveness + audit trail |
+| `kubernaut-tool-remediation-approver` | Human approval workflows | 4 | `kubernaut_approve`, `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch` |
 
 ### Binding example
 

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -3,7 +3,7 @@
 Kubernaut follows a least-privilege model: each service runs under its own ServiceAccount with only the permissions it needs. This page is the consolidated reference for all RBAC resources.
 
 !!! info "Helm vs Operator RBAC"
-    The Helm chart and the Kubernaut Operator create the same logical set of ClusterRoles, but the **Operator** prefixes each name with the CR's namespace (e.g., `kubernaut-system-gateway-role`) to prevent collisions when multiple Kubernaut CRs exist. The Operator creates **13** baseline ClusterRoles, plus **2** additional ones (`alertmanager-view`, `gateway-signal-source`) when `spec.monitoring.enabled: true`. An optional `workflowexecution-awx` ClusterRole is created when Ansible integration is enabled.
+    The Helm chart and the Kubernaut Operator create the same logical set of ClusterRoles, but the **Operator** prefixes each name with the CR's namespace (e.g., `kubernaut-system-gateway-role`) to prevent collisions when multiple Kubernaut CRs exist. The Operator creates **14** baseline ClusterRoles (including the API Frontend ClusterRole in v1.5+), plus **2** additional ones (`alertmanager-view`, `gateway-signal-source`) when `spec.monitoring.enabled: true`, **6** per-persona tool ClusterRoles for SAR authorization (v1.5+), and an optional `workflowexecution-awx` ClusterRole when Ansible integration is enabled.
 
     The Operator also supports `spec.kubernautAgent.additionalClusterRoleBindings` — a list of pre-existing ClusterRole names to bind to the Kubernaut Agent ServiceAccount (max 64). **Use with caution**: any writable cluster-scoped privileges referenced here are granted to the agent, creating a privilege escalation path. Restrict who may edit the Kubernaut CR via cluster RBAC. See the [Operator threat model](https://github.com/jordigilh/kubernaut-operator/blob/main/docs/security/threat-model.md) for details.
 
@@ -219,6 +219,7 @@ Kubernaut Agent itself has a broad **read-only** ClusterRole (`kubernaut-agent-i
 | `security.istio.io` | authorizationpolicies, peerauthentications, requestauthentications | get, list, watch | Istio security policy investigation |
 | `networking.istio.io` | virtualservices, destinationrules, gateways, serviceentries | get, list, watch | Istio networking investigation |
 | `monitoring.coreos.com` | prometheusrules, servicemonitors, podmonitors, probes | get, list, watch | Monitoring investigation |
+| `config.openshift.io` | nodes, clusteroperators, clusterversions, infrastructures | get, list, watch | OCP platform investigation (Operator only) |
 
 This read-only access allows the LLM to investigate root causes using live cluster data without making changes.
 
@@ -389,10 +390,10 @@ The Helm chart ships 6 per-persona ClusterRoles via a data-driven template (`api
 
 | ClusterRole | Persona | Tool Count | Tools |
 |---|---|---|---|
-| `kubernaut-tool-sre` | Full SRE access | 19 | All SAR-gated tools |
-| `kubernaut-tool-ai-orchestrator` | Automated agent orchestration | 15 | Remediation lifecycle (5) + investigation (4) + cluster context (6) |
+| `kubernaut-tool-sre` | Full SRE access | 18 | All SAR-gated tools |
+| `kubernaut-tool-ai-orchestrator` | Automated agent orchestration | 14 | Remediation lifecycle (5) + investigation (4) + cluster context (5) |
 | `kubernaut-tool-cicd` | CI/CD pipeline integration | 3 | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch` |
-| `kubernaut-tool-observability` | Read-only observability | 8 | list/get/watch + effectiveness + workflows + cluster context (4) |
+| `kubernaut-tool-observability` | Read-only observability | 7 | list/get/watch + effectiveness + workflows + cluster context (3) |
 | `kubernaut-tool-l3-audit` | Compliance and auditing | 6 | list/get + workflows + history + effectiveness + audit trail |
 | `kubernaut-tool-remediation-approver` | Human approval workflows | 4 | `kubernaut_approve`, `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch` |
 
@@ -436,7 +437,7 @@ apifrontend:
 
 ### OIDC-direct mode — eliminating impersonation (v1.5)
 
-The AF's 4 read-only triage tools (`af_list_events`, `af_get_pods`, `af_get_workloads`, `af_resolve_owner`) make K8s API calls as the authenticated user. By default, this uses **impersonation** (`Impersonate-User` / `Impersonate-Group` headers), which requires the AF ClusterRole to have `impersonate` on `users` and `groups`.
+The AF's 3 read-only triage tools (`kubectl_get`, `kubectl_list`, `kubectl_list_events`) make K8s API calls as the authenticated user. By default, this uses **impersonation** (`Impersonate-User` / `Impersonate-Group` headers), which requires the AF ClusterRole to have `impersonate` on `users` and `groups`.
 
 v1.5 adds an opt-in **OIDC-direct mode** (PR #1227) that forwards the user's raw OIDC JWT as a bearer token instead of impersonating. This eliminates impersonation privileges entirely, addressing CIS benchmark and SOC 2 audit concerns.
 

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -237,7 +237,14 @@ The `list` verb (new in v1.5) is required for `ReconcileOrphanedLeases` — on s
 
 ### API Frontend RBAC (v1.5+)
 
-The API Frontend ServiceAccount requires permissions for authentication and downstream service access. The AF authenticates users via JWKS (OIDC) and proxies MCP/A2A calls to the Kubernaut Agent and DataStorage.
+The API Frontend ServiceAccount requires:
+
+| apiGroup | Resources | Verbs | Purpose |
+|---|---|---|---|
+| `apifrontend.kubernaut.ai` | `investigationsessions`, `investigationsessions/status` | get, list, watch, create, update, patch, delete | Session CRD management |
+| `kubernaut.ai` | `remediationrequests` | get, list, create | RR access for interactive sessions |
+| `authorization.k8s.io` | `subjectaccessreviews` | create | SAR-based tool authorization |
+| _(core)_ | `users`, `groups`, `serviceaccounts` | impersonate | Triage tool delegation ([#1226](https://github.com/jordigilh/kubernaut/issues/1226) plans OIDC-direct mode to eliminate this) |
 
 ## Infrastructure and Hooks
 
@@ -363,19 +370,74 @@ Custom CIDR ranges can be configured for services that need external access (e.g
 
 ## Tool Authorization {: #tool-authorization-v15 }
 
-### Current model (v1.5)
+### SAR-based tool authorization (v1.5)
 
-The API Frontend uses a **file-based RBAC model** via `rbac_roles.yaml` ConfigMap. Roles are mapped to MCP tool access and loaded at startup.
+v1.5 replaces the API Frontend's file-based `rbac_roles.yaml` with **Kubernetes-native SubjectAccessReview (SAR)** authorization (PR #1222). Every MCP `tools/call` invocation triggers a SAR check before execution. `tools/list` is unfiltered (ADR-020) — authorization is enforced only at call time.
 
-### Planned: SAR-based authorization
+### How it works
 
-!!! info "Planned — not yet implemented"
-    [Issue #1221](https://github.com/jordigilh/kubernaut/issues/1221) proposes replacing the file-based model with Kubernetes-native SubjectAccessReview (SAR) authorization. This work is in progress and will ship in a future release. The design calls for:
+1. Client authenticates via OIDC — the API Frontend extracts the user identity from the JWT
+2. On each tool invocation, AF issues a SAR: `can <user> use tools/<tool-name> in apiGroup kubernaut.ai?`
+3. The Kubernetes API server evaluates the user's ClusterRoleBindings
+4. If denied (or if the SAR API is unreachable), the tool call is rejected — **fail-closed**
 
-    - SAR check on every MCP tool call: `can <user> use tools/<tool-name> in apiGroup kubernaut.ai?`
-    - 6 pre-built ClusterRoles (sre, orchestrator, approver, viewer, cicd, audit)
-    - Fail-closed authorization with configurable cache TTL
-    - Removal of the `rbac_roles.yaml` ConfigMap
+All 3 AF RBAC code paths (MCP bridge `checkRBAC()`, A2A agent `newRBACGuard()`, and main wiring) delegate to the `SARChecker`.
+
+### Per-persona ClusterRoles
+
+The Helm chart ships 6 per-persona ClusterRoles via a data-driven template (`apifrontend.config.rbac.personas`):
+
+| ClusterRole | Persona | Tools |
+|---|---|---|
+| `kubernaut-tool-sre` | Full SRE access | All 20 tools |
+| `kubernaut-tool-ai-orchestrator` | Automated agent orchestration | Orchestration + triage + cluster context |
+| `kubernaut-tool-cicd` | CI/CD pipeline integration | list, get, watch |
+| `kubernaut-tool-observability` | Read-only observability | Read-only tools |
+| `kubernaut-tool-l3-audit` | Compliance and auditing | Audit, history, effectiveness |
+| `kubernaut-tool-remediation-approver` | Human approval workflows | Approve + read |
+
+### Binding example
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sre-team-kubernaut-tools
+subjects:
+  - kind: Group
+    name: sre-team
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: kubernaut-tool-sre
+  apiGroup: rbac.authorization.k8s.io
+```
+
+### SAR caching
+
+Authorization results are cached with a SHA256-keyed TTL cache (default 30s) to avoid per-call SAR overhead:
+
+```yaml
+apifrontend:
+  config:
+    rbac:
+      sarCacheTTL: 30s
+```
+
+### Migration from rbac_roles.yaml
+
+!!! warning "Breaking change"
+    The `rbac_roles.yaml` ConfigMap and `RBACConfig.GroupMapping` are removed in v1.5. Customers who customized file-based RBAC must create equivalent ClusterRoleBindings.
+
+1. Identify which tools each role had access to
+2. Map those to the closest per-persona ClusterRole (or create a custom one with `verb: use` on `resource: tools` in `apiGroup: kubernaut.ai`)
+3. Create ClusterRoleBindings for your OIDC groups
+4. The `rbac_roles.yaml` ConfigMap is no longer read
+
+### Planned: OIDC-direct authentication (eliminates impersonation)
+
+!!! info "Planned — [Issue #1226](https://github.com/jordigilh/kubernaut/issues/1226)"
+    The AF currently uses K8s impersonation headers for triage tools (`af_list_events`, `af_get_pods`, `af_get_workloads`, `af_resolve_owner`). Issue #1226 proposes an opt-in OIDC-direct mode that forwards the user's raw JWT as a bearer token to the K8s API server, eliminating impersonation privileges entirely. This works when the K8s API server trusts the same OIDC provider as AF.
 
 ## Next Steps
 

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -392,14 +392,17 @@ All 3 AF RBAC code paths (MCP bridge `checkRBAC()`, A2A agent `newRBACGuard()`, 
 
 The Helm chart ships 6 per-persona ClusterRoles via a data-driven template (`apifrontend.config.rbac.personas`):
 
-| ClusterRole | Persona | Tool Count | Tools |
+| ClusterRole | Persona | MCP Tools | Tool List |
 |---|---|---|---|
-| `kubernaut-tool-sre` | Full SRE access | 26 | All 23 MCP tools + 3 internal `kubectl_*` + `af_check_existing_rr` + `af_create_rr` |
-| `kubernaut-tool-ai-orchestrator` | Automated agent orchestration | 19 | CRD ops (3) + investigation (3) + interactive (6) + stream + discovery/selection + presentation + internal triage (5) |
+| `kubernaut-tool-sre` | Investigation + remediation (no approval) | 20 | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_cancel_remediation`, `kubernaut_watch`, `kubernaut_start_investigation`, `kubernaut_poll_investigation`, `kubernaut_discover_workflows`, `kubernaut_select_workflow`, `kubernaut_present_decision`, `kubernaut_list_workflows`, `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail`, `kubernaut_takeover`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect`, `kubernaut_stream_investigation` |
+| `kubernaut-tool-ai-orchestrator` | Automated agent orchestration | 15 | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch`, `kubernaut_start_investigation`, `kubernaut_poll_investigation`, `kubernaut_discover_workflows`, `kubernaut_select_workflow`, `kubernaut_present_decision`, `kubernaut_takeover`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect`, `kubernaut_stream_investigation` |
 | `kubernaut-tool-cicd` | CI/CD pipeline integration | 3 | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch` |
-| `kubernaut-tool-observability` | Read-only observability | 5 | list/get/watch + effectiveness + workflows |
-| `kubernaut-tool-l3-audit` | Compliance and auditing | 6 | list/get + workflows + history + effectiveness + audit trail |
-| `kubernaut-tool-remediation-approver` | Human approval workflows | 4 | `kubernaut_approve`, `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch` |
+| `kubernaut-tool-observability` | Read-only observability | 5 | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch`, `kubernaut_get_effectiveness`, `kubernaut_list_workflows` |
+| `kubernaut-tool-l3-audit` | Compliance and auditing | 6 | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_list_workflows`, `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail` |
+| `kubernaut-tool-remediation-approver` | Human approval workflows | 4 | `kubernaut_list_approval_requests`, `kubernaut_get_approval_request`, `kubernaut_approve`, `kubernaut_watch` |
+
+!!! info "Internal tools"
+    The AF also uses 5 internal tools (`kubectl_get`, `kubectl_list`, `kubectl_list_events`, `af_check_existing_rr`, `af_create_rr`) that run under the AF pod's own ServiceAccount. These are **not** exposed via MCP/A2A, are **not** SAR-gated, and are not included in persona tool counts.
 
 ### Binding example
 
@@ -445,8 +448,6 @@ All AF Kubernetes API calls use the **AF pod's own ServiceAccount** — there is
 
 **User attribution** is preserved in the application audit trail (`tool.executed` events include `UserID`, `actor_ip`, `target_namespace`, `target_kind`) rather than in Kubernetes audit logs.
 
-!!! note "History"
-    Earlier v1.5 pre-releases included impersonation and an opt-in OIDC-direct mode (PR #1227). PR #1233 (ADR-022) removed both in favor of the unified SA model. The AF ClusterRole no longer includes `impersonate` verbs.
 
 **Accepted risks** (documented in ADR-022):
 

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -242,10 +242,14 @@ The API Frontend ServiceAccount requires:
 
 | apiGroup | Resources | Verbs | Purpose |
 |---|---|---|---|
-| `kubernaut.ai` | `investigationsessions`, `investigationsessions/status` | get, list, watch, create, update, patch, delete | Session CRD management (PR #1224) |
-| `kubernaut.ai` | `remediationrequests` | get, list, create | RR access for interactive sessions |
+| `kubernaut.ai` | `investigationsessions`, `investigationsessions/status` | get, list, watch, create, update, patch, delete | Session CRD management |
+| `kubernaut.ai` | `remediationrequests` | get, list, watch, create, update, patch | RR lifecycle for MCP/A2A sessions |
+| `kubernaut.ai` | `remediationapprovalrequests`, `remediationapprovalrequests/status` | get, list, create, update, patch | Approval request access |
 | `authorization.k8s.io` | `subjectaccessreviews` | create | SAR-based tool authorization |
-| _(core)_ | `users`, `groups` | impersonate | Triage tool delegation (default mode; `serviceaccounts` removed in PR #1227) |
+| _(core)_ | `events` | get, list, create, patch | Cluster context triage tools |
+| _(core)_ | `pods`, `replicationcontrollers` | get, list | Cluster context triage tools |
+| `apps` | `deployments`, `replicasets`, `statefulsets`, `daemonsets` | get, list | Cluster context triage tools |
+| `batch` | `jobs`, `cronjobs` | get | Cluster context triage tools |
 
 ## Infrastructure and Hooks
 
@@ -390,10 +394,10 @@ The Helm chart ships 6 per-persona ClusterRoles via a data-driven template (`api
 
 | ClusterRole | Persona | Tool Count | Tools |
 |---|---|---|---|
-| `kubernaut-tool-sre` | Full SRE access | 18 | All SAR-gated tools |
-| `kubernaut-tool-ai-orchestrator` | Automated agent orchestration | 14 | Remediation lifecycle (5) + investigation (4) + cluster context (5) |
+| `kubernaut-tool-sre` | Full SRE access | 26 | All 23 MCP tools + 3 internal `kubectl_*` + `af_check_existing_rr` + `af_create_rr` |
+| `kubernaut-tool-ai-orchestrator` | Automated agent orchestration | 19 | CRD ops (3) + investigation (3) + interactive (6) + stream + discovery/selection + presentation + internal triage (5) |
 | `kubernaut-tool-cicd` | CI/CD pipeline integration | 3 | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch` |
-| `kubernaut-tool-observability` | Read-only observability | 7 | list/get/watch + effectiveness + workflows + cluster context (3) |
+| `kubernaut-tool-observability` | Read-only observability | 5 | list/get/watch + effectiveness + workflows |
 | `kubernaut-tool-l3-audit` | Compliance and auditing | 6 | list/get + workflows + history + effectiveness + audit trail |
 | `kubernaut-tool-remediation-approver` | Human approval workflows | 4 | `kubernaut_approve`, `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch` |
 
@@ -435,36 +439,23 @@ apifrontend:
 3. Create ClusterRoleBindings for your OIDC groups
 4. The `rbac_roles.yaml` ConfigMap is no longer read
 
-### OIDC-direct mode — eliminating impersonation (v1.5)
+### Unified ServiceAccount model (v1.5, ADR-022) {: #unified-sa-model }
 
-The AF's 3 read-only triage tools (`kubectl_get`, `kubectl_list`, `kubectl_list_events`) make K8s API calls as the authenticated user. By default, this uses **impersonation** (`Impersonate-User` / `Impersonate-Group` headers), which requires the AF ClusterRole to have `impersonate` on `users` and `groups`.
+All AF Kubernetes API calls use the **AF pod's own ServiceAccount** — there is no per-user impersonation or OIDC-direct token forwarding. This simplifies the security model: the AF SA has a fixed, auditable set of permissions, and application-level authorization is enforced entirely through SAR-based tool gating (see [Per-persona ClusterRoles](#per-persona-clusterroles)).
 
-v1.5 adds an opt-in **OIDC-direct mode** (PR #1227) that forwards the user's raw OIDC JWT as a bearer token instead of impersonating. This eliminates impersonation privileges entirely, addressing CIS benchmark and SOC 2 audit concerns.
+**User attribution** is preserved in the application audit trail (`tool.executed` events include `UserID`, `actor_ip`, `target_namespace`, `target_kind`) rather than in Kubernetes audit logs.
 
-```yaml
-apifrontend:
-  config:
-    rbac:
-      useOIDCDirect: true   # default: false (impersonation)
-```
+!!! note "History"
+    Earlier v1.5 pre-releases included impersonation and an opt-in OIDC-direct mode (PR #1227). PR #1233 (ADR-022) removed both in favor of the unified SA model. The AF ClusterRole no longer includes `impersonate` verbs.
 
-**How it works:** The `NewOIDCDirectDynamicFactory` creates a `rest.Config` with `BearerToken: identity.RawToken` instead of `Impersonate` headers. The base config is deep-copied via `rest.CopyConfig`; `BearerTokenFile` is cleared and `Impersonate` config zeroed. Fail-closed: missing identity, empty token, or expired token all return errors.
+**Accepted risks** (documented in ADR-022):
 
-**Compatible deployments** (K8s API server trusts the same OIDC provider as AF):
-
-- Self-managed K8s / kubeadm
-- OpenShift (integrated OAuth)
-- EKS with OIDC identity provider association
-- AKS with OIDC issuer
-
-**Not compatible** (impersonation remains the default):
-
-- GKE (only trusts Google IAM)
-- EKS without OIDC association
-- Any deployment where K8s and AF use different identity providers
-
-!!! tip "Quick win: `serviceaccounts` removed"
-    PR #1227 also removes `serviceaccounts` from the impersonation resources in the AF ClusterRole — no AF code path impersonates a service account, so this eliminates the highest-risk vector immediately, regardless of whether OIDC-direct is enabled.
+| ID | Risk | Mitigation |
+|---|---|---|
+| SEC-01 | AF SA has broad kubernaut CRD access | Namespace-scoped where possible; SAR gates each tool call |
+| SEC-02 | K8s audit logs attribute actions to AF SA, not the end user | Application audit trail carries user identity; correlate via `actor_ip` |
+| SEC-04 | AF SA privilege aggregation | ClusterRole is explicit and minimal; reviewed per release |
+| SEC-09 | Persona misconfiguration could over-grant | Helm values are the source of truth; `kubernaut-tool-*` roles are data-driven |
 
 ## Next Steps
 

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -244,7 +244,7 @@ The API Frontend ServiceAccount requires:
 | `kubernaut.ai` | `investigationsessions`, `investigationsessions/status` | get, list, watch, create, update, patch, delete | Session CRD management (PR #1224) |
 | `kubernaut.ai` | `remediationrequests` | get, list, create | RR access for interactive sessions |
 | `authorization.k8s.io` | `subjectaccessreviews` | create | SAR-based tool authorization |
-| _(core)_ | `users`, `groups`, `serviceaccounts` | impersonate | Triage tool delegation ([#1226](https://github.com/jordigilh/kubernaut/issues/1226) plans OIDC-direct mode to eliminate this) |
+| _(core)_ | `users`, `groups` | impersonate | Triage tool delegation (default mode; `serviceaccounts` removed in PR #1227) |
 
 ## Infrastructure and Hooks
 
@@ -434,10 +434,36 @@ apifrontend:
 3. Create ClusterRoleBindings for your OIDC groups
 4. The `rbac_roles.yaml` ConfigMap is no longer read
 
-### Planned: OIDC-direct authentication (eliminates impersonation)
+### OIDC-direct mode — eliminating impersonation (v1.5)
 
-!!! info "Planned — [Issue #1226](https://github.com/jordigilh/kubernaut/issues/1226)"
-    The AF currently uses K8s impersonation headers for triage tools (`af_list_events`, `af_get_pods`, `af_get_workloads`, `af_resolve_owner`). Issue #1226 proposes an opt-in OIDC-direct mode that forwards the user's raw JWT as a bearer token to the K8s API server, eliminating impersonation privileges entirely. This works when the K8s API server trusts the same OIDC provider as AF.
+The AF's 4 read-only triage tools (`af_list_events`, `af_get_pods`, `af_get_workloads`, `af_resolve_owner`) make K8s API calls as the authenticated user. By default, this uses **impersonation** (`Impersonate-User` / `Impersonate-Group` headers), which requires the AF ClusterRole to have `impersonate` on `users` and `groups`.
+
+v1.5 adds an opt-in **OIDC-direct mode** (PR #1227) that forwards the user's raw OIDC JWT as a bearer token instead of impersonating. This eliminates impersonation privileges entirely, addressing CIS benchmark and SOC 2 audit concerns.
+
+```yaml
+apifrontend:
+  config:
+    rbac:
+      useOIDCDirect: true   # default: false (impersonation)
+```
+
+**How it works:** The `NewOIDCDirectDynamicFactory` creates a `rest.Config` with `BearerToken: identity.RawToken` instead of `Impersonate` headers. The base config is deep-copied via `rest.CopyConfig`; `BearerTokenFile` is cleared and `Impersonate` config zeroed. Fail-closed: missing identity, empty token, or expired token all return errors.
+
+**Compatible deployments** (K8s API server trusts the same OIDC provider as AF):
+
+- Self-managed K8s / kubeadm
+- OpenShift (integrated OAuth)
+- EKS with OIDC identity provider association
+- AKS with OIDC issuer
+
+**Not compatible** (impersonation remains the default):
+
+- GKE (only trusts Google IAM)
+- EKS without OIDC association
+- Any deployment where K8s and AF use different identity providers
+
+!!! tip "Quick win: `serviceaccounts` removed"
+    PR #1227 also removes `serviceaccounts` from the impersonation resources in the AF ClusterRole — no AF code path impersonates a service account, so this eliminates the highest-risk vector immediately, regardless of whether OIDC-direct is enabled.
 
 ## Next Steps
 

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -222,6 +222,30 @@ Kubernaut Agent itself has a broad **read-only** ClusterRole (`kubernaut-agent-i
 
 This read-only access allows the LLM to investigate root causes using live cluster data without making changes.
 
+### Lease RBAC for Interactive Sessions (v1.5+)
+
+Interactive MCP sessions use Kubernetes Leases for distributed locking. The Kubernaut Agent ServiceAccount requires Lease permissions in addition to its existing investigator role:
+
+| apiGroup | Resources | Verbs | Purpose |
+|---|---|---|---|
+| `coordination.k8s.io` | `leases` | get, create, update, delete, **list** | Session locking + orphan reclamation |
+
+The `list` verb (new in v1.5) is required for `ReconcileOrphanedLeases` — on startup, KA scans for Leases whose holder identity no longer exists and reclaims them.
+
+!!! note "Automatic provisioning"
+    Both the Helm chart and the Kubernaut Operator provision this permission automatically. Only custom RBAC configurations need manual updating.
+
+### API Frontend RBAC (v1.5+)
+
+The API Frontend ServiceAccount requires:
+
+| apiGroup | Resources | Verbs | Purpose |
+|---|---|---|---|
+| `authentication.k8s.io` | `tokenreviews` | create | Validate OIDC bearer tokens |
+| `authorization.k8s.io` | `subjectaccessreviews` | create | SAR-based tool authorization |
+
+The AF also needs `create` on `services/kubernaut-agent` and `services/data-storage-service` for proxying MCP tool calls to backend services.
+
 ## Infrastructure and Hooks
 
 ### PostgreSQL and Valkey
@@ -343,6 +367,66 @@ Verify your cluster's CNI plugin supports NetworkPolicy enforcement (Calico, Cil
     ```
 
 Custom CIDR ranges can be configured for services that need external access (e.g., Gateway ingress from AlertManager).
+
+## Tool Authorization (v1.5) {: #tool-authorization-v15 }
+
+v1.5 replaces the API Frontend's file-based `rbac_roles.yaml` with **Kubernetes-native SubjectAccessReview (SAR)** authorization. Every MCP tool call triggers a SAR check before execution.
+
+### How it works
+
+1. Client authenticates via OIDC — the API Frontend extracts the user identity from the JWT
+2. On each tool invocation, AF issues a SAR: `can <user> use tools/<tool-name> in apiGroup kubernaut.ai?`
+3. The Kubernetes API server evaluates the user's ClusterRoleBindings
+4. If denied (or if the SAR API is unreachable), the tool call is rejected — **fail-closed**
+
+### Pre-built ClusterRoles
+
+The Helm chart and Operator ship six ClusterRoles:
+
+| ClusterRole | Tools | Use case |
+|---|---|---|
+| `kubernaut-tool-sre` | All 20 tools | Full SRE access |
+| `kubernaut-tool-orchestrator` | Orchestration + triage | Automated agent orchestration |
+| `kubernaut-tool-approver` | Approve + read | Human approval workflows |
+| `kubernaut-tool-viewer` | Read-only tools | Dashboards, monitoring |
+| `kubernaut-tool-cicd` | list, get, watch | CI/CD pipeline integration |
+| `kubernaut-tool-audit` | Audit, history, effectiveness | Compliance and auditing |
+
+### Binding example
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sre-team-kubernaut-tools
+subjects:
+  - kind: Group
+    name: sre-team
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: kubernaut-tool-sre
+  apiGroup: rbac.authorization.k8s.io
+```
+
+### SAR caching
+
+Authorization results are cached for a configurable TTL (default 30s) to avoid per-call SAR overhead:
+
+```yaml
+apifrontend:
+  rbac:
+    sarCacheTTL: 30s
+```
+
+### Migration from rbac_roles.yaml
+
+If you customized the file-based `rbac_roles.yaml` in v1.4:
+
+1. Identify which tools each role had access to
+2. Map those to the closest pre-built ClusterRole (or create a custom one)
+3. Create ClusterRoleBindings for your users/groups
+4. Remove the `rbac_roles.yaml` ConfigMap — it is no longer read
 
 ## Next Steps
 

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -237,14 +237,7 @@ The `list` verb (new in v1.5) is required for `ReconcileOrphanedLeases` — on s
 
 ### API Frontend RBAC (v1.5+)
 
-The API Frontend ServiceAccount requires:
-
-| apiGroup | Resources | Verbs | Purpose |
-|---|---|---|---|
-| `authentication.k8s.io` | `tokenreviews` | create | Validate OIDC bearer tokens |
-| `authorization.k8s.io` | `subjectaccessreviews` | create | SAR-based tool authorization |
-
-The AF also needs `create` on `services/kubernaut-agent` and `services/data-storage-service` for proxying MCP tool calls to backend services.
+The API Frontend ServiceAccount requires permissions for authentication and downstream service access. The AF authenticates users via JWKS (OIDC) and proxies MCP/A2A calls to the Kubernaut Agent and DataStorage.
 
 ## Infrastructure and Hooks
 
@@ -368,65 +361,21 @@ Verify your cluster's CNI plugin supports NetworkPolicy enforcement (Calico, Cil
 
 Custom CIDR ranges can be configured for services that need external access (e.g., Gateway ingress from AlertManager).
 
-## Tool Authorization (v1.5) {: #tool-authorization-v15 }
+## Tool Authorization {: #tool-authorization-v15 }
 
-v1.5 replaces the API Frontend's file-based `rbac_roles.yaml` with **Kubernetes-native SubjectAccessReview (SAR)** authorization. Every MCP tool call triggers a SAR check before execution.
+### Current model (v1.5)
 
-### How it works
+The API Frontend uses a **file-based RBAC model** via `rbac_roles.yaml` ConfigMap. Roles are mapped to MCP tool access and loaded at startup.
 
-1. Client authenticates via OIDC — the API Frontend extracts the user identity from the JWT
-2. On each tool invocation, AF issues a SAR: `can <user> use tools/<tool-name> in apiGroup kubernaut.ai?`
-3. The Kubernetes API server evaluates the user's ClusterRoleBindings
-4. If denied (or if the SAR API is unreachable), the tool call is rejected — **fail-closed**
+### Planned: SAR-based authorization
 
-### Pre-built ClusterRoles
+!!! info "Planned — not yet implemented"
+    [Issue #1221](https://github.com/jordigilh/kubernaut/issues/1221) proposes replacing the file-based model with Kubernetes-native SubjectAccessReview (SAR) authorization. This work is in progress and will ship in a future release. The design calls for:
 
-The Helm chart and Operator ship six ClusterRoles:
-
-| ClusterRole | Tools | Use case |
-|---|---|---|
-| `kubernaut-tool-sre` | All 20 tools | Full SRE access |
-| `kubernaut-tool-orchestrator` | Orchestration + triage | Automated agent orchestration |
-| `kubernaut-tool-approver` | Approve + read | Human approval workflows |
-| `kubernaut-tool-viewer` | Read-only tools | Dashboards, monitoring |
-| `kubernaut-tool-cicd` | list, get, watch | CI/CD pipeline integration |
-| `kubernaut-tool-audit` | Audit, history, effectiveness | Compliance and auditing |
-
-### Binding example
-
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: sre-team-kubernaut-tools
-subjects:
-  - kind: Group
-    name: sre-team
-    apiGroup: rbac.authorization.k8s.io
-roleRef:
-  kind: ClusterRole
-  name: kubernaut-tool-sre
-  apiGroup: rbac.authorization.k8s.io
-```
-
-### SAR caching
-
-Authorization results are cached for a configurable TTL (default 30s) to avoid per-call SAR overhead:
-
-```yaml
-apifrontend:
-  rbac:
-    sarCacheTTL: 30s
-```
-
-### Migration from rbac_roles.yaml
-
-If you customized the file-based `rbac_roles.yaml` in v1.4:
-
-1. Identify which tools each role had access to
-2. Map those to the closest pre-built ClusterRole (or create a custom one)
-3. Create ClusterRoleBindings for your users/groups
-4. Remove the `rbac_roles.yaml` ConfigMap — it is no longer read
+    - SAR check on every MCP tool call: `can <user> use tools/<tool-name> in apiGroup kubernaut.ai?`
+    - 6 pre-built ClusterRoles (sre, orchestrator, approver, viewer, cicd, audit)
+    - Fail-closed authorization with configurable cache TTL
+    - Removal of the `rbac_roles.yaml` ConfigMap
 
 ## Next Steps
 

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -10,7 +10,27 @@
   --kn-em: #059669;
   --kn-notif: #DC2626;
   --kn-gw: #0891B2;
+  --kn-af: #64748B;
   --kn-support: #64748B;
+}
+
+/* Pipeline phase cards: hover lift */
+.phase-card:hover > g > rect:first-child,
+.phase-card:hover > rect:first-child {
+  filter: brightness(0.97);
+}
+
+.phase-card {
+  transition: transform 0.15s ease;
+}
+
+.phase-card:hover {
+  opacity: 0.92;
+}
+
+/* Hide the "Select a phase" prompt — cards handle navigation */
+#pipeline-svg + p {
+  display: none;
 }
 
 /* Mermaid: transparent background for any remaining diagrams */

--- a/docs/assets/extra.js
+++ b/docs/assets/extra.js
@@ -1,0 +1,101 @@
+/**
+ * Pipeline phase card <-> tab synchronisation.
+ *
+ * Each SVG card has class="phase-card" and data-tab="N" (0-based index).
+ * Material for MkDocs renders === tabs as .tabbed-set with .tabbed-labels
+ * containing one <label> per tab and <input type="radio"> siblings.
+ */
+(function () {
+  function setup() {
+    var obj = document.getElementById("pipeline-svg");
+    if (!obj) return;
+
+    var svgDoc = null;
+    if (obj.tagName === "OBJECT" || obj.tagName === "object") {
+      try {
+        svgDoc = obj.contentDocument;
+      } catch (e) {
+        return;
+      }
+    } else if (obj.tagName === "svg" || obj.tagName === "SVG") {
+      svgDoc = obj;
+    }
+    if (!svgDoc) return;
+
+    var cards = svgDoc.querySelectorAll(".phase-card");
+    if (!cards.length) return;
+
+    function getTabbedSet() {
+      var sets = document.querySelectorAll(".tabbed-set");
+      for (var i = 0; i < sets.length; i++) {
+        if (sets[i].closest(".md-content")) return sets[i];
+      }
+      return sets[0] || null;
+    }
+
+    function updateIndicators(activeIndex) {
+      var indicators = svgDoc.querySelectorAll(".phase-indicator");
+      indicators.forEach(function (ind) {
+        var parent = ind.closest(".phase-card");
+        if (!parent) return;
+        var idx = parseInt(parent.getAttribute("data-tab"), 10);
+        ind.setAttribute(
+          "fill",
+          idx === activeIndex
+            ? ind.getAttribute("data-color")
+            : "transparent"
+        );
+      });
+    }
+
+    function activateTab(index) {
+      var tabSet = getTabbedSet();
+      if (!tabSet) return;
+      var labels = tabSet.querySelectorAll(".tabbed-labels > label");
+      if (labels[index]) labels[index].click();
+      updateIndicators(index);
+    }
+
+    cards.forEach(function (card) {
+      card.style.cursor = "pointer";
+      card.addEventListener("click", function () {
+        var idx = parseInt(card.getAttribute("data-tab"), 10);
+        activateTab(idx);
+      });
+    });
+
+    var tabSet = getTabbedSet();
+    if (tabSet) {
+      var inputs = tabSet.querySelectorAll('input[type="radio"]');
+      inputs.forEach(function (input, i) {
+        input.addEventListener("change", function () {
+          if (input.checked) updateIndicators(i);
+        });
+      });
+    }
+
+    updateIndicators(0);
+  }
+
+  function waitForSVG() {
+    var obj = document.getElementById("pipeline-svg");
+    if (!obj) return;
+
+    if (obj.tagName === "OBJECT" || obj.tagName === "object") {
+      obj.addEventListener("load", function () {
+        setTimeout(setup, 50);
+      });
+      if (obj.contentDocument && obj.contentDocument.readyState === "complete") {
+        setTimeout(setup, 50);
+      }
+    } else {
+      setup();
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", waitForSVG);
+  } else {
+    waitForSVG();
+  }
+})();

--- a/docs/assets/images/pipeline-phases.svg
+++ b/docs/assets/images/pipeline-phases.svg
@@ -1,171 +1,256 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="40 220 1840 400" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1860 730" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
   <defs>
     <filter id="sh" x="-2%" y="-4%" width="104%" height="112%">
-      <feDropShadow dx="0" dy="3" stdDeviation="8" flood-color="#000" flood-opacity="0.08"/>
+      <feDropShadow dx="0" dy="3" stdDeviation="6" flood-color="#000" flood-opacity="0.06"/>
     </filter>
+    <marker id="ar" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0,0 8,3 0,6" fill="#CBD5E1"/>
+    </marker>
   </defs>
 
-  <rect x="40" y="220" width="1840" height="400" fill="white"/>
+  <rect x="0" y="0" width="1860" height="730" fill="white"/>
 
-  <!-- Phase 1: Signal Processing (x=60, w=270) -->
-  <g filter="url(#sh)">
-    <rect x="60" y="240" width="270" height="370" rx="14" fill="white"/>
+  <!-- ═══════════ API Frontend card (top, full-width) ═══════════ -->
+  <g class="phase-card" data-tab="6">
+    <g filter="url(#sh)">
+      <rect x="20" y="16" width="1820" height="260" rx="12" fill="white"/>
+    </g>
+    <rect x="20" y="16" width="1820" height="46" rx="12" fill="#64748B"/>
+    <rect x="20" y="50" width="1820" height="12" fill="#64748B"/>
+    <text x="48" y="47" font-size="19px" font-weight="700" fill="white">API Frontend</text>
+    <rect x="200" y="33" width="46" height="22" rx="4" fill="#0891B2"/>
+    <text x="223" y="48" text-anchor="middle" font-size="12px" font-weight="700" fill="white">v1.5</text>
+
+    <!-- ── Section 1: Protocols (left) ── -->
+    <text x="48" y="92" font-size="15px" font-weight="600" fill="#64748B">Protocols</text>
+    <text x="48" y="114" font-size="14px" fill="#374151">MCP Streamable HTTP</text>
+    <text x="48" y="134" font-size="14px" fill="#374151">A2A JSON-RPC</text>
+    <text x="48" y="154" font-size="14px" fill="#374151">Agent Card discovery</text>
+
+    <line x1="610" y1="76" x2="610" y2="162" stroke="#E2E8F0" stroke-width="1"/>
+
+    <!-- ── Section 2: Authentication (center) ── -->
+    <text x="640" y="92" font-size="15px" font-weight="600" fill="#64748B">Authentication</text>
+    <text x="640" y="114" font-size="14px" fill="#374151">SAR-based tool gating</text>
+    <text x="640" y="134" font-size="14px" fill="#374151">6 per-persona ClusterRoles</text>
+
+    <line x1="1210" y1="76" x2="1210" y2="162" stroke="#E2E8F0" stroke-width="1"/>
+
+    <!-- ── Section 3: Interactive Journey (right) ── -->
+    <text x="1240" y="92" font-size="15px" font-weight="600" fill="#64748B">Interactive Journey</text>
+    <text x="1240" y="114" font-size="14px" fill="#374151">Investigate → Discover → Select → Watch</text>
+    <text x="1240" y="134" font-size="14px" fill="#374151">CRD status monitoring</text>
+
+    <!-- CRD badge (centered) -->
+    <rect x="790" y="168" width="240" height="28" rx="6" fill="#F8FAFC"/>
+    <text x="910" y="187" text-anchor="middle" font-size="13px" font-weight="600" fill="#64748B">CRD: InvestigationSession</text>
+
+    <!-- ── Divider before relationship row ── -->
+    <line x1="44" y1="204" x2="1816" y2="204" stroke="#E2E8F0" stroke-width="1"/>
+
+    <!-- ── Relationship row: 6 subcards with colored accent bars ── -->
+
+    <!-- 1. Signal Processing -->
+    <rect x="30" y="212" width="260" height="3" rx="1" fill="#0891B2"/>
+    <text x="48" y="234" font-size="13px" font-weight="600" fill="#0891B2">Signal intake</text>
+    <text x="48" y="252" font-size="12px" fill="#94A3B8">A2A + webhook ingestion</text>
+
+    <line x1="300" y1="212" x2="300" y2="268" stroke="#E2E8F0" stroke-width="1"/>
+
+    <!-- 2. AI Analysis -->
+    <rect x="310" y="212" width="286" height="3" rx="1" fill="#6366F1"/>
+    <text x="350" y="234" font-size="13px" font-weight="600" fill="#6366F1">Investigation</text>
+    <text x="350" y="252" font-size="12px" fill="#94A3B8">KA dispatch + SSE stream</text>
+
+    <line x1="606" y1="212" x2="606" y2="268" stroke="#E2E8F0" stroke-width="1"/>
+
+    <!-- 3. Approval -->
+    <rect x="616" y="212" width="286" height="3" rx="1" fill="#0F172A"/>
+    <text x="656" y="234" font-size="13px" font-weight="600" fill="#0F172A">Identity</text>
+    <text x="656" y="252" font-size="12px" fill="#94A3B8">Operator ID in Rego context</text>
+
+    <line x1="912" y1="212" x2="912" y2="268" stroke="#E2E8F0" stroke-width="1"/>
+
+    <!-- 4. Execution -->
+    <rect x="922" y="212" width="286" height="3" rx="1" fill="#D97706"/>
+    <text x="962" y="234" font-size="13px" font-weight="600" fill="#D97706">Monitoring</text>
+    <text x="962" y="252" font-size="12px" fill="#94A3B8">CRD status transitions</text>
+
+    <line x1="1218" y1="212" x2="1218" y2="268" stroke="#E2E8F0" stroke-width="1"/>
+
+    <!-- 5. Effectiveness -->
+    <rect x="1228" y="212" width="286" height="3" rx="1" fill="#059669"/>
+    <text x="1268" y="234" font-size="13px" font-weight="600" fill="#059669">Outcomes</text>
+    <text x="1268" y="252" font-size="12px" fill="#94A3B8">Effectiveness tracking</text>
+
+    <line x1="1524" y1="212" x2="1524" y2="268" stroke="#E2E8F0" stroke-width="1"/>
+
+    <!-- 6. Notification -->
+    <rect x="1534" y="212" width="296" height="3" rx="1" fill="#DC2626"/>
+    <text x="1574" y="234" font-size="13px" font-weight="600" fill="#DC2626">Delivery</text>
+    <text x="1574" y="252" font-size="12px" fill="#94A3B8">Progress to operator</text>
+
+    <rect x="20" y="280" width="1820" height="4" rx="2" fill="transparent" class="phase-indicator" data-color="#64748B"/>
+    <rect x="20" y="16" width="1820" height="260" rx="12" fill="transparent" style="cursor:pointer"/>
   </g>
-  <rect x="60" y="240" width="270" height="56" rx="14" fill="#0891B2"/>
-  <rect x="60" y="282" width="270" height="14" fill="#0891B2"/>
-  <circle cx="308" cy="268" r="16" fill="white" opacity="0.2"/>
-  <text x="308" y="274" text-anchor="middle" font-size="18" font-weight="700" fill="white">1</text>
-  <text x="86" y="274" font-size="18px" font-weight="700" fill="white">Signal Processing</text>
 
-  <text x="86" y="330" font-size="16px" font-weight="600" fill="#0891B2">Ingest</text>
-  <text x="86" y="354" font-size="15px" fill="#151515">AlertManager webhooks</text>
-  <text x="86" y="374" font-size="15px" fill="#151515">Kubernetes Events</text>
+  <!-- AF → pipeline connection lines -->
+  <line x1="155" y1="284" x2="155" y2="310" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="4,4"/>
+  <line x1="461" y1="284" x2="461" y2="310" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="4,4"/>
+  <line x1="767" y1="284" x2="767" y2="310" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="4,4"/>
+  <line x1="1073" y1="284" x2="1073" y2="310" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="4,4"/>
+  <line x1="1379" y1="284" x2="1379" y2="310" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="4,4"/>
+  <line x1="1685" y1="284" x2="1685" y2="310" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="4,4"/>
 
-  <line x1="86" y1="410" x2="306" y2="410" stroke="#F0F0F0" stroke-width="1"/>
+  <!-- ═══════════ Pipeline phase cards ═══════════ -->
 
-  <text x="86" y="436" font-size="16px" font-weight="600" fill="#0891B2">Classify</text>
-  <text x="86" y="460" font-size="15px" fill="#151515">OPA/Rego severity classification</text>
-  <text x="86" y="480" font-size="15px" fill="#151515">Category-to-workflow mapping</text>
-
-  <rect x="86" y="530" width="220" height="44" rx="8" fill="#F5F5F5"/>
-  <text x="196" y="558" text-anchor="middle" font-size="14px" font-weight="600" fill="#6A6E73">CRD: RemediationRequest</text>
+  <!-- Phase 1: Signal Processing -->
+  <g class="phase-card" data-tab="0">
+    <g filter="url(#sh)">
+      <rect x="20" y="310" width="270" height="390" rx="12" fill="white"/>
+    </g>
+    <rect x="20" y="310" width="270" height="46" rx="12" fill="#0891B2"/>
+    <rect x="20" y="344" width="270" height="12" fill="#0891B2"/>
+    <text x="44" y="341" font-size="17px" font-weight="700" fill="white">Signal Processing</text>
+    <text x="44" y="384" font-size="15px" font-weight="600" fill="#0891B2">Ingest</text>
+    <text x="44" y="406" font-size="14px" fill="#374151">AlertManager webhooks</text>
+    <text x="44" y="426" font-size="14px" fill="#374151">Kubernetes Events</text>
+    <text x="44" y="446" font-size="14px" fill="#374151">A2A / Interactive sessions</text>
+    <line x1="44" y1="464" x2="270" y2="464" stroke="#F0F0F0" stroke-width="1"/>
+    <text x="44" y="486" font-size="15px" font-weight="600" fill="#0891B2">Classify</text>
+    <text x="44" y="508" font-size="14px" fill="#374151">OPA/Rego severity</text>
+    <text x="44" y="528" font-size="14px" fill="#374151">Category mapping</text>
+    <rect x="44" y="624" width="222" height="36" rx="8" fill="#F8FAFC"/>
+    <text x="155" y="647" text-anchor="middle" font-size="13px" font-weight="600" fill="#64748B">CRD: SignalProcessing</text>
+    <rect x="20" y="704" width="270" height="4" rx="2" fill="transparent" class="phase-indicator" data-color="#0891B2"/>
+    <rect x="20" y="310" width="270" height="390" rx="12" fill="transparent" style="cursor:pointer"/>
+  </g>
 
   <!-- Arrow 1→2 -->
-  <line x1="340" y1="460" x2="368" y2="460" stroke="#A3A6A9" stroke-width="3"/>
-  <polygon points="368,460 358,454 358,466" fill="#A3A6A9"/>
+  <line x1="298" y1="470" x2="318" y2="470" stroke="#CBD5E1" stroke-width="2" marker-end="url(#ar)"/>
 
-  <!-- Phase 2: AI Analysis (x=378, w=270) -->
-  <g filter="url(#sh)">
-    <rect x="378" y="240" width="270" height="370" rx="14" fill="white"/>
+  <!-- Phase 2: AI Analysis -->
+  <g class="phase-card" data-tab="1">
+    <g filter="url(#sh)">
+      <rect x="326" y="310" width="270" height="390" rx="12" fill="white"/>
+    </g>
+    <rect x="326" y="310" width="270" height="46" rx="12" fill="#6366F1"/>
+    <rect x="326" y="344" width="270" height="12" fill="#6366F1"/>
+    <text x="350" y="341" font-size="17px" font-weight="700" fill="white">AI Analysis</text>
+    <text x="350" y="384" font-size="15px" font-weight="600" fill="#6366F1">Three-phased pipeline</text>
+    <text x="350" y="406" font-size="14px" fill="#374151">1. LLM investigates with 36</text>
+    <text x="358" y="426" font-size="14px" fill="#374151">native Go tools</text>
+    <text x="350" y="446" font-size="14px" fill="#374151">2. Server-side enrichment</text>
+    <text x="350" y="466" font-size="14px" fill="#374151">3. LLM selects workflow</text>
+    <line x1="350" y1="484" x2="576" y2="484" stroke="#F0F0F0" stroke-width="1"/>
+    <text x="350" y="506" font-size="15px" font-weight="600" fill="#6366F1">Kubernaut Agent</text>
+    <text x="350" y="528" font-size="14px" fill="#374151">Autonomous: LLM + 36 Go tools</text>
+    <text x="350" y="548" font-size="14px" fill="#374151">Interactive: Lease sessions, SSE</text>
+    <text x="350" y="568" font-size="14px" fill="#374151">Workflow selection + enrichment</text>
+    <rect x="350" y="624" width="222" height="36" rx="8" fill="#F8FAFC"/>
+    <text x="461" y="647" text-anchor="middle" font-size="13px" font-weight="600" fill="#64748B">CRD: AIAnalysis</text>
+    <rect x="326" y="704" width="270" height="4" rx="2" fill="transparent" class="phase-indicator" data-color="#6366F1"/>
+    <rect x="326" y="310" width="270" height="390" rx="12" fill="transparent" style="cursor:pointer"/>
   </g>
-  <rect x="378" y="240" width="270" height="56" rx="14" fill="#6366F1"/>
-  <rect x="378" y="282" width="270" height="14" fill="#6366F1"/>
-  <circle cx="626" cy="268" r="16" fill="white" opacity="0.2"/>
-  <text x="626" y="274" text-anchor="middle" font-size="18" font-weight="700" fill="white">2</text>
-  <text x="404" y="274" font-size="18px" font-weight="700" fill="white">AI Analysis</text>
-
-  <text x="404" y="330" font-size="16px" font-weight="600" fill="#6366F1">Three-phased pipeline</text>
-  <text x="404" y="354" font-size="15px" fill="#151515">1. LLM investigates with 36</text>
-  <text x="416" y="374" font-size="15px" fill="#151515">native Go tools (client-go)</text>
-  <text x="404" y="398" font-size="15px" fill="#151515">2. Server-side enrichment</text>
-  <text x="416" y="418" font-size="15px" fill="#151515">(context, history, metrics)</text>
-  <text x="404" y="442" font-size="15px" fill="#151515">3. LLM selects best workflow</text>
-  <text x="416" y="462" font-size="15px" fill="#151515">from user-declared catalog</text>
-
-  <rect x="404" y="530" width="220" height="44" rx="8" fill="#F5F5F5"/>
-  <text x="514" y="558" text-anchor="middle" font-size="14px" font-weight="600" fill="#6A6E73">CRD: AiAnalysis</text>
 
   <!-- Arrow 2→3 -->
-  <line x1="658" y1="460" x2="686" y2="460" stroke="#A3A6A9" stroke-width="3"/>
-  <polygon points="686,460 676,454 676,466" fill="#A3A6A9"/>
+  <line x1="604" y1="470" x2="624" y2="470" stroke="#CBD5E1" stroke-width="2" marker-end="url(#ar)"/>
 
-  <!-- Phase 3: Approval (x=696, w=270) -->
-  <g filter="url(#sh)">
-    <rect x="696" y="240" width="270" height="370" rx="14" fill="white"/>
+  <!-- Phase 3: Approval -->
+  <g class="phase-card" data-tab="2">
+    <g filter="url(#sh)">
+      <rect x="632" y="310" width="270" height="390" rx="12" fill="white"/>
+    </g>
+    <rect x="632" y="310" width="270" height="46" rx="12" fill="#0F172A"/>
+    <rect x="632" y="344" width="270" height="12" fill="#0F172A"/>
+    <text x="656" y="341" font-size="17px" font-weight="700" fill="white">Approval</text>
+    <text x="656" y="384" font-size="15px" font-weight="600" fill="#0891B2">Policy-Gated</text>
+    <text x="656" y="406" font-size="14px" fill="#374151">Auto-approve low-risk</text>
+    <text x="656" y="426" font-size="14px" fill="#374151">Slack / Teams / PagerDuty</text>
+    <text x="656" y="446" font-size="14px" fill="#374151">Operator param overrides</text>
+    <line x1="656" y1="464" x2="882" y2="464" stroke="#F0F0F0" stroke-width="1"/>
+    <text x="656" y="486" font-size="15px" font-weight="600" fill="#0891B2">Safety</text>
+    <text x="656" y="508" font-size="14px" fill="#374151">OPA/Rego enforcement</text>
+    <text x="656" y="528" font-size="14px" fill="#374151">Confidence thresholds</text>
+    <rect x="656" y="624" width="222" height="36" rx="8" fill="#F8FAFC"/>
+    <text x="767" y="647" text-anchor="middle" font-size="13px" font-weight="600" fill="#64748B">CRD: ApprovalRequest</text>
+    <rect x="632" y="704" width="270" height="4" rx="2" fill="transparent" class="phase-indicator" data-color="#0F172A"/>
+    <rect x="632" y="310" width="270" height="390" rx="12" fill="transparent" style="cursor:pointer"/>
   </g>
-  <rect x="696" y="240" width="270" height="56" rx="14" fill="#0F172A"/>
-  <rect x="696" y="282" width="270" height="14" fill="#0F172A"/>
-  <circle cx="944" cy="268" r="16" fill="white" opacity="0.2"/>
-  <text x="944" y="274" text-anchor="middle" font-size="18" font-weight="700" fill="white">3</text>
-  <text x="722" y="274" font-size="18px" font-weight="700" fill="white">Approval</text>
-
-  <text x="722" y="330" font-size="16px" font-weight="600" fill="#0891B2">Policy-Gated</text>
-  <text x="722" y="354" font-size="15px" fill="#151515">Auto-approve low-risk actions</text>
-  <text x="722" y="374" font-size="15px" fill="#151515">Notified via Slack, Teams</text>
-  <text x="722" y="394" font-size="15px" fill="#151515">or PagerDuty</text>
-  <text x="722" y="418" font-size="15px" fill="#151515">Operator can override params</text>
-
-  <line x1="722" y1="438" x2="942" y2="438" stroke="#F0F0F0" stroke-width="1"/>
-
-  <text x="722" y="462" font-size="16px" font-weight="600" fill="#0891B2">Safety</text>
-  <text x="722" y="484" font-size="15px" fill="#151515">OPA/Rego policy enforcement</text>
-  <text x="722" y="504" font-size="15px" fill="#151515">Confidence thresholds</text>
-
-  <rect x="722" y="530" width="220" height="44" rx="8" fill="#F5F5F5"/>
-  <text x="832" y="558" text-anchor="middle" font-size="14px" font-weight="600" fill="#6A6E73">CRD: RemediationApprovalReq</text>
 
   <!-- Arrow 3→4 -->
-  <line x1="976" y1="460" x2="1004" y2="460" stroke="#A3A6A9" stroke-width="3"/>
-  <polygon points="1004,460 994,454 994,466" fill="#A3A6A9"/>
+  <line x1="910" y1="470" x2="930" y2="470" stroke="#CBD5E1" stroke-width="2" marker-end="url(#ar)"/>
 
-  <!-- Phase 4: Execution (x=1014, w=270) -->
-  <g filter="url(#sh)">
-    <rect x="1014" y="240" width="270" height="370" rx="14" fill="white"/>
+  <!-- Phase 4: Execution -->
+  <g class="phase-card" data-tab="3">
+    <g filter="url(#sh)">
+      <rect x="938" y="310" width="270" height="390" rx="12" fill="white"/>
+    </g>
+    <rect x="938" y="310" width="270" height="46" rx="12" fill="#D97706"/>
+    <rect x="938" y="344" width="270" height="12" fill="#D97706"/>
+    <text x="962" y="341" font-size="17px" font-weight="700" fill="white">Execution</text>
+    <text x="962" y="384" font-size="15px" font-weight="600" fill="#D97706">3 Engines</text>
+    <text x="962" y="406" font-size="14px" fill="#374151">Tekton Pipelines</text>
+    <text x="962" y="426" font-size="14px" fill="#374151">Kubernetes Jobs</text>
+    <text x="962" y="446" font-size="14px" fill="#374151">Ansible / AWX</text>
+    <line x1="962" y1="464" x2="1188" y2="464" stroke="#F0F0F0" stroke-width="1"/>
+    <text x="962" y="486" font-size="15px" font-weight="600" fill="#D97706">Security</text>
+    <text x="962" y="508" font-size="14px" fill="#374151">Per-workflow SA</text>
+    <text x="962" y="528" font-size="14px" fill="#374151">Short-lived TokenRequest</text>
+    <rect x="962" y="624" width="222" height="36" rx="8" fill="#F8FAFC"/>
+    <text x="1073" y="647" text-anchor="middle" font-size="13px" font-weight="600" fill="#64748B">CRD: WorkflowExecution</text>
+    <rect x="938" y="704" width="270" height="4" rx="2" fill="transparent" class="phase-indicator" data-color="#D97706"/>
+    <rect x="938" y="310" width="270" height="390" rx="12" fill="transparent" style="cursor:pointer"/>
   </g>
-  <rect x="1014" y="240" width="270" height="56" rx="14" fill="#D97706"/>
-  <rect x="1014" y="282" width="270" height="14" fill="#D97706"/>
-  <circle cx="1262" cy="268" r="16" fill="white" opacity="0.2"/>
-  <text x="1262" y="274" text-anchor="middle" font-size="18" font-weight="700" fill="white">4</text>
-  <text x="1040" y="274" font-size="18px" font-weight="700" fill="white">Execution</text>
-
-  <text x="1040" y="330" font-size="16px" font-weight="600" fill="#D97706">3 Engines</text>
-  <text x="1040" y="356" font-size="15px" fill="#151515">Tekton Pipelines</text>
-  <text x="1040" y="376" font-size="15px" fill="#151515">Kubernetes Jobs</text>
-  <text x="1040" y="396" font-size="15px" fill="#151515">Ansible / AWX</text>
-
-  <line x1="1040" y1="416" x2="1260" y2="416" stroke="#F0F0F0" stroke-width="1"/>
-
-  <text x="1040" y="442" font-size="16px" font-weight="600" fill="#D97706">Security Model</text>
-  <text x="1040" y="466" font-size="15px" fill="#151515">Per-workflow ServiceAccount</text>
-  <text x="1040" y="486" font-size="15px" fill="#151515">Short-lived TokenRequest auth</text>
-
-  <rect x="1040" y="530" width="220" height="44" rx="8" fill="#F5F5F5"/>
-  <text x="1150" y="558" text-anchor="middle" font-size="14px" font-weight="600" fill="#6A6E73">CRD: WorkflowExecution</text>
 
   <!-- Arrow 4→5 -->
-  <line x1="1294" y1="460" x2="1322" y2="460" stroke="#A3A6A9" stroke-width="3"/>
-  <polygon points="1322,460 1312,454 1312,466" fill="#A3A6A9"/>
+  <line x1="1216" y1="470" x2="1236" y2="470" stroke="#CBD5E1" stroke-width="2" marker-end="url(#ar)"/>
 
-  <!-- Phase 5: Effectiveness (x=1332, w=270) -->
-  <g filter="url(#sh)">
-    <rect x="1332" y="240" width="270" height="370" rx="14" fill="white"/>
+  <!-- Phase 5: Effectiveness -->
+  <g class="phase-card" data-tab="4">
+    <g filter="url(#sh)">
+      <rect x="1244" y="310" width="270" height="390" rx="12" fill="white"/>
+    </g>
+    <rect x="1244" y="310" width="270" height="46" rx="12" fill="#059669"/>
+    <rect x="1244" y="344" width="270" height="12" fill="#059669"/>
+    <text x="1268" y="341" font-size="17px" font-weight="700" fill="white">Effectiveness</text>
+    <text x="1268" y="384" font-size="15px" font-weight="600" fill="#059669">Verify</text>
+    <text x="1268" y="406" font-size="14px" fill="#374151">Alert resolution confirmed</text>
+    <text x="1268" y="426" font-size="14px" fill="#374151">Drift detection after fix</text>
+    <text x="1268" y="446" font-size="14px" fill="#374151">Cooldown monitoring</text>
+    <line x1="1268" y1="464" x2="1494" y2="464" stroke="#F0F0F0" stroke-width="1"/>
+    <text x="1268" y="486" font-size="15px" font-weight="600" fill="#059669">Learn</text>
+    <text x="1268" y="508" font-size="14px" fill="#374151">Health scoring (0-100%)</text>
+    <text x="1268" y="528" font-size="14px" fill="#374151">Outcomes feed future RCA</text>
+    <rect x="1268" y="624" width="222" height="36" rx="8" fill="#F8FAFC"/>
+    <text x="1379" y="647" text-anchor="middle" font-size="13px" font-weight="600" fill="#64748B">CRD: EffectivenessAssessment</text>
+    <rect x="1244" y="704" width="270" height="4" rx="2" fill="transparent" class="phase-indicator" data-color="#059669"/>
+    <rect x="1244" y="310" width="270" height="390" rx="12" fill="transparent" style="cursor:pointer"/>
   </g>
-  <rect x="1332" y="240" width="270" height="56" rx="14" fill="#059669"/>
-  <rect x="1332" y="282" width="270" height="14" fill="#059669"/>
-  <circle cx="1580" cy="268" r="16" fill="white" opacity="0.2"/>
-  <text x="1580" y="274" text-anchor="middle" font-size="18" font-weight="700" fill="white">5</text>
-  <text x="1358" y="274" font-size="18px" font-weight="700" fill="white">Effectiveness</text>
-
-  <text x="1358" y="330" font-size="16px" font-weight="600" fill="#059669">Verify</text>
-  <text x="1358" y="354" font-size="15px" fill="#151515">Alert resolution confirmed</text>
-  <text x="1358" y="374" font-size="15px" fill="#151515">Drift detection after fix</text>
-  <text x="1358" y="394" font-size="15px" fill="#151515">Cooldown monitoring</text>
-
-  <line x1="1358" y1="414" x2="1578" y2="414" stroke="#F0F0F0" stroke-width="1"/>
-
-  <text x="1358" y="440" font-size="16px" font-weight="600" fill="#059669">Learn</text>
-  <text x="1358" y="464" font-size="15px" fill="#151515">Health scoring (0-100%)</text>
-  <text x="1358" y="484" font-size="15px" fill="#151515">Outcomes feed future RCA</text>
-
-  <rect x="1358" y="530" width="220" height="44" rx="8" fill="#F5F5F5"/>
-  <text x="1468" y="558" text-anchor="middle" font-size="14px" font-weight="600" fill="#6A6E73">CRD: EffectivenessAssessment</text>
 
   <!-- Arrow 5→6 -->
-  <line x1="1612" y1="460" x2="1640" y2="460" stroke="#A3A6A9" stroke-width="3"/>
-  <polygon points="1640,460 1630,454 1630,466" fill="#A3A6A9"/>
+  <line x1="1522" y1="470" x2="1542" y2="470" stroke="#CBD5E1" stroke-width="2" marker-end="url(#ar)"/>
 
-  <!-- Phase 6: Notification (x=1650, w=270) -->
-  <g filter="url(#sh)">
-    <rect x="1650" y="240" width="220" height="370" rx="14" fill="white"/>
+  <!-- Phase 6: Notification -->
+  <g class="phase-card" data-tab="5">
+    <g filter="url(#sh)">
+      <rect x="1550" y="310" width="270" height="390" rx="12" fill="white"/>
+    </g>
+    <rect x="1550" y="310" width="270" height="46" rx="12" fill="#DC2626"/>
+    <rect x="1550" y="344" width="270" height="12" fill="#DC2626"/>
+    <text x="1574" y="341" font-size="17px" font-weight="700" fill="white">Notification</text>
+    <text x="1574" y="384" font-size="15px" font-weight="600" fill="#DC2626">Channels</text>
+    <text x="1574" y="406" font-size="14px" fill="#374151">Slack, PagerDuty, Teams</text>
+    <text x="1574" y="426" font-size="14px" fill="#374151">Console, log, file</text>
+    <line x1="1574" y1="446" x2="1800" y2="446" stroke="#F0F0F0" stroke-width="1"/>
+    <text x="1574" y="468" font-size="15px" font-weight="600" fill="#DC2626">Reliability</text>
+    <text x="1574" y="490" font-size="14px" fill="#374151">Label-based routing</text>
+    <text x="1574" y="510" font-size="14px" fill="#374151">Circuit-breaker retry</text>
+    <text x="1574" y="530" font-size="14px" fill="#374151">Delivery audit trail</text>
+    <rect x="1574" y="624" width="222" height="36" rx="8" fill="#F8FAFC"/>
+    <text x="1685" y="647" text-anchor="middle" font-size="13px" font-weight="600" fill="#64748B">CRD: NotificationRequest</text>
+    <rect x="1550" y="704" width="270" height="4" rx="2" fill="transparent" class="phase-indicator" data-color="#DC2626"/>
+    <rect x="1550" y="310" width="270" height="390" rx="12" fill="transparent" style="cursor:pointer"/>
   </g>
-  <rect x="1650" y="240" width="220" height="56" rx="14" fill="#7C3AED"/>
-  <rect x="1650" y="282" width="220" height="14" fill="#7C3AED"/>
-  <circle cx="848" cy="268" r="16" fill="white" opacity="0.2" transform="translate(800,0)"/>
-  <text x="1848" y="274" text-anchor="middle" font-size="18" font-weight="700" fill="white">6</text>
-  <text x="1676" y="274" font-size="18px" font-weight="700" fill="white">Notification</text>
-
-  <text x="1676" y="330" font-size="16px" font-weight="600" fill="#7C3AED">Channels</text>
-  <text x="1676" y="354" font-size="15px" fill="#151515">Slack, PagerDuty, Teams</text>
-  <text x="1676" y="374" font-size="15px" fill="#151515">Console, log, file</text>
-
-  <line x1="1676" y1="394" x2="1846" y2="394" stroke="#F0F0F0" stroke-width="1"/>
-
-  <text x="1676" y="418" font-size="16px" font-weight="600" fill="#7C3AED">Reliability</text>
-  <text x="1676" y="442" font-size="15px" fill="#151515">Label-based routing</text>
-  <text x="1676" y="462" font-size="15px" fill="#151515">Circuit-breaker retry</text>
-  <text x="1676" y="482" font-size="15px" fill="#151515">Delivery audit trail</text>
-
-  <rect x="1676" y="530" width="170" height="44" rx="8" fill="#F5F5F5"/>
-  <text x="1761" y="558" text-anchor="middle" font-size="14px" font-weight="600" fill="#6A6E73">CRD: NotificationRequest</text>
 
 </svg>

--- a/docs/getting-started/architecture-overview.md
+++ b/docs/getting-started/architecture-overview.md
@@ -91,11 +91,11 @@ Kubernaut is a microservices platform with 11 services (v1.5+; 10 in v1.4) that 
 </svg>
 </div>
 
-The **Gateway** receives signals (Prometheus alerts, Kubernetes events) and creates RemediationRequest CRDs. The **Remediation Orchestrator** coordinates the pipeline, creating child CRDs for each phase. Five phase controllers -- Signal Processing, AI Analysis, Workflow Execution, Effectiveness Monitor, and Notification -- each handle one phase. The **DataStorage** foundation layer persists audit events, the workflow catalog, and remediation history to PostgreSQL (with Valkey for the DLQ). All services emit audit events to DataStorage over HTTP. AI Analysis delegates to Kubernaut Agent for LLM-driven investigation, and Kubernaut Agent queries DataStorage for the workflow catalog and remediation history.
+The **Gateway** receives signals (Prometheus alerts, Kubernetes events) and creates RemediationRequest CRDs. The **Remediation Orchestrator** coordinates the pipeline, creating child CRDs for each phase. Six phase controllers -- Signal Processing, AI Analysis, Workflow Execution, Effectiveness Monitor, and Notification -- each handle one phase. The **DataStorage** foundation layer persists audit events, the workflow catalog, and remediation history to PostgreSQL (with Valkey for the DLQ). All services emit audit events to DataStorage over HTTP. AI Analysis delegates to Kubernaut Agent for LLM-driven investigation, and Kubernaut Agent queries DataStorage for the workflow catalog and remediation history. The **API Frontend** (v1.5+) exposes MCP and A2A protocol endpoints for interactive sessions. `InvestigationSession` CRDs are created with **deferred materialization** — the CRD only appears in the cluster after a RemediationRequest is successfully created via `af_create_rr`, so sessions that never produce an RR leave no cluster footprint.
 
 ## Remediation Pipeline
 
-The pipeline processes signals through five CRD-native phases:
+The pipeline processes signals through six CRD-native phases:
 
 | Phase | What it does | CRD |
 |---|---|---|
@@ -104,6 +104,7 @@ The pipeline processes signals through five CRD-native phases:
 | **3. Approval** | Policy-gated review — auto-approve low-risk, manual review via Slack/Console, operator param override | `RemediationApprovalRequest` |
 | **4. Execution** | Run remediation via Tekton Pipelines, Kubernetes Jobs, or Ansible (AWX/AAP) with per-workflow SA | `WorkflowExecution` |
 | **5. Effectiveness** | Verify fix via alert resolution, spec drift detection, cooldown monitoring; health score feeds future RCA | `EffectivenessAssessment` |
+| **6. Notification** | Deliver outcome notifications to Slack, PagerDuty, Microsoft Teams, console, or file; retry with exponential backoff and circuit breaker | `NotificationRequest` |
 
 For a detailed breakdown of all sub-phases and tools, see the [Architecture: Investigation Pipeline](../architecture/kubernaut-agent-investigation.md).
 
@@ -127,14 +128,14 @@ Kubernaut supports two pipeline modes simultaneously:
 |---|---|---|
 | **Trigger** | Alert webhook (Prometheus, K8s Event) | Operator connects via MCP through API Frontend |
 | **Workflow selection** | LLM selects automatically | Operator chooses from LLM-populated alternatives |
-| **Approval** | Rego policy + RAR gate | Operator's selection is the approval |
+| **Approval** | Rego policy + RAR gate | Same Rego policy + RAR gate; identity-aware policies can auto-approve trusted operators |
 | **Visibility** | Post-hoc via kubectl, notifications | Real-time SSE streaming |
 
 Both modes use the same CRDs, audit events, and effectiveness assessments. An investigation started autonomously can be joined mid-flight by an operator via the API Frontend. See [Interactive Sessions](../user-guide/interactive-sessions.md) for the operator guide.
 
 ## Communication Pattern
 
-All inter-service communication in the remediation pipeline uses **Kubernetes CRDs**. The HTTP exceptions are: all controllers emit audit events to DataStorage, WFE queries DataStorage for the workflow catalog, RO queries DataStorage for remediation history, AA calls Kubernaut Agent for AI investigation, EM queries AlertManager and Prometheus for effectiveness assessment, and the API Frontend proxies MCP/A2A calls to Kubernaut Agent and DataStorage.
+All inter-service communication in the remediation pipeline uses **Kubernetes CRDs**. The HTTP exceptions are: all controllers emit audit events to DataStorage, WFE queries DataStorage for the workflow catalog, RO queries DataStorage for remediation history, AA calls Kubernaut Agent for AI investigation, EM queries AlertManager and Prometheus for effectiveness assessment, and the API Frontend dispatches its 14 MCP tools to multiple backends (K8s API, Kubernaut Agent REST/MCP, DataStorage).
 
 This architecture provides:
 
@@ -145,7 +146,7 @@ This architecture provides:
 
 ## Custom Resources
 
-Kubernaut defines 9 CRD types. Each CRD is owned by a dedicated controller. See [System Overview](../architecture/overview.md) for the complete service topology and CRD ownership model.
+Kubernaut defines 10 CRD types (v1.5+; 9 in v1.4), all in API group `kubernaut.ai/v1alpha1` and namespaced. The six pipeline CRDs are each owned by a dedicated controller. `RemediationWorkflow` and `ActionType` are catalog resources managed by the AuthWebhook. `RemediationRequest` is the top-level orchestration CRD. `InvestigationSession` (v1.5+) is created and managed by the API Frontend for interactive MCP/A2A sessions. See [System Overview](../architecture/overview.md) for the complete service topology and CRD ownership model.
 
 ## Remediation Lifecycle
 

--- a/docs/getting-started/architecture-overview.md
+++ b/docs/getting-started/architecture-overview.md
@@ -67,18 +67,27 @@ Kubernaut is a microservices platform with 11 services (v1.5+; 10 in v1.4) that 
   <rect x="646" y="108" width="136" height="5" rx="3" fill="#DC2626"/>
   <text x="714" y="132" text-anchor="middle" font-size="12" font-weight="700" fill="#1a1a1a">Notification</text>
   <text x="714" y="148" text-anchor="middle" font-size="9" fill="#888">Slack / PagerDuty / Teams</text>
+  <!-- API Frontend (v1.5+) -->
+  <rect x="624" y="16" width="180" height="48" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
+  <rect x="624" y="16" width="180" height="5" rx="3" fill="#8B5CF6"/>
+  <text x="714" y="40" text-anchor="middle" font-size="12" font-weight="700" fill="#1a1a1a">API Frontend</text>
+  <text x="714" y="54" text-anchor="middle" font-size="9" fill="#888">MCP / A2A / REST (v1.5+)</text>
   <!-- Support Services -->
   <rect x="30" y="182" width="760" height="80" rx="10" fill="white" stroke="#E0E0E0" stroke-width="1"/>
   <rect x="30" y="182" width="6" height="80" rx="3" fill="#64748B"/>
   <text x="50" y="200" font-size="11" font-weight="700" fill="#64748B">Support Services</text>
-  <rect x="42" y="210" width="360" height="42" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
+  <rect x="42" y="210" width="240" height="42" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
   <rect x="42" y="210" width="5" height="42" rx="2" fill="#64748B"/>
   <text x="60" y="228" font-size="12" font-weight="600" fill="#1a1a1a">DataStorage</text>
   <text x="60" y="242" font-size="9" fill="#888">PostgreSQL + Valkey</text>
-  <rect x="418" y="210" width="360" height="42" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
-  <rect x="418" y="210" width="5" height="42" rx="2" fill="#64748B"/>
-  <text x="436" y="228" font-size="12" font-weight="600" fill="#1a1a1a">AuthWebhook</text>
-  <text x="436" y="242" font-size="9" fill="#888">RAR override validation</text>
+  <rect x="298" y="210" width="240" height="42" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
+  <rect x="298" y="210" width="5" height="42" rx="2" fill="#64748B"/>
+  <text x="316" y="228" font-size="12" font-weight="600" fill="#1a1a1a">AuthWebhook</text>
+  <text x="316" y="242" font-size="9" fill="#888">RAR override validation</text>
+  <rect x="554" y="210" width="224" height="42" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
+  <rect x="554" y="210" width="5" height="42" rx="2" fill="#64748B"/>
+  <text x="572" y="228" font-size="12" font-weight="600" fill="#1a1a1a">Kubernaut Agent</text>
+  <text x="572" y="242" font-size="9" fill="#888">LLM investigation (Go)</text>
 </svg>
 </div>
 
@@ -110,9 +119,22 @@ Each CRD is owned by a dedicated controller. See [System Overview](../architectu
 
 See [System Overview](../architecture/overview.md) for the complete service topology including Gateway, DataStorage, Auth Webhook, and Kubernaut Agent.
 
+## Pipeline Modes (v1.5+)
+
+Kubernaut supports two pipeline modes simultaneously:
+
+| | Autonomous | Interactive |
+|---|---|---|
+| **Trigger** | Alert webhook (Prometheus, K8s Event) | Operator connects via MCP through API Frontend |
+| **Workflow selection** | LLM selects automatically | Operator chooses from LLM-populated alternatives |
+| **Approval** | Rego policy + RAR gate | Operator's selection is the approval |
+| **Visibility** | Post-hoc via kubectl, notifications | Real-time SSE streaming |
+
+Both modes use the same CRDs, audit events, and effectiveness assessments. An investigation started autonomously can be joined mid-flight by an operator via the API Frontend. See [Interactive Sessions](../user-guide/interactive-sessions.md) for the operator guide.
+
 ## Communication Pattern
 
-All inter-service communication in the remediation pipeline uses **Kubernetes CRDs**. The HTTP exceptions are: all controllers emit audit events to DataStorage, WFE queries DataStorage for the workflow catalog, RO queries DataStorage for remediation history, AA calls Kubernaut Agent for AI investigation, and EM queries AlertManager and Prometheus for effectiveness assessment.
+All inter-service communication in the remediation pipeline uses **Kubernetes CRDs**. The HTTP exceptions are: all controllers emit audit events to DataStorage, WFE queries DataStorage for the workflow catalog, RO queries DataStorage for remediation history, AA calls Kubernaut Agent for AI investigation, EM queries AlertManager and Prometheus for effectiveness assessment, and the API Frontend proxies MCP/A2A calls to Kubernaut Agent and DataStorage.
 
 This architecture provides:
 

--- a/docs/getting-started/architecture-overview.md
+++ b/docs/getting-started/architecture-overview.md
@@ -71,7 +71,7 @@ Kubernaut is a microservices platform with 11 services (v1.5+; 10 in v1.4) that 
   <rect x="624" y="16" width="180" height="48" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
   <rect x="624" y="16" width="180" height="5" rx="3" fill="#8B5CF6"/>
   <text x="714" y="40" text-anchor="middle" font-size="12" font-weight="700" fill="#1a1a1a">API Frontend</text>
-  <text x="714" y="54" text-anchor="middle" font-size="9" fill="#888">MCP / A2A / REST (v1.5+)</text>
+  <text x="714" y="54" text-anchor="middle" font-size="9" fill="#888">MCP / A2A (v1.5+)</text>
   <!-- Support Services -->
   <rect x="30" y="182" width="760" height="80" rx="10" fill="white" stroke="#E0E0E0" stroke-width="1"/>
   <rect x="30" y="182" width="6" height="80" rx="3" fill="#64748B"/>

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -424,11 +424,10 @@ changes between releases.
 
 ### v1.4 → v1.5 migration notes
 
-v1.5 introduces breaking changes that require manual steps during reinstall:
+v1.5 introduces changes that require attention during reinstall:
 
-1. **SAR-based tool authorization** — The API Frontend's `rbac_roles.yaml` ConfigMap is removed. Create `ClusterRoleBindings` for MCP tool access using the [pre-built ClusterRoles](../architecture/security-rbac.md#tool-authorization-v15).
-2. **11th service — API Frontend** — Resource planning must account for the new service. See [Configuration: API Frontend](../user-guide/configuration.md#api-frontend-v15) for resource defaults.
-3. **Lease RBAC** — The Kubernaut Agent ServiceAccount now requires `list` on `coordination.k8s.io/leases`. Both Helm and Operator provision this automatically, but custom RBAC configurations may need updating.
+1. **11th service — API Frontend** — Resource planning must account for the new service. See [Configuration: API Frontend](../user-guide/configuration.md#api-frontend-v15) for resource defaults.
+2. **Lease RBAC** — The Kubernaut Agent ServiceAccount now requires `list` on `coordination.k8s.io/leases`. Both Helm and Operator provision this automatically, but custom RBAC configurations may need updating.
 
 ## Uninstalling
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -34,7 +34,7 @@ For complete installation instructions, see the [Kubernaut Operator Installation
 | Valkey / Redis | 7+ | **BYO** — provide connection details via `spec.valkey` |
 | LLM provider | — | Any [supported provider](../user-guide/configmap-kubernaut-agent.md#supported-providers) with JSON structured output |
 
-**Operator image:** `quay.io/kubernaut-ai/kubernaut-operator:1.4.0` (note: no `v` prefix, unlike component images which use `v1.4.0`).
+**Operator image:** `quay.io/kubernaut-ai/kubernaut-operator:{{ operator_image_tag }}` (note: no `v` prefix, unlike component images which use `{{ image_tag }}`).
 
 **Minimal Kubernaut CR:**
 
@@ -421,6 +421,14 @@ See [Signals & Alert Routing](../user-guide/signals.md) for details on scope man
 Kubernaut does not support in-place upgrades. To move to a new version,
 perform a fresh install. See [What's New](../whats-new/index.md) for
 changes between releases.
+
+### v1.4 → v1.5 migration notes
+
+v1.5 introduces breaking changes that require manual steps during reinstall:
+
+1. **SAR-based tool authorization** — The API Frontend's `rbac_roles.yaml` ConfigMap is removed. Create `ClusterRoleBindings` for MCP tool access using the [pre-built ClusterRoles](../architecture/security-rbac.md#tool-authorization-v15).
+2. **11th service — API Frontend** — Resource planning must account for the new service. See [Configuration: API Frontend](../user-guide/configuration.md#api-frontend-v15) for resource defaults.
+3. **Lease RBAC** — The Kubernaut Agent ServiceAccount now requires `list` on `coordination.k8s.io/leases`. Both Helm and Operator provision this automatically, but custom RBAC configurations may need updating.
 
 ## Uninstalling
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -67,6 +67,7 @@ spec:
 - Runs embedded database schema migrations
 - Installs and upgrades the 9 Kubernaut workload CRDs
 - Deploys all 11 microservices (v1.5+; 10 in v1.4) with RBAC, ConfigMaps, PDBs, admission webhooks, and NetworkPolicies
+- Applies preferred pod anti-affinity to all deployments (spread across nodes by `kubernetes.io/hostname`)
 - Configures OCP Routes and service-serving CA TLS
 - Reports per-service readiness status on the `Kubernaut` CR
 - Cleans up cluster-scoped RBAC and workflow namespace on CR deletion (workload CRDs are retained by design)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -424,10 +424,11 @@ changes between releases.
 
 ### v1.4 → v1.5 migration notes
 
-v1.5 introduces changes that require attention during reinstall:
+v1.5 introduces breaking changes that require manual steps during reinstall:
 
-1. **11th service — API Frontend** — Resource planning must account for the new service. See [Configuration: API Frontend](../user-guide/configuration.md#api-frontend-v15) for resource defaults.
-2. **Lease RBAC** — The Kubernaut Agent ServiceAccount now requires `list` on `coordination.k8s.io/leases`. Both Helm and Operator provision this automatically, but custom RBAC configurations may need updating.
+1. **SAR-based tool authorization** — The API Frontend's `rbac_roles.yaml` ConfigMap is removed. Create `ClusterRoleBindings` mapping OIDC groups to the [per-persona ClusterRoles](../architecture/security-rbac.md#tool-authorization-v15) shipped in the Helm chart.
+2. **11th service — API Frontend** — Resource planning must account for the new service. See [Configuration: API Frontend](../user-guide/configuration.md#api-frontend-v15) for resource defaults.
+3. **Lease RBAC** — The Kubernaut Agent ServiceAccount now requires `list` on `coordination.k8s.io/leases`. Both Helm and Operator provision this automatically, but custom RBAC configurations may need updating.
 
 ## Uninstalling
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ Kubernaut is an open-source AIOps platform that closes the loop from Kubernetes 
 
     ---
 
-    Understand the 10-service microservices architecture, CRD communication patterns, and data flows.
+    Understand the 11-service microservices architecture, CRD communication patterns, and data flows.
 
     [:octicons-arrow-right-24: Architecture Overview](getting-started/architecture-overview.md)
 
@@ -64,11 +64,11 @@ Kubernaut is an open-source AIOps platform that closes the loop from Kubernetes 
 
     [:octicons-arrow-right-24: API Reference](api-reference/index.md)
 
--   :material-new-box:{ .lg .middle } **What's New in v1.4**
+-   :material-new-box:{ .lg .middle } **What's New in v1.5**
 
     ---
 
-    Dry-run mode, Shadow Agent prompt injection defense, operator workflow overrides, and more.
+    API Frontend, interactive MCP sessions, SAR-based tool authorization, unified SA model, and more.
 
     [:octicons-arrow-right-24: Release Highlights](whats-new/index.md)
 
@@ -76,7 +76,7 @@ Kubernaut is an open-source AIOps platform that closes the loop from Kubernetes 
 
     ---
 
-    v1.5 roadmap — interactive sessions, Backstage console, MCP/A2A integration, fleet operations.
+    Backstage console, declarative recipes, fleet operations, natural language signal intake.
 
     [:octicons-arrow-right-24: Roadmap](whats-next/index.md)
 
@@ -96,17 +96,17 @@ Kubernaut is an open-source AIOps platform that closes the loop from Kubernetes 
 
 Kubernaut automates the entire incident response lifecycle through a CRD-native pipeline.
 
-<div style="max-width:100%;overflow-x:auto;margin:1.5rem 0">
-<img src="assets/images/pipeline-phases.svg" alt="Kubernaut Remediation Pipeline — 5 phases" style="width:100%">
+<div style="max-width:100%;overflow-x:auto;margin:1.5rem 0" id="pipeline-svg-wrap">
+<object data="assets/images/pipeline-phases.svg" type="image/svg+xml" style="width:100%;height:auto" id="pipeline-svg" aria-label="Kubernaut Remediation Pipeline — 6 phases + interactive mode"></object>
 </div>
 
-Select a phase to learn more:
+Click a phase card above, or select a tab:
 
 === "1 · Signal Processing"
 
     **CRD:** `SignalProcessing`
 
-    AlertManager webhooks and Kubernetes Events are ingested, enriched with Kubernetes context (owner chain, namespace labels, workload metadata), and classified by OPA/Rego policies across multiple dimensions:
+    AlertManager webhooks, Kubernetes Events, and A2A/Interactive sessions (v1.5) are ingested, enriched with Kubernetes context (owner chain, namespace labels, workload metadata), and classified by OPA/Rego policies across multiple dimensions:
 
     - **Severity** — normalized to a standard scale (critical, high, medium, low).
     - **Environment** — inferred from namespace labels (production, staging, development).
@@ -123,7 +123,13 @@ Select a phase to learn more:
     Three-phased pipeline:
 
     - **Investigate** — The LLM investigates the incident using 36 built-in tools and produces a root cause analysis (RCA).
-    - **Select** — Using the RCA and server-side enrichment (historical context, detectable labels), the LLM selects a workflow from the existing user-created `RemediationWorkflow` catalog.
+    - **Enrich** — Server-side enrichment adds historical context, detectable labels, and prior remediation outcomes.
+    - **Select** — Using the RCA and enrichment data, the LLM selects a workflow from the existing user-created `RemediationWorkflow` catalog.
+
+    **Kubernaut Agent** — The AI Analysis phase is powered by the Kubernaut Agent (KA), which drives both autonomous and interactive investigations:
+
+    - **Autonomous** — KA runs LLM-driven investigation with 36 native Go tools, performs server-side enrichment, and selects the best-matching workflow without operator involvement.
+    - **Interactive (v1.5)** — When an operator connects via the API Frontend, KA manages Lease-based sessions with SSE streaming of investigation events. The operator guides workflow selection through the AF's MCP/A2A tools while KA handles the underlying investigation and enrichment.
 
 === "3 · Approval"
 
@@ -170,6 +176,32 @@ Select a phase to learn more:
     - **Routing:** Label-based rules with regex matching and fan-out to multiple channels.
     - **Reliability:** Circuit-breaker retry with exponential backoff per channel.
     - **Audit:** Every delivery attempt (success or failure) is recorded with correlation IDs linking back to the originating `RemediationRequest`.
+
+=== "API Frontend (v1.5)"
+
+    **CRD:** `InvestigationSession` &nbsp; **Services:** API Frontend ↔ Kubernaut Agent
+
+    The interactive path is a **parallel entry point**, not a pipeline phase. The API Frontend connects to the Kubernaut Agent for a 4-phase interactive journey:
+
+    1. **Investigate** — AF subscribes to KA's SSE stream and relays investigation events in real-time as the LLM works.
+    2. **Discover** — After RCA, AF calls `kubernaut_discover_workflows` to present workflow options with LLM-populated parameters.
+    3. **Select** — Operator picks a workflow via `kubernaut_select_workflow` → KA creates the `RemediationRequest`, entering the same autonomous pipeline (Approval → Execution → Effectiveness → Notification).
+    4. **Watch** — AF monitors CRD status transitions and reports progress to the user until a terminal phase.
+
+    The investigation creates an `InvestigationSession` CRD (deferred until RR creation). The same Rego approval gates apply — identity-aware policies can auto-approve trusted operators. See [Interactive Sessions](user-guide/interactive-sessions.md).
+
+    **SAR-gated personas** — All MCP/A2A tool access is gated by SubjectAccessReview against 6 per-persona ClusterRoles:
+
+    | Persona | MCP Tools | Tool Domains |
+    |---|---|---|
+    | **SRE** | 20 | **RemediationRequest:** `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_cancel_remediation`, `kubernaut_watch`<br>**Investigation:** `kubernaut_start_investigation`, `kubernaut_poll_investigation`, `kubernaut_stream_investigation`<br>**Interactive:** `kubernaut_takeover`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect`<br>**Workflow:** `kubernaut_discover_workflows`, `kubernaut_select_workflow`, `kubernaut_list_workflows`<br>**Data:** `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail`<br>**Presentation:** `kubernaut_present_decision` |
+    | **AI Orchestrator** | 15 | **RemediationRequest:** `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch`<br>**Investigation:** `kubernaut_start_investigation`, `kubernaut_poll_investigation`, `kubernaut_stream_investigation`<br>**Interactive:** `kubernaut_takeover`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect`<br>**Workflow:** `kubernaut_discover_workflows`, `kubernaut_select_workflow`<br>**Presentation:** `kubernaut_present_decision` |
+    | **CI/CD** | 3 | **RemediationRequest:** `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch` |
+    | **Observability** | 5 | **RemediationRequest:** `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch`<br>**Workflow:** `kubernaut_list_workflows`<br>**Data:** `kubernaut_get_effectiveness` |
+    | **L3 Audit** | 6 | **RemediationRequest:** `kubernaut_list_remediations`, `kubernaut_get_remediation`<br>**Workflow:** `kubernaut_list_workflows`<br>**Data:** `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail` |
+    | **Remediation Approver** | 4 | **RemediationApprovalRequest:** `kubernaut_list_approval_requests`, `kubernaut_get_approval_request`, `kubernaut_approve`, `kubernaut_watch` |
+
+    See [MCP Tool Reference](api-reference/mcp-tools.md) for full tool descriptions, parameters, and response examples. See [Per-persona ClusterRoles](architecture/security-rbac.md#per-persona-clusterroles) for the RBAC reference.
 
 ---
 

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -133,11 +133,17 @@ scrape_configs:
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
-| `af_tool_calls_total` | Counter | `tool`, `status` | MCP/A2A tool invocations by tool name and outcome |
-| `af_a2a_tasks_total` | Counter | `task_type`, `status` | A2A task executions by type and outcome |
-| `af_session_active` | Gauge | -- | Currently active API sessions |
-| `af_session_duration_seconds` | Histogram | -- | Session duration from connect to disconnect |
-| `af_http_request_duration_seconds` | Histogram | `endpoint`, `method`, `status` | HTTP request duration |
+| `af_http_requests_total` | Counter | `method`, `path`, `status` | Total HTTP requests |
+| `af_http_request_duration_seconds` | Histogram | `method`, `path`, `status` | HTTP request latency distribution |
+| `af_http_panics_total` | Counter | -- | HTTP handler panics recovered |
+| `af_tool_calls_total` | Counter | `tool`, `result` | MCP/A2A tool invocations by tool name and result |
+| `af_tool_call_duration_seconds` | Histogram | `tool`, `type` | Tool execution latency by tool name and type |
+| `af_downstream_request_duration_seconds` | Histogram | `dependency`, `status_class` | Downstream HTTP request duration (KA, DS) |
+| `af_auth_duration_seconds` | Histogram | `result` | Authentication latency distribution |
+| `af_rate_limit_rejections_total` | Counter | `tier`, `reason` | Rate limit rejections |
+| `af_sse_active_connections` | Gauge | -- | Currently active SSE connections |
+| `af_llm_tokens_total` | Counter | `direction` | LLM tokens consumed (input/output) |
+| `af_sessions_active` | Gauge | `phase` | Active InvestigationSessions by phase |
 
 ## Kubernaut Agent Metrics
 

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -142,7 +142,8 @@ scrape_configs:
 | `af_auth_duration_seconds` | Histogram | `result` | Authentication latency distribution |
 | `af_rate_limit_rejections_total` | Counter | `tier`, `reason` | Rate limit rejections |
 | `af_sse_active_connections` | Gauge | -- | Currently active SSE connections |
-| `af_llm_tokens_total` | Counter | `direction` | LLM tokens consumed (input/output) |
+| `af_auth_circuit_breaker_state` | Gauge | `provider` | Authentication circuit breaker state (0=closed, 1=open) |
+| `af_llm_tokens_total` | Counter | `direction`, `model` | LLM tokens consumed by direction (input/output) and model |
 | `af_sessions_active` | Gauge | `phase` | Active InvestigationSessions by phase |
 
 ## Kubernaut Agent Metrics

--- a/docs/user-guide/interactive-sessions.md
+++ b/docs/user-guide/interactive-sessions.md
@@ -23,8 +23,8 @@ Any MCP-compatible client can connect to Kubernaut's interactive sessions. The A
 
 ### Prerequisites
 
-- OIDC provider configured for the API Frontend
-- User has RBAC permissions for MCP tool access
+- OIDC provider configured for the API Frontend (DEX, Keycloak, etc.)
+- User has a `ClusterRoleBinding` to one of the [per-persona ClusterRoles](../architecture/security-rbac.md#tool-authorization-v15) (e.g., `kubernaut-tool-sre`)
 - MCP client supporting Streamable HTTP transport (spec 2025-03-26)
 
 ## MCP Tools
@@ -97,11 +97,14 @@ Select a workflow from the discovery results. Requires a prior `discover_workflo
   "workflow_id": "rollback-config",
   "kind": "Deployment",
   "name": "checkout-service",
-  "namespace": "production"
+  "namespace": "production",
+  "api_version": "apps/v1",
+  "spec_hash": "a1b2c3d4",
+  "incident_id": "inc-2026-0512"
 }
 ```
 
-The `kind`, `name`, and `namespace` fields are optional — when provided, they trigger enrichment (owner chain resolution, labels, history) before catalog lookup.
+Only `rr_id` and `workflow_id` are required. The remaining fields are optional — when `kind` is provided, enrichment runs (owner chain resolution, labels, history) before catalog lookup. `api_version` disambiguates Kinds that exist in multiple API groups (e.g., `Event`). `spec_hash` and `incident_id` enable correlation with prior investigations.
 
 Parameters are validated against the workflow's declared schema. If validation fails, the LLM attempts self-correction automatically (PR #1187).
 

--- a/docs/user-guide/interactive-sessions.md
+++ b/docs/user-guide/interactive-sessions.md
@@ -1,0 +1,166 @@
+# Interactive Sessions
+
+!!! warning "This page is under active development for v1.5 GA"
+
+Interactive MCP sessions let operators and AI agents connect to Kubernaut for real-time investigation, workflow discovery, and remediation steering. This is an alternative to the fully autonomous pipeline — operators stay in the loop and make decisions at key points.
+
+## Overview
+
+The interactive flow has four phases:
+
+```
+  Investigate → Discover Workflows → Select Workflow → Watch Effectiveness
+```
+
+1. **Investigate** — Connect to Kubernaut and start (or join) an investigation. The LLM performs root cause analysis with full Kubernetes tool access while streaming findings in real time.
+2. **Discover Workflows** — After RCA, Kubernaut presents matching workflows with LLM-populated parameters. Operators review the options.
+3. **Select Workflow** — Operator selects a workflow (or decides no action is needed). Parameters can be reviewed and edited before execution.
+4. **Watch Effectiveness** — After execution, the effectiveness assessment runs and results are streamed back.
+
+## Connecting via MCP
+
+Any MCP-compatible client can connect to Kubernaut's interactive sessions. The API Frontend handles authentication (OIDC/OAuth2) and authorization (SAR-based).
+
+### Prerequisites
+
+- OIDC provider configured (e.g., DEX)
+- User has a `ClusterRoleBinding` to one of the [tool-level ClusterRoles](../architecture/security-rbac.md#tool-authorization-v15)
+- MCP client capable of SSE streaming
+
+## MCP Tools
+
+### `kubernaut_investigate`
+
+The primary investigation tool with four actions:
+
+| Action | Description |
+|---|---|
+| `start` | Start a new investigation for a signal or resource |
+| `reconnect` | Reconnect to an existing in-progress investigation |
+| `status` | Check the current status of an investigation |
+| `complete` | Mark an investigation as complete |
+
+**Start a new investigation:**
+
+```json
+{
+  "action": "start",
+  "signal_name": "PodCrashLoopBackOff",
+  "namespace": "production",
+  "resource_kind": "Deployment",
+  "resource_name": "checkout-service"
+}
+```
+
+**Join a running investigation:**
+
+```json
+{
+  "action": "reconnect",
+  "session_id": "sess-a1b2c3d4"
+}
+```
+
+### `discover_workflows`
+
+After root cause analysis, returns matching workflows with parameters pre-populated by the LLM:
+
+```json
+{
+  "alternatives": [
+    {
+      "workflow_id": "restart-and-patch-memory",
+      "description": "Bump memory limit to 768Mi + rolling restart",
+      "confidence": 0.91,
+      "risk": "low",
+      "parameters": {
+        "memory_limit": "768Mi",
+        "target_deployment": "checkout-service"
+      }
+    },
+    {
+      "workflow_id": "rollback-config",
+      "description": "Revert ConfigMap to pre-incident version",
+      "confidence": 0.85,
+      "risk": "low",
+      "parameters": {
+        "configmap_name": "checkout-config",
+        "target_revision": "v42"
+      }
+    }
+  ]
+}
+```
+
+### `select_workflow`
+
+Select a workflow from the discovery results:
+
+```json
+{
+  "workflow_id": "rollback-config",
+  "parameters": {
+    "configmap_name": "checkout-config",
+    "target_revision": "v42"
+  }
+}
+```
+
+Parameters are validated against the workflow's declared schema. If validation fails, the LLM attempts self-correction automatically.
+
+### `complete_no_action`
+
+If no workflow is suitable, the operator can close the investigation without remediation:
+
+```json
+{
+  "reason": "Root cause is external — vendor API outage, not actionable by us"
+}
+```
+
+### `stream_investigation`
+
+Subscribe to a real-time SSE stream of investigation progress:
+
+- Token-by-token LLM output
+- Tool call events (which Kubernetes resources are being inspected)
+- Phase transitions (RCA complete, discovery started, etc.)
+- Keepalive pings to maintain the connection
+
+## Session Management
+
+### Session lifecycle
+
+Each interactive session is backed by a Kubernetes Lease for distributed locking:
+
+1. **Start** — A Lease is created in `kubernaut-system`; the session is bound to the authenticated user
+2. **Active** — The Lease is renewed periodically; investigation proceeds
+3. **Reconnect** — The same user can reconnect to their session after a disconnect
+4. **Takeover** — A different user connecting causes the original session to be abandoned (SEC-TAKEOVER-001)
+5. **Complete** — The session Lease is released
+
+### Disconnect handling
+
+If a client disconnects unexpectedly:
+
+- The session remains active for the duration of `session.disconnectTTL` (default: 10m)
+- The same user can reconnect within this window using `action:reconnect`
+- After the TTL expires, the session is cleaned up
+
+### Pod restarts
+
+On KA pod restart, orphaned Leases (from the previous pod) are automatically reclaimed. In-progress investigations are not lost — clients reconnect to the new pod transparently.
+
+## Autonomous vs Interactive
+
+Kubernaut supports both modes simultaneously:
+
+| Aspect | Autonomous | Interactive |
+|---|---|---|
+| **Trigger** | Alert webhook (Prometheus, K8s Event) | Operator connects via MCP |
+| **Workflow selection** | LLM selects automatically | Operator chooses from alternatives |
+| **Approval** | Rego policy + RAR gate | Operator's selection is the approval |
+| **Visibility** | Post-hoc via kubectl, notifications | Real-time SSE streaming |
+| **Pipeline** | Full 6-stage pipeline | Same pipeline, operator-driven at selection stage |
+
+Both modes produce the same CRDs, audit events, and effectiveness assessments. An investigation started autonomously (from an alert) can be joined mid-flight by an operator via `action:reconnect`.

--- a/docs/user-guide/interactive-sessions.md
+++ b/docs/user-guide/interactive-sessions.md
@@ -19,7 +19,7 @@ The interactive flow has four phases:
 
 ## Connecting via MCP
 
-Any MCP-compatible client can connect to Kubernaut's interactive sessions. The API Frontend exposes a MCP Streamable HTTP endpoint (`POST /mcp`) with 23 tools spanning CRD operations, investigation, interactive session lifecycle, data/history, and presentation. The AF dispatches interactive lifecycle tools to the Kubernaut Agent's MCP server; other tools are handled locally or via REST/DataStorage.
+Any MCP-compatible client can connect to Kubernaut's interactive sessions. The API Frontend exposes a MCP Streamable HTTP endpoint (`POST /mcp`) with 23 `kubernaut_*` MCP tools spanning CRD operations, investigation, interactive session lifecycle, data/history, and presentation. The AF dispatches interactive lifecycle tools to the Kubernaut Agent's MCP server; other tools are handled locally or via REST/DataStorage.
 
 ### Prerequisites
 
@@ -29,7 +29,7 @@ Any MCP-compatible client can connect to Kubernaut's interactive sessions. The A
 
 ## MCP Tools
 
-The API Frontend exposes **23 tools** on `POST /mcp`. For interactive investigation, the key tools are:
+The API Frontend exposes **23 MCP tools** on `POST /mcp`. For interactive investigation, the key tools are:
 
 ### Interactive session lifecycle
 

--- a/docs/user-guide/interactive-sessions.md
+++ b/docs/user-guide/interactive-sessions.md
@@ -12,144 +12,152 @@ The interactive flow has four phases:
   Investigate → Discover Workflows → Select Workflow → Watch Effectiveness
 ```
 
-1. **Investigate** — Connect to Kubernaut and start (or join) an investigation. The LLM performs root cause analysis with full Kubernetes tool access while streaming findings in real time.
+1. **Investigate** — Connect to Kubernaut and start (or join) an investigation. The LLM performs root cause analysis with full Kubernetes tool access while streaming findings in real time via SSE.
 2. **Discover Workflows** — After RCA, Kubernaut presents matching workflows with LLM-populated parameters. Operators review the options.
 3. **Select Workflow** — Operator selects a workflow (or decides no action is needed). Parameters can be reviewed and edited before execution.
-4. **Watch Effectiveness** — After execution, the effectiveness assessment runs and results are streamed back.
+4. **Watch Effectiveness** — After execution, the AF watches the RemediationRequest CRD and relays phase transitions back to the user.
 
 ## Connecting via MCP
 
-Any MCP-compatible client can connect to Kubernaut's interactive sessions. The API Frontend handles authentication (OIDC/OAuth2) and authorization (SAR-based).
+Any MCP-compatible client can connect to Kubernaut's interactive sessions. The API Frontend exposes a single MCP Streamable HTTP endpoint (`POST /mcp`) that proxies tool calls to the Kubernaut Agent, where the MCP tools are registered.
 
 ### Prerequisites
 
-- OIDC provider configured (e.g., DEX)
-- User has a `ClusterRoleBinding` to one of the [tool-level ClusterRoles](../architecture/security-rbac.md#tool-authorization-v15)
-- MCP client capable of SSE streaming
+- OIDC provider configured for the API Frontend
+- User has RBAC permissions for MCP tool access
+- MCP client supporting Streamable HTTP transport (spec 2025-03-26)
 
 ## MCP Tools
 
+The Kubernaut Agent registers **3 MCP tools** via the [go-sdk MCP server](https://github.com/modelcontextprotocol/go-sdk):
+
 ### `kubernaut_investigate`
 
-The primary investigation tool with four actions:
+The primary investigation tool with **8 actions**:
 
 | Action | Description |
 |---|---|
-| `start` | Start a new investigation for a signal or resource |
-| `reconnect` | Reconnect to an existing in-progress investigation |
-| `status` | Check the current status of an investigation |
-| `complete` | Mark an investigation as complete |
+| `start` | Start a new interactive investigation for a RemediationRequest |
+| `message` | Send a follow-up message in a multi-turn conversation |
+| `complete` | Mark the investigation as complete |
+| `cancel` | Cancel the investigation |
+| `takeover` | Take over a session owned by another user (SEC-TAKEOVER-001) |
+| `status` | Check the current status — returns mode (autonomous/interactive/not_found) and driver |
+| `reconnect` | Reconnect to an existing session after a disconnect |
+| `discover_workflows` | After RCA, run workflow discovery and return alternatives with LLM-populated parameters |
 
-**Start a new investigation:**
+**Input schema:**
 
 ```json
 {
-  "action": "start",
-  "signal_name": "PodCrashLoopBackOff",
-  "namespace": "production",
-  "resource_kind": "Deployment",
-  "resource_name": "checkout-service"
+  "rr_id": "rr-b83e19d4a7f1-5c2d09ae",
+  "action": "start"
 }
 ```
 
-**Join a running investigation:**
+All actions require `rr_id` — the tool operates on an existing RemediationRequest. The `message` action additionally requires a `message` field for multi-turn conversation.
+
+**Start an investigation:**
 
 ```json
 {
-  "action": "reconnect",
-  "session_id": "sess-a1b2c3d4"
+  "rr_id": "rr-b83e19d4a7f1-5c2d09ae",
+  "action": "start"
 }
 ```
 
-### `discover_workflows`
-
-After root cause analysis, returns matching workflows with parameters pre-populated by the LLM:
+**Send a follow-up message:**
 
 ```json
 {
-  "alternatives": [
-    {
-      "workflow_id": "restart-and-patch-memory",
-      "description": "Bump memory limit to 768Mi + rolling restart",
-      "confidence": 0.91,
-      "risk": "low",
-      "parameters": {
-        "memory_limit": "768Mi",
-        "target_deployment": "checkout-service"
-      }
-    },
-    {
-      "workflow_id": "rollback-config",
-      "description": "Revert ConfigMap to pre-incident version",
-      "confidence": 0.85,
-      "risk": "low",
-      "parameters": {
-        "configmap_name": "checkout-config",
-        "target_revision": "v42"
-      }
-    }
-  ]
+  "rr_id": "rr-b83e19d4a7f1-5c2d09ae",
+  "action": "message",
+  "message": "Can you also check the memory limits on the sidecar containers?"
 }
 ```
 
-### `select_workflow`
-
-Select a workflow from the discovery results:
+**Discover workflows after RCA:**
 
 ```json
 {
+  "rr_id": "rr-b83e19d4a7f1-5c2d09ae",
+  "action": "discover_workflows"
+}
+```
+
+### `kubernaut_select_workflow`
+
+Select a workflow from the discovery results. Requires a prior `discover_workflows` call.
+
+**Input schema:**
+
+```json
+{
+  "rr_id": "rr-b83e19d4a7f1-5c2d09ae",
   "workflow_id": "rollback-config",
-  "parameters": {
-    "configmap_name": "checkout-config",
-    "target_revision": "v42"
-  }
+  "kind": "Deployment",
+  "name": "checkout-service",
+  "namespace": "production"
 }
 ```
 
-Parameters are validated against the workflow's declared schema. If validation fails, the LLM attempts self-correction automatically.
+The `kind`, `name`, and `namespace` fields are optional — when provided, they trigger enrichment (owner chain resolution, labels, history) before catalog lookup.
 
-### `complete_no_action`
+Parameters are validated against the workflow's declared schema. If validation fails, the LLM attempts self-correction automatically (PR #1187).
 
-If no workflow is suitable, the operator can close the investigation without remediation:
+### `kubernaut_complete_no_action`
+
+Close an investigation without selecting a workflow. Can be called at any point in the session — no discovery gate required.
+
+**Input schema:**
 
 ```json
 {
+  "rr_id": "rr-b83e19d4a7f1-5c2d09ae",
   "reason": "Root cause is external — vendor API outage, not actionable by us"
 }
 ```
 
-### `stream_investigation`
+## SSE Streaming
 
-Subscribe to a real-time SSE stream of investigation progress:
+Real-time investigation output is available via the Kubernaut Agent's SSE endpoint:
 
-- Token-by-token LLM output
-- Tool call events (which Kubernetes resources are being inspected)
-- Phase transitions (RCA complete, discovery started, etc.)
-- Keepalive pings to maintain the connection
+```
+GET /api/v1/incident/session/{session_id}/stream
+```
+
+The API Frontend subscribes to this stream and relays events to MCP clients. Events include token-by-token LLM output, tool call notifications, and phase transitions.
 
 ## Session Management
 
+Interactive sessions are managed by the **Kubernaut Agent's MCP layer** using Kubernetes Leases for distributed locking.
+
 ### Session lifecycle
 
-Each interactive session is backed by a Kubernetes Lease for distributed locking:
+Each interactive session is backed by a Kubernetes Lease (prefix: `kubernaut-interactive-`) in the `kubernaut-system` namespace:
 
-1. **Start** — A Lease is created in `kubernaut-system`; the session is bound to the authenticated user
-2. **Active** — The Lease is renewed periodically; investigation proceeds
-3. **Reconnect** — The same user can reconnect to their session after a disconnect
-4. **Takeover** — A different user connecting causes the original session to be abandoned (SEC-TAKEOVER-001)
-5. **Complete** — The session Lease is released
+1. **Start** — A Lease is created; the session is bound to the authenticated user
+2. **Active** — The session is renewed periodically; investigation proceeds
+3. **Message** — Multi-turn conversation within the active session
+4. **Reconnect** — The same user can reconnect after a disconnect
+5. **Takeover** — A different user connecting causes the original session to be abandoned (SEC-TAKEOVER-001)
+6. **Complete/Cancel** — The session Lease is released
+
+### Session limits and timeouts
+
+| Setting | Default | Description |
+|---|---|---|
+| Session TTL | 30 minutes | Maximum session duration before auto-expiry |
+| Inactivity timeout | Configurable | Session expires after period of no activity |
+| Max concurrent sessions | Configurable | Rejects new sessions when capacity is exhausted (SEC-03) |
 
 ### Disconnect handling
 
-If a client disconnects unexpectedly:
-
-- The session remains active for the duration of `session.disconnectTTL` (default: 10m)
-- The same user can reconnect within this window using `action:reconnect`
-- After the TTL expires, the session is cleaned up
+If a client disconnects unexpectedly, the Kubernaut Agent's `SessionClosedHandler` detects the MCP connection closure and triggers session release and reconstruction (DD-INTERACTIVE-002). The same user can reconnect via `action:reconnect`.
 
 ### Pod restarts
 
-On KA pod restart, orphaned Leases (from the previous pod) are automatically reclaimed. In-progress investigations are not lost — clients reconnect to the new pod transparently.
+On KA pod restart, the `LeaseSessionManager` scans for orphaned Leases (those whose holder identity no longer exists) and reclaims them. The `SessionDrainer` handles graceful shutdown — notifying connected clients and releasing all Leases before the pod terminates (BR-OPS-013).
 
 ## Autonomous vs Interactive
 
@@ -158,7 +166,7 @@ Kubernaut supports both modes simultaneously:
 | Aspect | Autonomous | Interactive |
 |---|---|---|
 | **Trigger** | Alert webhook (Prometheus, K8s Event) | Operator connects via MCP |
-| **Workflow selection** | LLM selects automatically | Operator chooses from alternatives |
+| **Workflow selection** | LLM selects automatically | Operator chooses from alternatives via `discover_workflows` |
 | **Approval** | Rego policy + RAR gate | Operator's selection is the approval |
 | **Visibility** | Post-hoc via kubectl, notifications | Real-time SSE streaming |
 | **Pipeline** | Full 6-stage pipeline | Same pipeline, operator-driven at selection stage |

--- a/docs/user-guide/interactive-sessions.md
+++ b/docs/user-guide/interactive-sessions.md
@@ -19,7 +19,7 @@ The interactive flow has four phases:
 
 ## Connecting via MCP
 
-Any MCP-compatible client can connect to Kubernaut's interactive sessions. The API Frontend exposes a single MCP Streamable HTTP endpoint (`POST /mcp`) that proxies tool calls to the Kubernaut Agent, where the MCP tools are registered.
+Any MCP-compatible client can connect to Kubernaut's interactive sessions. The API Frontend exposes a MCP Streamable HTTP endpoint (`POST /mcp`) with 23 tools spanning CRD operations, investigation, interactive session lifecycle, data/history, and presentation. The AF dispatches interactive lifecycle tools to the Kubernaut Agent's MCP server; other tools are handled locally or via REST/DataStorage.
 
 ### Prerequisites
 
@@ -29,22 +29,23 @@ Any MCP-compatible client can connect to Kubernaut's interactive sessions. The A
 
 ## MCP Tools
 
-The Kubernaut Agent registers **3 MCP tools** via the [go-sdk MCP server](https://github.com/modelcontextprotocol/go-sdk):
+The API Frontend exposes **23 tools** on `POST /mcp`. For interactive investigation, the key tools are:
 
-### `kubernaut_investigate`
+### Interactive session lifecycle
 
-The primary investigation tool with **8 actions**:
+These tools are dispatched to the Kubernaut Agent's MCP server (`kubernaut_investigate` with per-action routing):
 
-| Action | Description |
+| Tool | Description |
 |---|---|
-| `start` | Start a new interactive investigation for a RemediationRequest |
-| `message` | Send a follow-up message in a multi-turn conversation |
-| `complete` | Mark the investigation as complete |
-| `cancel` | Cancel the investigation |
-| `takeover` | Take over a session owned by another user (SEC-TAKEOVER-001) |
-| `status` | Check the current status — returns mode (autonomous/interactive/not_found) and driver |
-| `reconnect` | Reconnect to an existing session after a disconnect |
-| `discover_workflows` | After RCA, run workflow discovery and return alternatives with LLM-populated parameters |
+| `kubernaut_start_investigation` | Start a new investigation for a RemediationRequest (via KA REST) |
+| `kubernaut_takeover` | Take over a session owned by another user (SEC-TAKEOVER-001) |
+| `kubernaut_message` | Send a follow-up message in a multi-turn conversation |
+| `kubernaut_complete` | Mark the investigation as complete |
+| `kubernaut_cancel` | Cancel the investigation |
+| `kubernaut_status` | Check the current status — returns mode (autonomous/interactive/not_found) and driver |
+| `kubernaut_reconnect` | Reconnect to an existing session after a disconnect |
+| `kubernaut_discover_workflows` | After RCA, run workflow discovery and return alternatives with LLM-populated parameters |
+| `kubernaut_stream_investigation` | Stream live SSE events from KA until a terminal state |
 
 **Input schema:**
 
@@ -170,7 +171,7 @@ Kubernaut supports both modes simultaneously:
 |---|---|---|
 | **Trigger** | Alert webhook (Prometheus, K8s Event) | Operator connects via MCP |
 | **Workflow selection** | LLM selects automatically | Operator chooses from alternatives via `discover_workflows` |
-| **Approval** | Rego policy + RAR gate | Operator's selection is the approval |
+| **Approval** | Rego policy + RAR gate | Same Rego policy + RAR gate; operator identity is exposed via `input.identity` (user, groups), enabling policies to auto-approve trusted operators |
 | **Visibility** | Post-hoc via kubectl, notifications | Real-time SSE streaming |
 | **Pipeline** | Full 6-stage pipeline | Same pipeline, operator-driven at selection stage |
 

--- a/docs/user-guide/trust-ladder.md
+++ b/docs/user-guide/trust-ladder.md
@@ -6,23 +6,26 @@ Operators rarely hand full control of cluster remediation to an AI on day one. K
 
 ```mermaid
 graph LR
-    subgraph v14["Available (v1.4)"]
+    subgraph v14["Available (v1.4+)"]
         L1["Level 1<br/><b>Observe</b><br/><small>Global dry-run</small>"]
         L3["Level 3<br/><b>Approve</b><br/><small>RAR gate</small>"]
         L4["Level 4<br/><b>Automate</b><br/><small>Full autonomous</small>"]
     end
-    subgraph v15["Planned (v1.5)"]
+    subgraph v15["Available (v1.5+)"]
         L2["Level 2<br/><b>Selective Trust</b><br/><small>Per-workflow dry-run</small>"]
+        L5["Interactive<br/><b>MCP Sessions</b><br/><small>Operator-in-the-loop</small>"]
     end
     L1 --> L2 --> L3 --> L4
+    L2 -.-> L5
 ```
 
 | Level | Name | Human Involvement | Available |
 |---|---|---|---|
 | **1** | **Observe** | Operator sees what Kubernaut *would* do — no execution | **v1.4** (global dry-run) |
-| **2** | Selective Trust | Trusted workflows execute; new ones stay in dry-run | v1.5 (per-workflow dry-run) |
+| **2** | **Selective Trust** | Trusted workflows execute; new ones stay in dry-run | **v1.5** (per-workflow dry-run) |
 | **3** | **Approve** | Rego policy gates remediation via RAR — operator approves/rejects | **v1.4** |
 | **4** | **Automate** | Matched workflows execute without human intervention | **v1.4** |
+| | **Interactive** | Operator connects via MCP for real-time investigation and workflow selection | **v1.5** ([Interactive Sessions](interactive-sessions.md)) |
 
 Operators typically start at Level 1 (observe) or Level 3 (approve) and graduate individual workflows or entire namespaces to Level 4 as they gain confidence in Kubernaut's decision-making.
 

--- a/docs/user-guide/trust-ladder.md
+++ b/docs/user-guide/trust-ladder.md
@@ -5,90 +5,83 @@ Operators rarely hand full control of cluster remediation to an AI on day one. K
 ## The Trust Ladder
 
 <div style="max-width:100%;overflow-x:auto;margin:1.5rem 0">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 310" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" style="width:100%;height:auto">
-  <rect width="820" height="310" fill="white"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 320" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" style="width:100%;height:auto">
+  <rect width="820" height="320" fill="white"/>
 
   <!-- Title -->
   <text x="24" y="28" font-size="14" font-weight="700" fill="#0F172A" letter-spacing="0.5">Trust Ladder</text>
   <text x="24" y="46" font-size="10" fill="#64748B">Build confidence incrementally — from full human oversight to autonomous remediation.</text>
 
-  <!-- Baseline for staircase alignment (cards bottom-align at y=290) -->
-
   <!-- L1: Observe (shortest — 120px tall) -->
-  <rect x="16" y="170" width="186" height="120" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
-  <rect x="16" y="170" width="186" height="5" rx="3" fill="#0891B2"/>
-  <text x="28" y="194" font-size="13" font-weight="700" fill="#0F172A">Observe</text>
-  <text x="28" y="212" font-size="9" fill="#64748B">Global dry-run mode. Kubernaut</text>
-  <text x="28" y="224" font-size="9" fill="#64748B">investigates and selects workflows</text>
-  <text x="28" y="236" font-size="9" fill="#64748B">but does not execute. Operators</text>
-  <text x="28" y="248" font-size="9" fill="#64748B">review RCA and selections via</text>
-  <text x="28" y="260" font-size="9" fill="#64748B">audit events and notifications.</text>
-  <text x="28" y="280" font-size="8" font-weight="600" fill="#0891B2">v1.4+</text>
+  <rect x="16" y="180" width="186" height="120" rx="6" fill="white" stroke="#E5E7EB"/>
+  <rect x="16" y="180" width="186" height="4" rx="3" fill="#DC2626"/>
+  <text x="28" y="204" font-size="13" font-weight="700" fill="#0F172A">Observe</text>
+  <text x="28" y="220" font-size="9" fill="#64748B">Global dry-run mode. Kubernaut</text>
+  <text x="28" y="232" font-size="9" fill="#64748B">investigates and selects workflows</text>
+  <text x="28" y="244" font-size="9" fill="#64748B">but does not execute. Operators</text>
+  <text x="28" y="256" font-size="9" fill="#64748B">review RCA and selections via</text>
+  <text x="28" y="268" font-size="9" fill="#64748B">audit events and notifications.</text>
 
   <!-- L2: Approve (160px tall) -->
-  <rect x="214" y="130" width="186" height="160" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
-  <rect x="214" y="130" width="186" height="5" rx="3" fill="#6366F1"/>
-  <text x="226" y="154" font-size="13" font-weight="700" fill="#0F172A">Approve</text>
-  <text x="226" y="172" font-size="9" fill="#64748B">Rego policy gates remediation.</text>
-  <text x="226" y="184" font-size="9" fill="#64748B">Human approves, rejects, or</text>
-  <text x="226" y="196" font-size="9" fill="#64748B">overrides the AI-selected</text>
-  <text x="226" y="208" font-size="9" fill="#64748B">workflow via RAR. Shadow agent</text>
-  <text x="226" y="220" font-size="9" fill="#64748B">alignment provides an additional</text>
-  <text x="226" y="232" font-size="9" fill="#64748B">safety layer independent of</text>
-  <text x="226" y="244" font-size="9" fill="#64748B">the trust level.</text>
-  <text x="226" y="280" font-size="8" font-weight="600" fill="#6366F1">v1.4+</text>
+  <rect x="214" y="140" width="186" height="160" rx="6" fill="white" stroke="#E5E7EB"/>
+  <rect x="214" y="140" width="186" height="4" rx="3" fill="#DC2626"/>
+  <text x="226" y="164" font-size="13" font-weight="700" fill="#0F172A">Approve</text>
+  <text x="226" y="180" font-size="9" fill="#64748B">Rego policy gates remediation.</text>
+  <text x="226" y="192" font-size="9" fill="#64748B">Human approves, rejects, or</text>
+  <text x="226" y="204" font-size="9" fill="#64748B">overrides the AI-selected</text>
+  <text x="226" y="216" font-size="9" fill="#64748B">workflow via RAR. Shadow agent</text>
+  <text x="226" y="228" font-size="9" fill="#64748B">alignment provides an additional</text>
+  <text x="226" y="240" font-size="9" fill="#64748B">safety layer independent of</text>
+  <text x="226" y="252" font-size="9" fill="#64748B">the trust level.</text>
 
   <!-- L3: Security & Autonomy (200px tall) -->
-  <rect x="412" y="90" width="186" height="200" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
-  <rect x="412" y="90" width="186" height="5" rx="3" fill="#D97706"/>
-  <text x="424" y="114" font-size="13" font-weight="700" fill="#0F172A">Security &amp; Autonomy</text>
-  <text x="424" y="132" font-size="9" fill="#64748B">SAR-based tool authorization</text>
-  <text x="424" y="144" font-size="9" fill="#64748B">with 6 per-persona ClusterRoles.</text>
-  <text x="424" y="156" font-size="9" fill="#64748B">Interactive MCP sessions for</text>
-  <text x="424" y="168" font-size="9" fill="#64748B">operator-in-the-loop investigation</text>
-  <text x="424" y="180" font-size="9" fill="#64748B">and workflow discovery. Session</text>
-  <text x="424" y="192" font-size="9" fill="#64748B">takeover security (SEC-TAKEOVER).</text>
-  <text x="424" y="210" font-size="9" fill="#64748B">A2A protocol for external agent</text>
-  <text x="424" y="222" font-size="9" fill="#64748B">delegation. API Frontend as the</text>
-  <text x="424" y="234" font-size="9" fill="#64748B">unified external protocol layer.</text>
-  <text x="424" y="280" font-size="8" font-weight="600" fill="#D97706">v1.5</text>
+  <rect x="412" y="100" width="186" height="200" rx="6" fill="white" stroke="#E5E7EB"/>
+  <rect x="412" y="100" width="186" height="4" rx="3" fill="#DC2626"/>
+  <text x="424" y="124" font-size="13" font-weight="700" fill="#0F172A">Security &amp; Autonomy</text>
+  <text x="424" y="140" font-size="9" fill="#64748B">SAR-based tool authorization</text>
+  <text x="424" y="152" font-size="9" fill="#64748B">with 6 per-persona ClusterRoles.</text>
+  <text x="424" y="164" font-size="9" fill="#64748B">Interactive MCP sessions for</text>
+  <text x="424" y="176" font-size="9" fill="#64748B">operator-in-the-loop investigation</text>
+  <text x="424" y="188" font-size="9" fill="#64748B">and workflow discovery. A2A</text>
+  <text x="424" y="200" font-size="9" fill="#64748B">protocol for external agent</text>
+  <text x="424" y="212" font-size="9" fill="#64748B">delegation. API Frontend as the</text>
+  <text x="424" y="224" font-size="9" fill="#64748B">unified external protocol layer.</text>
 
   <!-- L4: Full Autonomy (240px tall) -->
-  <rect x="610" y="50" width="194" height="240" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
-  <rect x="610" y="50" width="194" height="5" rx="3" fill="#059669"/>
-  <text x="622" y="74" font-size="13" font-weight="700" fill="#0F172A">Full Autonomy</text>
-  <text x="622" y="92" font-size="9" fill="#64748B">Matched workflows execute</text>
-  <text x="622" y="104" font-size="9" fill="#64748B">without human intervention.</text>
-  <text x="622" y="116" font-size="9" fill="#64748B">Effectiveness Monitor verifies</text>
-  <text x="622" y="128" font-size="9" fill="#64748B">fixes and feeds scores back</text>
-  <text x="622" y="140" font-size="9" fill="#64748B">into future investigations.</text>
-  <text x="622" y="158" font-size="9" fill="#64748B">Operators monitor outcomes</text>
-  <text x="622" y="170" font-size="9" fill="#64748B">via notifications, dashboards,</text>
-  <text x="622" y="182" font-size="9" fill="#64748B">and Effectiveness Monitor</text>
-  <text x="622" y="194" font-size="9" fill="#64748B">metrics. Rollback to Approve</text>
-  <text x="622" y="206" font-size="9" fill="#64748B">at any time by updating the</text>
-  <text x="622" y="218" font-size="9" fill="#64748B">Rego policy — no pod restart.</text>
-  <text x="622" y="280" font-size="8" font-weight="600" fill="#059669">v1.4+</text>
+  <rect x="610" y="60" width="194" height="240" rx="6" fill="white" stroke="#E5E7EB"/>
+  <rect x="610" y="60" width="194" height="4" rx="3" fill="#DC2626"/>
+  <text x="622" y="84" font-size="13" font-weight="700" fill="#0F172A">Full Autonomy</text>
+  <text x="622" y="100" font-size="9" fill="#64748B">Matched workflows execute</text>
+  <text x="622" y="112" font-size="9" fill="#64748B">without human intervention.</text>
+  <text x="622" y="124" font-size="9" fill="#64748B">Effectiveness Monitor verifies</text>
+  <text x="622" y="136" font-size="9" fill="#64748B">fixes and feeds scores back</text>
+  <text x="622" y="148" font-size="9" fill="#64748B">into future investigations.</text>
+  <text x="622" y="166" font-size="9" fill="#64748B">Operators monitor outcomes</text>
+  <text x="622" y="178" font-size="9" fill="#64748B">via notifications, dashboards,</text>
+  <text x="622" y="190" font-size="9" fill="#64748B">and Effectiveness Monitor</text>
+  <text x="622" y="202" font-size="9" fill="#64748B">metrics. Rollback to Approve</text>
+  <text x="622" y="214" font-size="9" fill="#64748B">at any time by updating the</text>
+  <text x="622" y="226" font-size="9" fill="#64748B">Rego policy — no pod restart.</text>
 
   <!-- Arrows connecting the levels -->
-  <line x1="202" y1="240" x2="214" y2="220" stroke="#B0B0B0" stroke-width="1.3" marker-end="url(#tl-arrow)"/>
-  <line x1="400" y1="200" x2="412" y2="180" stroke="#B0B0B0" stroke-width="1.3" marker-end="url(#tl-arrow)"/>
-  <line x1="598" y1="180" x2="610" y2="160" stroke="#B0B0B0" stroke-width="1.3" marker-end="url(#tl-arrow)"/>
+  <line x1="202" y1="250" x2="214" y2="230" stroke="#D1D5DB" stroke-width="1.3" marker-end="url(#tl-arrow)"/>
+  <line x1="400" y1="210" x2="412" y2="190" stroke="#D1D5DB" stroke-width="1.3" marker-end="url(#tl-arrow)"/>
+  <line x1="598" y1="190" x2="610" y2="170" stroke="#D1D5DB" stroke-width="1.3" marker-end="url(#tl-arrow)"/>
 
   <defs>
     <marker id="tl-arrow" markerWidth="7" markerHeight="5" refX="6" refY="2.5" orient="auto">
-      <polygon points="0 0, 7 2.5, 0 5" fill="#B0B0B0"/>
+      <polygon points="0 0, 7 2.5, 0 5" fill="#D1D5DB"/>
     </marker>
   </defs>
 </svg>
 </div>
 
-| Level | Name | Human Involvement | Available |
-|---|---|---|---|
-| **1** | **Observe** | Operator sees what Kubernaut *would* do — no execution (global dry-run) | **v1.4+** |
-| **2** | **Approve** | Rego policy gates remediation via RAR — operator approves/rejects/overrides | **v1.4+** |
-| **3** | **Security & Autonomy** | SAR-based tool authorization, per-persona ClusterRoles, interactive MCP sessions | **v1.5** |
-| **4** | **Full Autonomy** | Matched workflows execute without human intervention | **v1.4+** |
+| Level | Name | Description |
+|---|---|---|
+| **1** | **Observe** | Operator sees what Kubernaut *would* do — no execution (global dry-run) |
+| **2** | **Approve** | Rego policy gates remediation via RAR — operator approves/rejects/overrides |
+| **3** | **Security & Autonomy** | SAR-based tool authorization, per-persona ClusterRoles, interactive MCP sessions, A2A delegation |
+| **4** | **Full Autonomy** | Matched workflows execute without human intervention |
 
 At every level, operators can connect via **[Interactive MCP Sessions](interactive-sessions.md)** (v1.5) for real-time investigation and workflow selection.
 

--- a/docs/user-guide/trust-ladder.md
+++ b/docs/user-guide/trust-ladder.md
@@ -4,34 +4,99 @@ Operators rarely hand full control of cluster remediation to an AI on day one. K
 
 ## The Trust Ladder
 
-```mermaid
-graph LR
-    subgraph v14["Available (v1.4+)"]
-        L1["Level 1<br/><b>Observe</b><br/><small>Global dry-run</small>"]
-        L3["Level 3<br/><b>Approve</b><br/><small>RAR gate</small>"]
-        L4["Level 4<br/><b>Automate</b><br/><small>Full autonomous</small>"]
-    end
-    subgraph v15["Available (v1.5+)"]
-        L2["Level 2<br/><b>Selective Trust</b><br/><small>Per-workflow dry-run</small>"]
-        L5["Interactive<br/><b>MCP Sessions</b><br/><small>Operator-in-the-loop</small>"]
-    end
-    L1 --> L2 --> L3 --> L4
-    L2 -.-> L5
-```
+<div style="max-width:100%;overflow-x:auto;margin:1.5rem 0">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 310" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" style="width:100%;height:auto">
+  <rect width="820" height="310" fill="white"/>
+
+  <!-- Title -->
+  <text x="24" y="28" font-size="14" font-weight="700" fill="#0F172A" letter-spacing="0.5">Trust Ladder</text>
+  <text x="24" y="46" font-size="10" fill="#64748B">Build confidence incrementally — from full human oversight to autonomous remediation.</text>
+
+  <!-- Baseline for staircase alignment (cards bottom-align at y=290) -->
+
+  <!-- L1: Observe (shortest — 120px tall) -->
+  <rect x="16" y="170" width="186" height="120" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
+  <rect x="16" y="170" width="186" height="5" rx="3" fill="#0891B2"/>
+  <text x="28" y="194" font-size="13" font-weight="700" fill="#0F172A">Observe</text>
+  <text x="28" y="212" font-size="9" fill="#64748B">Global dry-run mode. Kubernaut</text>
+  <text x="28" y="224" font-size="9" fill="#64748B">investigates and selects workflows</text>
+  <text x="28" y="236" font-size="9" fill="#64748B">but does not execute. Operators</text>
+  <text x="28" y="248" font-size="9" fill="#64748B">review RCA and selections via</text>
+  <text x="28" y="260" font-size="9" fill="#64748B">audit events and notifications.</text>
+  <text x="28" y="280" font-size="8" font-weight="600" fill="#0891B2">v1.4+</text>
+
+  <!-- L2: Approve (160px tall) -->
+  <rect x="214" y="130" width="186" height="160" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
+  <rect x="214" y="130" width="186" height="5" rx="3" fill="#6366F1"/>
+  <text x="226" y="154" font-size="13" font-weight="700" fill="#0F172A">Approve</text>
+  <text x="226" y="172" font-size="9" fill="#64748B">Rego policy gates remediation.</text>
+  <text x="226" y="184" font-size="9" fill="#64748B">Human approves, rejects, or</text>
+  <text x="226" y="196" font-size="9" fill="#64748B">overrides the AI-selected</text>
+  <text x="226" y="208" font-size="9" fill="#64748B">workflow via RAR. Shadow agent</text>
+  <text x="226" y="220" font-size="9" fill="#64748B">alignment provides an additional</text>
+  <text x="226" y="232" font-size="9" fill="#64748B">safety layer independent of</text>
+  <text x="226" y="244" font-size="9" fill="#64748B">the trust level.</text>
+  <text x="226" y="280" font-size="8" font-weight="600" fill="#6366F1">v1.4+</text>
+
+  <!-- L3: Security & Autonomy (200px tall) -->
+  <rect x="412" y="90" width="186" height="200" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
+  <rect x="412" y="90" width="186" height="5" rx="3" fill="#D97706"/>
+  <text x="424" y="114" font-size="13" font-weight="700" fill="#0F172A">Security &amp; Autonomy</text>
+  <text x="424" y="132" font-size="9" fill="#64748B">SAR-based tool authorization</text>
+  <text x="424" y="144" font-size="9" fill="#64748B">with 6 per-persona ClusterRoles.</text>
+  <text x="424" y="156" font-size="9" fill="#64748B">Interactive MCP sessions for</text>
+  <text x="424" y="168" font-size="9" fill="#64748B">operator-in-the-loop investigation</text>
+  <text x="424" y="180" font-size="9" fill="#64748B">and workflow discovery. Session</text>
+  <text x="424" y="192" font-size="9" fill="#64748B">takeover security (SEC-TAKEOVER).</text>
+  <text x="424" y="210" font-size="9" fill="#64748B">A2A protocol for external agent</text>
+  <text x="424" y="222" font-size="9" fill="#64748B">delegation. API Frontend as the</text>
+  <text x="424" y="234" font-size="9" fill="#64748B">unified external protocol layer.</text>
+  <text x="424" y="280" font-size="8" font-weight="600" fill="#D97706">v1.5</text>
+
+  <!-- L4: Full Autonomy (240px tall) -->
+  <rect x="610" y="50" width="194" height="240" rx="8" fill="#F5F5F5" stroke="#E0E0E0"/>
+  <rect x="610" y="50" width="194" height="5" rx="3" fill="#059669"/>
+  <text x="622" y="74" font-size="13" font-weight="700" fill="#0F172A">Full Autonomy</text>
+  <text x="622" y="92" font-size="9" fill="#64748B">Matched workflows execute</text>
+  <text x="622" y="104" font-size="9" fill="#64748B">without human intervention.</text>
+  <text x="622" y="116" font-size="9" fill="#64748B">Effectiveness Monitor verifies</text>
+  <text x="622" y="128" font-size="9" fill="#64748B">fixes and feeds scores back</text>
+  <text x="622" y="140" font-size="9" fill="#64748B">into future investigations.</text>
+  <text x="622" y="158" font-size="9" fill="#64748B">Operators monitor outcomes</text>
+  <text x="622" y="170" font-size="9" fill="#64748B">via notifications, dashboards,</text>
+  <text x="622" y="182" font-size="9" fill="#64748B">and Effectiveness Monitor</text>
+  <text x="622" y="194" font-size="9" fill="#64748B">metrics. Rollback to Approve</text>
+  <text x="622" y="206" font-size="9" fill="#64748B">at any time by updating the</text>
+  <text x="622" y="218" font-size="9" fill="#64748B">Rego policy — no pod restart.</text>
+  <text x="622" y="280" font-size="8" font-weight="600" fill="#059669">v1.4+</text>
+
+  <!-- Arrows connecting the levels -->
+  <line x1="202" y1="240" x2="214" y2="220" stroke="#B0B0B0" stroke-width="1.3" marker-end="url(#tl-arrow)"/>
+  <line x1="400" y1="200" x2="412" y2="180" stroke="#B0B0B0" stroke-width="1.3" marker-end="url(#tl-arrow)"/>
+  <line x1="598" y1="180" x2="610" y2="160" stroke="#B0B0B0" stroke-width="1.3" marker-end="url(#tl-arrow)"/>
+
+  <defs>
+    <marker id="tl-arrow" markerWidth="7" markerHeight="5" refX="6" refY="2.5" orient="auto">
+      <polygon points="0 0, 7 2.5, 0 5" fill="#B0B0B0"/>
+    </marker>
+  </defs>
+</svg>
+</div>
 
 | Level | Name | Human Involvement | Available |
 |---|---|---|---|
-| **1** | **Observe** | Operator sees what Kubernaut *would* do — no execution | **v1.4** (global dry-run) |
-| **2** | **Selective Trust** | Trusted workflows execute; new ones stay in dry-run | **v1.5** (per-workflow dry-run) |
-| **3** | **Approve** | Rego policy gates remediation via RAR — operator approves/rejects | **v1.4** |
-| **4** | **Automate** | Matched workflows execute without human intervention | **v1.4** |
-| | **Interactive** | Operator connects via MCP for real-time investigation and workflow selection | **v1.5** ([Interactive Sessions](interactive-sessions.md)) |
+| **1** | **Observe** | Operator sees what Kubernaut *would* do — no execution (global dry-run) | **v1.4+** |
+| **2** | **Approve** | Rego policy gates remediation via RAR — operator approves/rejects/overrides | **v1.4+** |
+| **3** | **Security & Autonomy** | SAR-based tool authorization, per-persona ClusterRoles, interactive MCP sessions | **v1.5** |
+| **4** | **Full Autonomy** | Matched workflows execute without human intervention | **v1.4+** |
 
-Operators typically start at Level 1 (observe) or Level 3 (approve) and graduate individual workflows or entire namespaces to Level 4 as they gain confidence in Kubernaut's decision-making.
+At every level, operators can connect via **[Interactive MCP Sessions](interactive-sessions.md)** (v1.5) for real-time investigation and workflow selection.
+
+Operators typically start at Level 1 (observe) or Level 2 (approve) and graduate individual workflows or entire namespaces to Level 4 as they gain confidence in Kubernaut's decision-making.
 
 ---
 
-## Level 3: Approve (Available Now) {: #level-3-approve }
+## Level 2: Approve (Available Now) {: #level-3-approve }
 
 At this level, the Rego approval policy determines which remediations require human review. When `require_approval` evaluates to `true`, a **RemediationApprovalRequest (RAR)** is created before execution. The operator reviews Kubernaut's recommendation — the selected workflow, confidence score, root cause analysis, and detected infrastructure labels — and either approves or rejects it.
 
@@ -99,7 +164,7 @@ You're ready to graduate a workflow to Level 4 when:
 
 ---
 
-## Level 4: Automate (Available Now) {: #level-4-automate }
+## Level 4: Full Autonomy (Available Now) {: #level-4-automate }
 
 At this level, matched workflows execute without human intervention. The operator monitors outcomes via notifications and Effectiveness Monitor dashboards.
 
@@ -205,20 +270,33 @@ remediationOrchestrator:
 
 ---
 
-## Level 2: Selective Trust (Planned — v1.5) {: #level-2-selective-trust }
+## Level 3: Security & Autonomy (v1.5) {: #level-3-security-autonomy }
 
-!!! note "Not yet available"
-    Level 2 depends on **per-workflow dry-run overrides** ([kubernaut#116](https://github.com/jordigilh/kubernaut/issues/116)), planned for v1.5. Global dry-run (Level 1) is available in v1.4.
+At this level, organizations layer **SAR-based tool authorization** and **interactive MCP sessions** on top of the existing approval gate, establishing fine-grained control over who can do what and enabling operator-in-the-loop investigation.
 
-At this level, trusted workflows that have been validated in dry-run mode graduate to real execution, while new or untested workflows continue to complete with outcome `DryRun`.
+### What v1.5 adds
 
-**Planned capabilities:**
+- **SAR-based tool authorization** — Kubernetes-native SubjectAccessReview replaces file-based RBAC. Six per-persona ClusterRoles control which tools each group can invoke. See [Security & RBAC: Tool Authorization](../architecture/security-rbac.md#tool-authorization-v15).
+- **Interactive MCP sessions** — Operators connect via MCP for real-time investigation, workflow discovery with LLM-populated parameters, and guided remediation. See [Interactive Sessions](interactive-sessions.md).
+- **Session takeover security** (SEC-TAKEOVER-001) — Identity-aware session management prevents privilege confusion during takeover.
 
-- Per-workflow dry-run overrides (disable dry-run for trusted workflows)
-- New workflows automatically enter dry-run until explicitly graduated
-- Effectiveness Monitor data drives graduation confidence
+### Configuration
 
-**Goal:** Graduate individual workflows as confidence grows, building a library of trusted automations.
+SAR authorization is configured via the API Frontend's `rbac.personas` values. Bind per-persona ClusterRoles to OIDC groups:
+
+```yaml
+apifrontend:
+  config:
+    rbac:
+      sarCacheTTL: 30s
+      personas:
+        sre: [kubernaut_list_remediations, kubernaut_get_remediation, ...]
+        cicd: [kubernaut_list_remediations, kubernaut_get_remediation, kubernaut_watch]
+```
+
+See the [Helm values reference](../user-guide/configuration.md#api-frontend-v15) for the full persona-to-tool mapping.
+
+**Goal:** Establish enterprise-grade security boundaries while enabling operator-AI collaboration.
 
 ---
 
@@ -254,15 +332,16 @@ For teams new to Kubernaut, we recommend the following progression:
 
 ---
 
-## Future: Agentic Enhancements (v1.5+) {: #agentic-enhancements }
+## Agentic Enhancements {: #agentic-enhancements }
 
-The v1.5 release will introduce agentic integration features that enhance every trust level:
+v1.5 introduced agentic integration features that enhance every trust level:
 
-| Feature | Enhancement |
-|---|---|
-| **MCP Interactive Mode** ([#703](https://github.com/jordigilh/kubernaut/issues/703)) | Operators investigate and review remediations through any MCP-compatible chat interface |
-| **Kubernaut Console** ([#713](https://github.com/jordigilh/kubernaut/issues/713)) | Web dashboard with chat UI, live remediation streaming, and workflow management |
-| **A2A Protocol** ([#705](https://github.com/jordigilh/kubernaut/issues/705)) | External AI agents can delegate remediation to Kubernaut |
-| **Natural Language Investigation** ([#714](https://github.com/jordigilh/kubernaut/issues/714)) | Trigger investigations by describing the problem in plain text |
+| Feature | Status | Enhancement |
+|---|---|---|
+| **MCP Interactive Mode** ([#703](https://github.com/jordigilh/kubernaut/issues/703)) | **Shipped (v1.5)** | Operators investigate and review remediations through any MCP-compatible chat interface |
+| **A2A Protocol** | **Shipped (v1.5)** | External AI agents can delegate remediation to Kubernaut via `POST /a2a/invoke` |
+| **SAR Tool Authorization** (PR #1222) | **Shipped (v1.5)** | Kubernetes-native per-persona tool authorization with 6 ClusterRoles |
+| **Kubernaut Console** | **Planned** | Web dashboard with chat UI, live remediation streaming, and workflow management |
+| **Natural Language Investigation** | **Planned** | Trigger investigations by describing the problem in plain text |
 
 These features are **complementary** to the Trust Ladder — they enhance how operators interact at each level (e.g., MCP chat during dry-run review at Level 1, Console dashboards for monitoring at Level 4) without changing the fundamental graduation model.

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -50,7 +50,7 @@ The API Frontend's static `rbac_roles.yaml` ConfigMap has been **replaced by Kub
 
 | ClusterRole | Persona |
 |---|---|
-| `kubernaut-tool-sre` | Full SRE access (all 20 tools) |
+| `kubernaut-tool-sre` | Full SRE access (all 19 tools) |
 | `kubernaut-tool-ai-orchestrator` | Automated agent orchestration |
 | `kubernaut-tool-cicd` | CI/CD pipeline integration |
 | `kubernaut-tool-observability` | Read-only observability |

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -15,7 +15,7 @@ Kubernaut v1.5 introduces the **API Frontend** (AF), the 11th microservice. It a
 - **MCP gateway** — Exposes investigation, workflow discovery, and remediation tools via the Model Context Protocol
 - **A2A support** — Agent-to-Agent protocol with agent card discovery at `/.well-known/agent-card.json`
 - **SSE streaming** — Real-time investigation output streamed token-by-token via Server-Sent Events
-- **Session management** — Kubernetes Lease-based distributed locking with orphaned session reclamation at startup, same-user reconnect, and graceful drain via `SessionDrainer` on pod shutdown
+- **MCP proxy** — Proxies MCP Streamable HTTP and A2A JSON-RPC to the Kubernaut Agent, where session management (Lease-based locking, orphan reclamation, `SessionDrainer`) is implemented
 
 See [API Frontend Architecture](../architecture/apifrontend.md) for the full design, and [Configuration: API Frontend](../user-guide/configuration.md#api-frontend-v15) for Helm values.
 
@@ -23,44 +23,23 @@ See [API Frontend Architecture](../architecture/apifrontend.md) for the full des
 
 Operators and AI agents can now connect to Kubernaut via MCP for **interactive investigation and remediation**. This is the flagship v1.5 feature, replacing the autonomous-only pipeline with an operator-in-the-loop model when desired.
 
-The interactive flow uses five MCP tools on the Kubernaut Agent:
+The Kubernaut Agent registers **3 MCP tools** via the go-sdk MCP server:
 
 | Tool | Purpose |
 |---|---|
-| `kubernaut_investigate` | Start, reconnect to, check status of, or complete an investigation (actions: `start`, `reconnect`, `status`, `complete`) |
-| `discover_workflows` | After RCA, returns matching workflows with LLM-populated parameters |
-| `select_workflow` | Operator selects a workflow from the discovery results |
-| `complete_no_action` | Operator decides no remediation is needed |
-| `stream_investigation` | Subscribe to real-time SSE stream of investigation progress |
+| `kubernaut_investigate` | Start, reconnect to, take over, check status of, send messages, discover workflows, or complete an investigation (8 actions: `start`, `message`, `complete`, `cancel`, `takeover`, `status`, `reconnect`, `discover_workflows`) |
+| `kubernaut_select_workflow` | Operator selects a workflow from the discovery results; triggers enrichment and catalog lookup |
+| `kubernaut_complete_no_action` | Operator decides no remediation is needed — can be called at any point |
 
 See [Interactive Sessions](../user-guide/interactive-sessions.md) for the operator guide.
 
 ### Interactive workflow discovery with LLM-populated parameters
 
-The `discover_workflows` tool returns workflow alternatives with **parameters pre-populated by the LLM** based on the root cause analysis. Operators can review and edit parameters before confirming execution via `select_workflow`.
+The `discover_workflows` action on `kubernaut_investigate` returns workflow alternatives with **parameters pre-populated by the LLM** based on the root cause analysis (PR #1171, PR #1188). Operators review and edit parameters before confirming execution via `kubernaut_select_workflow`.
 
-Parameter safety is enforced through **comprehensive validation with LLM self-correction**: type checking against the workflow's declared parameter schema, regex pattern matching (`maxPatternLength: 1024`), required field enforcement, and automatic retry when the LLM provides invalid values.
+Parameter safety is enforced through **comprehensive validation with LLM self-correction** (PR #1187): type checking against the workflow's declared parameter schema, regex pattern matching, required field enforcement, and automatic retry when the LLM provides invalid values.
 
 See [Workflow Authoring: Parameters](../user-guide/workflows.md#parameters) for the parameter schema reference.
-
-### Breaking: SAR-based tool authorization replaces file-based RBAC
-
-The API Frontend's static `rbac_roles.yaml` ConfigMap has been **replaced by Kubernetes-native SubjectAccessReview (SAR)** authorization at tool invocation time.
-
-**Migration required**: customers who customized `rbac_roles.yaml` must create equivalent `ClusterRoleBinding` resources. The Helm chart ships 6 pre-built `ClusterRoles`:
-
-| ClusterRole | Scope |
-|---|---|
-| `kubernaut-tool-sre` | All tools |
-| `kubernaut-tool-orchestrator` | Orchestration + triage tools |
-| `kubernaut-tool-approver` | Approve + read tools |
-| `kubernaut-tool-viewer` | Read-only tools |
-| `kubernaut-tool-cicd` | List, get, watch |
-| `kubernaut-tool-audit` | Audit, history, effectiveness |
-
-SAR uses verb `use` on resource `tools` in apiGroup `kubernaut.ai`. Authorization is fail-closed: SAR API errors deny the tool call. Results are cached with a configurable TTL (default 30s via `apifrontend.rbac.sarCacheTTL`).
-
-See [Security & RBAC: Tool Authorization](../architecture/security-rbac.md#tool-authorization-v15) for the full model and binding examples.
 
 ### Session takeover security (SEC-TAKEOVER-001)
 
@@ -82,20 +61,14 @@ The [disconnected installation guide](../operations/disconnected-install.md) has
 
 The OLM flow uses `oc-mirror` v2 with an upstream digest-pinned `ImageSetConfiguration` from the operator repository, producing IDMS and CatalogSource resources automatically.
 
-### InvestigationSession CRD enhancements
-
-The `InvestigationSession` sub-resource on `AIAnalysis` now includes `StartedAt` and `CompletedAt` timestamps, enabling operators to measure interactive session duration via `kubectl`.
-
 ### Lease RBAC for session management
 
 The Kubernaut Agent ServiceAccount now requires `list` permission on `coordination.k8s.io/leases` (in addition to the existing create/get/update/delete) for orphaned session reclamation at startup. The Helm chart and Operator both provision this automatically.
 
 ### Platform hardening
 
-- **SessionDrainer** (GAP-16) — Active MCP sessions are drained before KA pod termination during rolling updates
+- **SessionDrainer** (BR-OPS-013) — Active MCP sessions are drained before KA pod termination during rolling updates
 - **Race-safe session transitions** — Mutex-protected session state machine prevents concurrent state corruption
-- **429 body replay** — MCP tool calls that receive rate-limit responses are automatically retried with the original request body
-- **Cross-namespace label overlap fix** — `labelsOverlap` no longer produces false positives across namespaces
 
 ---
 

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -16,7 +16,7 @@ Kubernaut v1.5 introduces the **API Frontend** (AF), the 11th microservice. It a
 - **A2A support** — Agent-to-Agent protocol with agent card discovery at `/.well-known/agent-card.json`
 - **SSE streaming** — Real-time investigation output streamed token-by-token via Server-Sent Events
 - **SAR authorization** — Kubernetes-native SubjectAccessReview tool authorization with 6 per-persona ClusterRoles, fail-closed, and TTL-cached results
-- **MCP bridge** — Dispatches 23 `kubernaut_*` tools to their backends (K8s API, KA REST, KA MCP, DataStorage) with per-tool RBAC, rate limiting, and audit. Not a transparent proxy — each tool has its own handler and routing
+- **MCP bridge** — Dispatches 23 `kubernaut_*` MCP tools to their backends (K8s API, KA REST, KA MCP, DataStorage) with per-tool RBAC, rate limiting, and audit. Not a transparent proxy — each tool has its own handler and routing
 
 See [API Frontend Architecture](../architecture/apifrontend.md) for the full design, and [Configuration: API Frontend](../user-guide/configuration.md#api-frontend-v15) for Helm values.
 
@@ -24,15 +24,20 @@ See [API Frontend Architecture](../architecture/apifrontend.md) for the full des
 
 Operators and AI agents can now connect to Kubernaut via MCP for **interactive investigation and remediation**. This is the flagship v1.5 feature, replacing the autonomous-only pipeline with an operator-in-the-loop model when desired.
 
-The Kubernaut Agent registers **3 MCP tools** via the go-sdk MCP server:
+The API Frontend exposes **23 `kubernaut_*` MCP tools** on its MCP endpoint (`POST /mcp`), including 6 interactive session lifecycle tools dispatched to the Kubernaut Agent:
 
-| Tool | Purpose |
+| Domain | Tools |
 |---|---|
-| `kubernaut_investigate` | Start, reconnect to, take over, check status of, send messages, discover workflows, or complete an investigation (8 actions: `start`, `message`, `complete`, `cancel`, `takeover`, `status`, `reconnect`, `discover_workflows`) |
-| `kubernaut_select_workflow` | Operator selects a workflow from the discovery results; triggers enrichment and catalog lookup |
-| `kubernaut_complete_no_action` | Operator decides no remediation is needed — can be called at any point |
+| **Interactive lifecycle** | `kubernaut_takeover`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect` |
+| **Investigation** | `kubernaut_start_investigation`, `kubernaut_poll_investigation`, `kubernaut_stream_investigation` |
+| **Workflow** | `kubernaut_discover_workflows`, `kubernaut_select_workflow` |
+| **CRD operations** | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_approve`, `kubernaut_cancel_remediation`, `kubernaut_watch`, `kubernaut_list_approval_requests`, `kubernaut_get_approval_request` |
+| **Data & history** | `kubernaut_list_workflows`, `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail` |
+| **Presentation** | `kubernaut_present_decision` |
 
-See [Interactive Sessions](../user-guide/interactive-sessions.md) for the operator guide.
+The Kubernaut Agent also runs a separate MCP server (`/api/v1/mcp`) with 3 tools (`kubernaut_investigate`, `kubernaut_select_workflow`, `kubernaut_complete_no_action`) for direct client connections with Lease-based session management.
+
+See [Interactive Sessions](../user-guide/interactive-sessions.md) for the operator guide and [API Frontend API](../api-reference/apifrontend-api.md) for the full tool reference.
 
 ### Interactive workflow discovery with LLM-populated parameters
 
@@ -48,14 +53,14 @@ The API Frontend's static `rbac_roles.yaml` ConfigMap has been **replaced by Kub
 
 **Migration required**: customers who customized `rbac_roles.yaml` must create equivalent `ClusterRoleBinding` resources. The Helm chart ships 6 per-persona `ClusterRoles`:
 
-| ClusterRole | Persona |
-|---|---|
-| `kubernaut-tool-sre` | Full SRE access (all 26 tools including internal) |
-| `kubernaut-tool-ai-orchestrator` | Automated agent orchestration |
-| `kubernaut-tool-cicd` | CI/CD pipeline integration |
-| `kubernaut-tool-observability` | Read-only observability |
-| `kubernaut-tool-l3-audit` | Compliance and auditing |
-| `kubernaut-tool-remediation-approver` | Human approval workflows |
+| ClusterRole | Persona | MCP Tools |
+|---|---|---|
+| `kubernaut-tool-sre` | Investigation + remediation (no approval) | 20 |
+| `kubernaut-tool-ai-orchestrator` | Automated agent orchestration | 15 |
+| `kubernaut-tool-cicd` | CI/CD pipeline integration | 3 |
+| `kubernaut-tool-observability` | Read-only observability | 5 |
+| `kubernaut-tool-l3-audit` | Compliance and auditing | 6 |
+| `kubernaut-tool-remediation-approver` | Human approval workflows | 4 |
 
 SAR uses verb `use` on resource `tools` in apiGroup `kubernaut.ai`. Authorization is fail-closed: SAR API errors deny the tool call. Results are cached with a configurable TTL (default 30s via `apifrontend.config.rbac.sarCacheTTL`).
 
@@ -79,7 +84,7 @@ The 4 narrow AF triage tools (`af_get_pods`, `af_get_workloads`, `af_list_events
 
 `af_resolve_owner` is removed — KA independently resolves the owner chain during RCA. The new tools use `RESTMapper` for dynamic kind-to-GVR resolution. Secret `.data` fields are redacted before returning to the LLM.
 
-All cluster context tools (`kubectl_*`, `af_check_existing_rr`, `af_create_rr`) are **internal to the AF's LLM agent** — they run inside the AF's agent loop and are not exposed to external MCP clients. The external MCP/A2A surface consists of **23 `kubernaut_*` tools** spanning CRD operations, investigation, interactive session lifecycle, analytics, and presentation.
+All cluster context tools (`kubectl_*`, `af_check_existing_rr`, `af_create_rr`) are **internal to the AF's LLM agent** — they run inside the AF's agent loop and are not exposed to external MCP clients. The external MCP/A2A surface consists of **23 `kubernaut_*` MCP tools** spanning CRD operations, investigation, interactive session lifecycle, analytics, and presentation.
 
 ### Session takeover security (SEC-TAKEOVER-001)
 

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -16,7 +16,7 @@ Kubernaut v1.5 introduces the **API Frontend** (AF), the 11th microservice. It a
 - **A2A support** — Agent-to-Agent protocol with agent card discovery at `/.well-known/agent-card.json`
 - **SSE streaming** — Real-time investigation output streamed token-by-token via Server-Sent Events
 - **SAR authorization** — Kubernetes-native SubjectAccessReview tool authorization with 6 per-persona ClusterRoles, fail-closed, and TTL-cached results
-- **MCP proxy** — Proxies MCP Streamable HTTP and A2A JSON-RPC to the Kubernaut Agent, where session management (Lease-based locking, orphan reclamation, `SessionDrainer`) is implemented
+- **MCP bridge** — Dispatches 23 `kubernaut_*` tools to their backends (K8s API, KA REST, KA MCP, DataStorage) with per-tool RBAC, rate limiting, and audit. Not a transparent proxy — each tool has its own handler and routing
 
 See [API Frontend Architecture](../architecture/apifrontend.md) for the full design, and [Configuration: API Frontend](../user-guide/configuration.md#api-frontend-v15) for Helm values.
 
@@ -50,7 +50,7 @@ The API Frontend's static `rbac_roles.yaml` ConfigMap has been **replaced by Kub
 
 | ClusterRole | Persona |
 |---|---|
-| `kubernaut-tool-sre` | Full SRE access (all 18 tools) |
+| `kubernaut-tool-sre` | Full SRE access (all 26 tools including internal) |
 | `kubernaut-tool-ai-orchestrator` | Automated agent orchestration |
 | `kubernaut-tool-cicd` | CI/CD pipeline integration |
 | `kubernaut-tool-observability` | Read-only observability |
@@ -61,17 +61,15 @@ SAR uses verb `use` on resource `tools` in apiGroup `kubernaut.ai`. Authorizatio
 
 See [Security & RBAC: Tool Authorization](../architecture/security-rbac.md#tool-authorization-v15) for the full model and binding examples.
 
-### OIDC-direct mode for triage tools
+### Unified ServiceAccount model (ADR-022)
 
-An opt-in authentication mode (PR #1227) that forwards the user's raw OIDC JWT as a bearer token to the K8s API server, eliminating the need for impersonation privileges. Enable via `apifrontend.config.rbac.useOIDCDirect: true`. Compatible with any deployment where the K8s API server trusts the same OIDC provider as the API Frontend. Impersonation remains the default for non-compatible environments.
+All AF Kubernetes API calls use the **AF pod's own ServiceAccount** — there is no per-user impersonation or token forwarding. Application-level authorization is enforced entirely through SAR-based tool gating; user attribution is preserved in the application audit trail (`tool.executed` events with `UserID`, `actor_ip`).
 
-Additionally, `serviceaccounts` has been removed from the AF ClusterRole's impersonation resources — no AF code path impersonates a service account.
-
-See [Security & RBAC: OIDC-direct mode](../architecture/security-rbac.md#oidc-direct-mode-eliminating-impersonation-v15) for the full model and compatibility matrix.
+See [Security & RBAC: Unified SA model](../architecture/security-rbac.md#unified-sa-model) for accepted risks and mitigations.
 
 ### Generic cluster context tools replace narrow triage tools
 
-The 4 narrow AF triage tools (`af_get_pods`, `af_get_workloads`, `af_list_events`, `af_resolve_owner`) have been replaced with 3 generic tools that can inspect any namespaced Kubernetes resource (#1230):
+The 4 narrow AF triage tools (`af_get_pods`, `af_get_workloads`, `af_list_events`, `af_resolve_owner`) have been replaced with 3 generic **internal** tools that can inspect any namespaced Kubernetes resource (#1230):
 
 | New Tool | Replaces | Purpose |
 |---|---|---|
@@ -80,6 +78,8 @@ The 4 narrow AF triage tools (`af_get_pods`, `af_get_workloads`, `af_list_events
 | `kubectl_list_events` | `af_list_events` | List events with reason/object filters (renamed for consistency) |
 
 `af_resolve_owner` is removed — KA independently resolves the owner chain during RCA. The new tools use `RESTMapper` for dynamic kind-to-GVR resolution. Secret `.data` fields are redacted before returning to the LLM.
+
+All cluster context tools (`kubectl_*`, `af_check_existing_rr`, `af_create_rr`) are **internal to the AF's LLM agent** — they run inside the AF's agent loop and are not exposed to external MCP clients. The external MCP/A2A surface consists of **23 `kubernaut_*` tools** spanning CRD operations, investigation, interactive session lifecycle, analytics, and presentation.
 
 ### Session takeover security (SEC-TAKEOVER-001)
 

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -50,7 +50,7 @@ The API Frontend's static `rbac_roles.yaml` ConfigMap has been **replaced by Kub
 
 | ClusterRole | Persona |
 |---|---|
-| `kubernaut-tool-sre` | Full SRE access (all 19 tools) |
+| `kubernaut-tool-sre` | Full SRE access (all 18 tools) |
 | `kubernaut-tool-ai-orchestrator` | Automated agent orchestration |
 | `kubernaut-tool-cicd` | CI/CD pipeline integration |
 | `kubernaut-tool-observability` | Read-only observability |
@@ -68,6 +68,18 @@ An opt-in authentication mode (PR #1227) that forwards the user's raw OIDC JWT a
 Additionally, `serviceaccounts` has been removed from the AF ClusterRole's impersonation resources — no AF code path impersonates a service account.
 
 See [Security & RBAC: OIDC-direct mode](../architecture/security-rbac.md#oidc-direct-mode-eliminating-impersonation-v15) for the full model and compatibility matrix.
+
+### Generic cluster context tools replace narrow triage tools
+
+The 4 narrow AF triage tools (`af_get_pods`, `af_get_workloads`, `af_list_events`, `af_resolve_owner`) have been replaced with 3 generic tools that can inspect any namespaced Kubernetes resource (#1230):
+
+| New Tool | Replaces | Purpose |
+|---|---|---|
+| `kubectl_get` | `af_get_pods`, `af_get_workloads` (single) | Get any namespaced resource by kind/name/namespace |
+| `kubectl_list` | `af_get_pods`, `af_get_workloads` (list) | List any namespaced resources with optional label selector |
+| `kubectl_list_events` | `af_list_events` | List events with reason/object filters (renamed for consistency) |
+
+`af_resolve_owner` is removed — KA independently resolves the owner chain during RCA. The new tools use `RESTMapper` for dynamic kind-to-GVR resolution. Secret `.data` fields are redacted before returning to the LLM.
 
 ### Session takeover security (SEC-TAKEOVER-001)
 

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -61,6 +61,14 @@ SAR uses verb `use` on resource `tools` in apiGroup `kubernaut.ai`. Authorizatio
 
 See [Security & RBAC: Tool Authorization](../architecture/security-rbac.md#tool-authorization-v15) for the full model and binding examples.
 
+### OIDC-direct mode for triage tools
+
+An opt-in authentication mode (PR #1227) that forwards the user's raw OIDC JWT as a bearer token to the K8s API server, eliminating the need for impersonation privileges. Enable via `apifrontend.config.rbac.useOIDCDirect: true`. Compatible with any deployment where the K8s API server trusts the same OIDC provider as the API Frontend. Impersonation remains the default for non-compatible environments.
+
+Additionally, `serviceaccounts` has been removed from the AF ClusterRole's impersonation resources — no AF code path impersonates a service account.
+
+See [Security & RBAC: OIDC-direct mode](../architecture/security-rbac.md#oidc-direct-mode-eliminating-impersonation-v15) for the full model and compatibility matrix.
+
 ### Session takeover security (SEC-TAKEOVER-001)
 
 When a second user connects to an active MCP session, the original user's investigation is **abandoned, not completed**. This prevents a takeover from inheriting or completing work under a different identity. The abandoned session is logged as an audit event.

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -6,6 +6,99 @@ Review the changes below to understand what differs from the version you are cur
 
 ---
 
+## v1.5
+
+### API Frontend — new service
+
+Kubernaut v1.5 introduces the **API Frontend** (AF), the 11th microservice. It acts as the unified external protocol layer for MCP, A2A, and REST clients — replacing direct access to internal services with a single authenticated entry point.
+
+- **MCP gateway** — Exposes investigation, workflow discovery, and remediation tools via the Model Context Protocol
+- **A2A support** — Agent-to-Agent protocol with agent card discovery at `/.well-known/agent-card.json`
+- **SSE streaming** — Real-time investigation output streamed token-by-token via Server-Sent Events
+- **Session management** — Kubernetes Lease-based distributed locking with orphaned session reclamation at startup, same-user reconnect, and graceful drain via `SessionDrainer` on pod shutdown
+
+See [API Frontend Architecture](../architecture/apifrontend.md) for the full design, and [Configuration: API Frontend](../user-guide/configuration.md#api-frontend-v15) for Helm values.
+
+### Interactive MCP sessions
+
+Operators and AI agents can now connect to Kubernaut via MCP for **interactive investigation and remediation**. This is the flagship v1.5 feature, replacing the autonomous-only pipeline with an operator-in-the-loop model when desired.
+
+The interactive flow uses five MCP tools on the Kubernaut Agent:
+
+| Tool | Purpose |
+|---|---|
+| `kubernaut_investigate` | Start, reconnect to, check status of, or complete an investigation (actions: `start`, `reconnect`, `status`, `complete`) |
+| `discover_workflows` | After RCA, returns matching workflows with LLM-populated parameters |
+| `select_workflow` | Operator selects a workflow from the discovery results |
+| `complete_no_action` | Operator decides no remediation is needed |
+| `stream_investigation` | Subscribe to real-time SSE stream of investigation progress |
+
+See [Interactive Sessions](../user-guide/interactive-sessions.md) for the operator guide.
+
+### Interactive workflow discovery with LLM-populated parameters
+
+The `discover_workflows` tool returns workflow alternatives with **parameters pre-populated by the LLM** based on the root cause analysis. Operators can review and edit parameters before confirming execution via `select_workflow`.
+
+Parameter safety is enforced through **comprehensive validation with LLM self-correction**: type checking against the workflow's declared parameter schema, regex pattern matching (`maxPatternLength: 1024`), required field enforcement, and automatic retry when the LLM provides invalid values.
+
+See [Workflow Authoring: Parameters](../user-guide/workflows.md#parameters) for the parameter schema reference.
+
+### Breaking: SAR-based tool authorization replaces file-based RBAC
+
+The API Frontend's static `rbac_roles.yaml` ConfigMap has been **replaced by Kubernetes-native SubjectAccessReview (SAR)** authorization at tool invocation time.
+
+**Migration required**: customers who customized `rbac_roles.yaml` must create equivalent `ClusterRoleBinding` resources. The Helm chart ships 6 pre-built `ClusterRoles`:
+
+| ClusterRole | Scope |
+|---|---|
+| `kubernaut-tool-sre` | All tools |
+| `kubernaut-tool-orchestrator` | Orchestration + triage tools |
+| `kubernaut-tool-approver` | Approve + read tools |
+| `kubernaut-tool-viewer` | Read-only tools |
+| `kubernaut-tool-cicd` | List, get, watch |
+| `kubernaut-tool-audit` | Audit, history, effectiveness |
+
+SAR uses verb `use` on resource `tools` in apiGroup `kubernaut.ai`. Authorization is fail-closed: SAR API errors deny the tool call. Results are cached with a configurable TTL (default 30s via `apifrontend.rbac.sarCacheTTL`).
+
+See [Security & RBAC: Tool Authorization](../architecture/security-rbac.md#tool-authorization-v15) for the full model and binding examples.
+
+### Session takeover security (SEC-TAKEOVER-001)
+
+When a second user connects to an active MCP session, the original user's investigation is **abandoned, not completed**. This prevents a takeover from inheriting or completing work under a different identity. The abandoned session is logged as an audit event.
+
+### DataStorage advanced configuration (v1.5)
+
+Three new configuration sub-blocks for DataStorage:
+
+- **`server`** — `maxBodySize` (5 MiB default), `corsAllowedOrigins` for browser-based access, `signerCertDir` for audit event signing
+- **`redis`** — `dlqMaxLen` (10,000), TLS configuration for Redis/Valkey connections
+- **`retention`** — Automatic data retention cleanup with configurable `interval` (24h), `batchSize` (1,000), and `defaultDays` (2,555 ≈ 7 years)
+
+See [Configuration: DataStorage](../user-guide/configuration.md#datastorage) for all parameters.
+
+### OLM-first disconnected installation
+
+The [disconnected installation guide](../operations/disconnected-install.md) has been rewritten with the **Operator (OLM) path as the primary method**. The Helm chart path is retained as a development/testing appendix.
+
+The OLM flow uses `oc-mirror` v2 with an upstream digest-pinned `ImageSetConfiguration` from the operator repository, producing IDMS and CatalogSource resources automatically.
+
+### InvestigationSession CRD enhancements
+
+The `InvestigationSession` sub-resource on `AIAnalysis` now includes `StartedAt` and `CompletedAt` timestamps, enabling operators to measure interactive session duration via `kubectl`.
+
+### Lease RBAC for session management
+
+The Kubernaut Agent ServiceAccount now requires `list` permission on `coordination.k8s.io/leases` (in addition to the existing create/get/update/delete) for orphaned session reclamation at startup. The Helm chart and Operator both provision this automatically.
+
+### Platform hardening
+
+- **SessionDrainer** (GAP-16) — Active MCP sessions are drained before KA pod termination during rolling updates
+- **Race-safe session transitions** — Mutex-protected session state machine prevents concurrent state corruption
+- **429 body replay** — MCP tool calls that receive rate-limit responses are automatically retried with the original request body
+- **Cross-namespace label overlap fix** — `labelsOverlap` no longer produces false positives across namespaces
+
+---
+
 ## v1.4
 
 ### Prompt injection defense — Shadow Agent

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -15,6 +15,7 @@ Kubernaut v1.5 introduces the **API Frontend** (AF), the 11th microservice. It a
 - **MCP gateway** — Exposes investigation, workflow discovery, and remediation tools via the Model Context Protocol
 - **A2A support** — Agent-to-Agent protocol with agent card discovery at `/.well-known/agent-card.json`
 - **SSE streaming** — Real-time investigation output streamed token-by-token via Server-Sent Events
+- **SAR authorization** — Kubernetes-native SubjectAccessReview tool authorization with 6 per-persona ClusterRoles, fail-closed, and TTL-cached results
 - **MCP proxy** — Proxies MCP Streamable HTTP and A2A JSON-RPC to the Kubernaut Agent, where session management (Lease-based locking, orphan reclamation, `SessionDrainer`) is implemented
 
 See [API Frontend Architecture](../architecture/apifrontend.md) for the full design, and [Configuration: API Frontend](../user-guide/configuration.md#api-frontend-v15) for Helm values.
@@ -40,6 +41,25 @@ The `discover_workflows` action on `kubernaut_investigate` returns workflow alte
 Parameter safety is enforced through **comprehensive validation with LLM self-correction** (PR #1187): type checking against the workflow's declared parameter schema, regex pattern matching, required field enforcement, and automatic retry when the LLM provides invalid values.
 
 See [Workflow Authoring: Parameters](../user-guide/workflows.md#parameters) for the parameter schema reference.
+
+### Breaking: SAR-based tool authorization replaces file-based RBAC
+
+The API Frontend's static `rbac_roles.yaml` ConfigMap has been **replaced by Kubernetes-native SubjectAccessReview (SAR)** authorization at `tools/call` time (PR #1222). `tools/list` remains unfiltered (ADR-020).
+
+**Migration required**: customers who customized `rbac_roles.yaml` must create equivalent `ClusterRoleBinding` resources. The Helm chart ships 6 per-persona `ClusterRoles`:
+
+| ClusterRole | Persona |
+|---|---|
+| `kubernaut-tool-sre` | Full SRE access (all 20 tools) |
+| `kubernaut-tool-ai-orchestrator` | Automated agent orchestration |
+| `kubernaut-tool-cicd` | CI/CD pipeline integration |
+| `kubernaut-tool-observability` | Read-only observability |
+| `kubernaut-tool-l3-audit` | Compliance and auditing |
+| `kubernaut-tool-remediation-approver` | Human approval workflows |
+
+SAR uses verb `use` on resource `tools` in apiGroup `kubernaut.ai`. Authorization is fail-closed: SAR API errors deny the tool call. Results are cached with a configurable TTL (default 30s via `apifrontend.config.rbac.sarCacheTTL`).
+
+See [Security & RBAC: Tool Authorization](../architecture/security-rbac.md#tool-authorization-v15) for the full model and binding examples.
 
 ### Session takeover security (SEC-TAKEOVER-001)
 

--- a/docs/whats-next/index.md
+++ b/docs/whats-next/index.md
@@ -6,7 +6,7 @@ hide:
 
 # What's Next
 
-The features below are planned for future Kubernaut releases. For features that shipped in v1.5 (Interactive Sessions, API Frontend, MCP tool authorization), see [What's New: v1.5](../whats-new/index.md#v15).
+The features below are planned for future Kubernaut releases. For features that shipped in v1.5 (Interactive MCP Sessions, API Frontend, SAR-based tool authorization), see [What's New: v1.5](../whats-new/index.md#v15).
 
 ## Backstage Console
 
@@ -42,7 +42,7 @@ Searchable workflow catalog with natural language filtering, KPI metrics, and a 
 ## Expanded MCP Tool Surface & A2A Protocol
 
 !!! note "v1.5 ships the core MCP tools"
-    The API Frontend and its core investigation/discovery tools (`kubernaut_investigate`, `discover_workflows`, `select_workflow`, `complete_no_action`, `stream_investigation`) shipped in v1.5. See [What's New: v1.5](../whats-new/index.md#v15). The items below are the planned expansion.
+    The API Frontend and its 3 interactive MCP tools (`kubernaut_investigate` with 8 actions, `kubernaut_select_workflow`, `kubernaut_complete_no_action`) shipped in v1.5. See [What's New: v1.5](../whats-new/index.md#v15). The items below are the planned expansion.
 
 The full 20-tool MCP surface will span four domains:
 

--- a/docs/whats-next/index.md
+++ b/docs/whats-next/index.md
@@ -39,19 +39,15 @@ Searchable workflow catalog with natural language filtering, KPI metrics, and a 
 <img src="../assets/images/backstage-workflows.svg" alt="Backstage Console — Workflow Catalog" style="width:100%">
 </div>
 
-## Expanded MCP Tool Surface & A2A Protocol
+## Expanded Tool Surface
 
-!!! note "v1.5 ships the core MCP tools"
-    The API Frontend and its 3 interactive MCP tools (`kubernaut_investigate` with 8 actions, `kubernaut_select_workflow`, `kubernaut_complete_no_action`) shipped in v1.5. See [What's New: v1.5](../whats-new/index.md#v15). The items below are the planned expansion.
+!!! note "v1.5 ships both MCP and A2A tool surfaces"
+    v1.5 ships two complementary tool surfaces. See [What's New: v1.5](../whats-new/index.md#v15).
 
-The full 20-tool MCP surface will span four domains:
+    - **MCP (interactive)** — 3 tools on the Kubernaut Agent (`kubernaut_investigate` with 8 actions, `kubernaut_select_workflow`, `kubernaut_complete_no_action`) for operator-in-the-loop sessions.
+    - **A2A (agent-to-agent)** — 19 SAR-gated Google ADK tools on the API Frontend spanning remediation lifecycle, investigation, data/history, and cluster context, plus internal orchestration tools. SAR-gated via per-persona ClusterRoles.
 
-- **Remediation lifecycle** — `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_approve`, `kubernaut_cancel_remediation`, `kubernaut_watch`, `kubernaut_submit_signal`
-- **Investigation** — `kubernaut_start_investigation`, `kubernaut_poll_investigation`, `kubernaut_select_workflow`, `kubernaut_present_decision`
-- **Data & history** — `kubernaut_list_workflows`, `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail`
-- **Cluster context** — `af_list_events`, `af_get_pods`, `af_get_workloads`, `af_resolve_owner`, `af_check_existing_rr`, `af_create_rr`
-
-A2A (Agent-to-Agent) protocol support is planned with agent card discovery at `/.well-known/agent-card.json`, ADK executor integration, and `InvestigationSession` CRDs linking A2A task IDs to remediation context.
+The items below are planned expansions beyond the v1.5 surface.
 
 ## Declarative Recipes
 

--- a/docs/whats-next/index.md
+++ b/docs/whats-next/index.md
@@ -6,99 +6,7 @@ hide:
 
 # What's Next
 
-Kubernaut v1.5 is the next major milestone, focused on agentic architecture and interactive sessions. The features below are in active development.
-
-## Interactive Sessions
-
-Streaming, conversational MCP interface enabling any consuming agent to interact with Kubernaut in real time:
-
-- **Real-time streaming** — Investigation findings streamed token-by-token via SSE; consuming agents render them natively (chat bubbles, log panels, progress bars).
-- **Choice presentation** — Workflow options returned as structured data (name, description, risk level, parameters) for agents to render in their preferred UX.
-- **Conversational steering** — Multi-turn context maintained across follow-up questions during an investigation.
-- **Join mid-flight** — Attach to an in-progress remediation that was already started autonomously (from an alert) and receive current state plus live updates without restarting the session.
-
-??? example "Joining an in-flight investigation"
-
-    <div class="kn-window">
-    <div class="kn-window-bar">
-    <div class="kn-window-dots"><span></span><span></span><span></span></div>
-    <span class="kn-window-title">Backstage &nbsp;&gt;&nbsp; Kubernaut &nbsp;&gt;&nbsp; rr-b83e19d4a7f1-5c2d09ae</span>
-    </div>
-    <div class="kn-chat">
-    <div class="kn-msg kn-user"><strong>Operator</strong><br>What's going on with <code>checkout-service</code> in <code>prod-us-east</code>? I see alerts firing.</div>
-    <div class="kn-msg kn-agent"><strong>Kubernaut</strong> <span class="kn-badge">live</span><br>
-    There's already an investigation running on <code>checkout-service</code> — it started 2 minutes ago from a <code>PodCrashLoopBackOff</code> alert. Let me catch you up.<br><br>
-    <span class="kn-thinking">Checking events first…</span> I see 14 OOMKilled events in the last 30 minutes, all on <code>checkout-service-7b4d9</code>. The memory limit is set to 512Mi.<br><br>
-    <span class="kn-thinking">Let me look at the metrics…</span> There's a clear spike in <code>container_memory_working_set_bytes</code> — usage jumped to 623Mi right at 03:14 UTC. Something changed at that time.<br><br>
-    <span class="kn-thinking">Pulling the logs around 03:14…</span> Found it: <em>"cache size exceeded soft limit, disabling eviction"</em>. A config reload at 03:14 introduced an unbounded in-memory cache — it's consuming all available memory and triggering the OOM kills.<br><br>
-    So the root cause is the config change, not a traffic spike.
-    </div>
-    <div class="kn-msg kn-user"><strong>Operator</strong><br>Makes sense. What can we do about it?</div>
-    <div class="kn-msg kn-agent"><strong>Kubernaut</strong><br>
-    <span class="kn-thinking">Searching workflow catalog…</span> Found two workflows that match this scenario:
-    <div class="kn-choices">
-    <div class="kn-choice">
-    <strong>restart-and-patch-memory</strong><br>
-    <span class="kn-choice-meta">Confidence: 91% &middot; Risk: low</span><br>
-    Bump memory limit to 768Mi + rolling restart
-    </div>
-    <div class="kn-choice">
-    <strong>rollback-config</strong><br>
-    <span class="kn-choice-meta">Confidence: 85% &middot; Risk: low</span><br>
-    Revert ConfigMap to pre-03:14 version
-    </div>
-    </div>
-    </div>
-    <div class="kn-msg kn-user"><strong>Operator</strong><br>Go with rollback-config — the cache change wasn't approved.</div>
-    <div class="kn-msg kn-agent"><strong>Kubernaut</strong><br>
-    <span class="kn-thinking">Reverting ConfigMap…</span> <code>checkout-config</code> rolled back to revision <code>v42</code> — that's the last known good version before the cache change.<br><br>
-    <span class="kn-thinking">Triggering rolling restart…</span> Pods are cycling now. 1/3 ready… 2/3 ready… <strong>3/3 ready</strong>. All pods are back up with the old config.<br><br>
-    Rollback complete. I'll keep watching for the next 5 minutes to make sure the OOM kills don't come back.
-    </div>
-    <div class="kn-msg kn-agent"><strong>Kubernaut</strong> <span class="kn-badge kn-badge-ok">resolved</span><br>All clear — no OOMKilled events in the last 5 minutes and memory is stable at 340Mi. Looks like the rollback did the trick. Closing this one out.</div>
-    </div>
-    </div>
-
-??? example "Starting from a natural language signal"
-
-    <div class="kn-window">
-    <div class="kn-window-bar">
-    <div class="kn-window-dots"><span></span><span></span><span></span></div>
-    <span class="kn-window-title">Backstage &nbsp;&gt;&nbsp; Kubernaut &nbsp;&gt;&nbsp; rr-d47f62c1e8a3-91b3f07c</span>
-    </div>
-    <div class="kn-chat">
-    <div class="kn-msg kn-user"><strong>Operator</strong><br>The payment processing in <code>prod-eu-west</code> feels sluggish since this morning. Customers are complaining about timeouts at checkout.</div>
-    <div class="kn-msg kn-agent"><strong>Kubernaut</strong> <span class="kn-badge">investigating</span><br>
-    Got it — sounds like a latency issue on <code>payment-gateway</code> in <code>prod-eu-west</code> starting this morning. Let me take a look.<br><br>
-    <span class="kn-thinking">Looking at the metrics…</span> p99 latency jumped from 120ms to 2.4s right at 07:58 UTC. That's a 20x increase — definitely not gradual.<br><br>
-    <span class="kn-thinking">Checking pod health…</span> All 5 replicas are running with no restarts, so it's not a crash loop. The issue is upstream.<br><br>
-    <span class="kn-thinking">Pulling logs…</span> I see repeated <em>"connection pool exhausted, waiting for available connection"</em> — the app can't reach its database fast enough.<br><br>
-    <span class="kn-thinking">Checking the database endpoints…</span> There it is — <code>payment-db</code> only has 1 of 3 endpoints ready. Two replicas went down at 07:55 UTC from a node drain. The remaining replica can't handle the full connection load, so the pool saturates and requests time out.
-    </div>
-    <div class="kn-msg kn-user"><strong>Operator</strong><br>That makes sense, the infra team had a maintenance window. What can we do to fix it?</div>
-    <div class="kn-msg kn-agent"><strong>Kubernaut</strong><br>
-    <span class="kn-thinking">Searching workflow catalog…</span> Two options based on the RCA:
-    <div class="kn-choices">
-    <div class="kn-choice">
-    <strong>scale-statefulset</strong><br>
-    <span class="kn-choice-meta">Confidence: 93% &middot; Risk: low</span><br>
-    Restore <code>payment-db</code> to 3 replicas on available nodes
-    </div>
-    <div class="kn-choice">
-    <strong>rollback-node-drain</strong><br>
-    <span class="kn-choice-meta">Confidence: 72% &middot; Risk: medium</span><br>
-    Uncordon the drained node and reschedule pods
-    </div>
-    </div>
-    </div>
-    <div class="kn-msg kn-user"><strong>Operator</strong><br>Go with scale-statefulset.</div>
-    <div class="kn-msg kn-agent"><strong>Kubernaut</strong><br>
-    <span class="kn-thinking">Scaling StatefulSet…</span> <code>payment-db</code> target set to 3 replicas. Waiting for the new pods to join the cluster.<br><br>
-    <span class="kn-thinking">Watching rollout…</span> 1/3 ready… 2/3 ready… <strong>3/3 ready</strong>. All database replicas are back.<br><br>
-    Connection pool is recovering — active connections dropped from 500/500 to 180/500. Latency should normalize shortly. I'll keep monitoring p99 for the next 10 minutes to confirm.
-    </div>
-    </div>
-    </div>
+The features below are planned for future Kubernaut releases. For features that shipped in v1.5 (Interactive Sessions, API Frontend, MCP tool authorization), see [What's New: v1.5](../whats-new/index.md#v15).
 
 ## Backstage Console
 
@@ -131,16 +39,19 @@ Searchable workflow catalog with natural language filtering, KPI metrics, and a 
 <img src="../assets/images/backstage-workflows.svg" alt="Backstage Console — Workflow Catalog" style="width:100%">
 </div>
 
-## MCP & A2A Integration
+## Expanded MCP Tool Surface & A2A Protocol
 
-The **API Frontend** service acts as the MCP/A2A gateway, exposing 20 MCP tools across four domains:
+!!! note "v1.5 ships the core MCP tools"
+    The API Frontend and its core investigation/discovery tools (`kubernaut_investigate`, `discover_workflows`, `select_workflow`, `complete_no_action`, `stream_investigation`) shipped in v1.5. See [What's New: v1.5](../whats-new/index.md#v15). The items below are the planned expansion.
+
+The full 20-tool MCP surface will span four domains:
 
 - **Remediation lifecycle** — `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_approve`, `kubernaut_cancel_remediation`, `kubernaut_watch`, `kubernaut_submit_signal`
 - **Investigation** — `kubernaut_start_investigation`, `kubernaut_poll_investigation`, `kubernaut_select_workflow`, `kubernaut_present_decision`
 - **Data & history** — `kubernaut_list_workflows`, `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail`
 - **Cluster context** — `af_list_events`, `af_get_pods`, `af_get_workloads`, `af_resolve_owner`, `af_check_existing_rr`, `af_create_rr`
 
-A2A (Agent-to-Agent) protocol support is implemented at the library level with agent card discovery at `/.well-known/agent-card.json`, ADK executor integration, and `InvestigationSession` CRDs linking A2A task IDs to remediation context.
+A2A (Agent-to-Agent) protocol support is planned with agent card discovery at `/.well-known/agent-card.json`, ADK executor integration, and `InvestigationSession` CRDs linking A2A task IDs to remediation context.
 
 ## Declarative Recipes
 
@@ -191,7 +102,7 @@ Hub-and-spoke deployment using [OCM](https://open-cluster-management.io/) (Open 
 
 ## Natural Language Signal Intake
 
-Accept signals described in plain language — not just structured Prometheus alerts or Kubernetes events. Operators, chat bots, and external agents can trigger investigations by describing symptoms conversationally. Kubernaut resolves the intent (cluster, service, symptom) and opens an investigation automatically. See the "Starting from a natural language signal" example under [Interactive Sessions](#interactive-sessions).
+Accept signals described in plain language — not just structured Prometheus alerts or Kubernetes events. Operators, chat bots, and external agents can trigger investigations by describing symptoms conversationally. Kubernaut resolves the intent (cluster, service, symptom) and opens an investigation automatically. Operators, chat bots, and external agents can trigger investigations by describing symptoms conversationally. See [Interactive Sessions](../user-guide/interactive-sessions.md) for examples.
 
 ## Observe Mode (Trust Ladder Level 2)
 

--- a/docs/whats-next/index.md
+++ b/docs/whats-next/index.md
@@ -45,7 +45,7 @@ Searchable workflow catalog with natural language filtering, KPI metrics, and a 
     v1.5 ships two complementary tool surfaces. See [What's New: v1.5](../whats-new/index.md#v15).
 
     - **MCP (interactive)** — 3 tools on the Kubernaut Agent (`kubernaut_investigate` with 8 actions, `kubernaut_select_workflow`, `kubernaut_complete_no_action`) for operator-in-the-loop sessions.
-    - **A2A (agent-to-agent)** — 19 SAR-gated Google ADK tools on the API Frontend spanning remediation lifecycle, investigation, data/history, and cluster context, plus internal orchestration tools. SAR-gated via per-persona ClusterRoles.
+    - **A2A (agent-to-agent)** — 18 SAR-gated Google ADK tools on the API Frontend spanning remediation lifecycle, investigation, data/history, and cluster context, plus internal orchestration tools. SAR-gated via per-persona ClusterRoles.
 
 The items below are planned expansions beyond the v1.5 surface.
 

--- a/docs/whats-next/index.md
+++ b/docs/whats-next/index.md
@@ -45,7 +45,7 @@ Searchable workflow catalog with natural language filtering, KPI metrics, and a 
     v1.5 ships two complementary tool surfaces. See [What's New: v1.5](../whats-new/index.md#v15).
 
     - **MCP (interactive)** — 3 tools on the Kubernaut Agent (`kubernaut_investigate` with 8 actions, `kubernaut_select_workflow`, `kubernaut_complete_no_action`) for operator-in-the-loop sessions.
-    - **A2A (agent-to-agent)** — 18 SAR-gated Google ADK tools on the API Frontend spanning remediation lifecycle, investigation, data/history, and cluster context, plus internal orchestration tools. SAR-gated via per-persona ClusterRoles.
+    - **A2A (agent-to-agent)** — 23 SAR-gated `kubernaut_*` tools on the API Frontend spanning CRD operations, investigation, interactive session lifecycle, data/history, and presentation. 5 additional cluster context and orchestration tools are internal to the AF's LLM agent. SAR-gated via per-persona ClusterRoles.
 
 The items below are planned expansions beyond the v1.5 surface.
 

--- a/docs/whats-next/index.md
+++ b/docs/whats-next/index.md
@@ -42,10 +42,11 @@ Searchable workflow catalog with natural language filtering, KPI metrics, and a 
 ## Expanded Tool Surface
 
 !!! note "v1.5 ships both MCP and A2A tool surfaces"
-    v1.5 ships two complementary tool surfaces. See [What's New: v1.5](../whats-new/index.md#v15).
+    v1.5 ships a unified tool surface on the API Frontend. See [What's New: v1.5](../whats-new/index.md#v15).
 
-    - **MCP (interactive)** — 3 tools on the Kubernaut Agent (`kubernaut_investigate` with 8 actions, `kubernaut_select_workflow`, `kubernaut_complete_no_action`) for operator-in-the-loop sessions.
-    - **A2A (agent-to-agent)** — 23 SAR-gated `kubernaut_*` tools on the API Frontend spanning CRD operations, investigation, interactive session lifecycle, data/history, and presentation. 5 additional cluster context and orchestration tools are internal to the AF's LLM agent. SAR-gated via per-persona ClusterRoles.
+    - **API Frontend MCP** — 23 `kubernaut_*` MCP tools on `POST /mcp` spanning CRD operations, investigation, interactive session lifecycle, data/history, and presentation. SAR-gated via 6 per-persona ClusterRoles.
+    - **KA MCP (direct)** — 3 tools on the Kubernaut Agent (`kubernaut_investigate`, `kubernaut_select_workflow`, `kubernaut_complete_no_action`) with Lease-based session management for direct client connections.
+    - **Internal (ADK-only)** — 5 tools (`kubectl_get`, `kubectl_list`, `kubectl_list_events`, `af_check_existing_rr`, `af_create_rr`) internal to the AF's LLM agent for cluster context and RR creation.
 
 The items below are planned expansions beyond the v1.5 surface.
 
@@ -102,7 +103,7 @@ Accept signals described in plain language — not just structured Prometheus al
 
 ## Observe Mode (Trust Ladder Level 2)
 
-Building on v1.4's global dry-run mode, v1.5 adds operator dashboard visibility through the Backstage console and a guided onboarding path for new clusters.
+Building on v1.4's global dry-run mode, a future release will add operator dashboard visibility through the Backstage console and a guided onboarding path for new clusters.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,9 @@ markdown_extensions:
 extra_css:
   - assets/extra.css
 
+extra_javascript:
+  - assets/extra.js
+
 plugins:
   - search
   - macros
@@ -139,6 +142,7 @@ nav:
       - DataStorage API: api-reference/datastorage-api.md
       - Kubernaut Agent API: api-reference/kubernaut-agent-api.md
       - API Frontend API: api-reference/apifrontend-api.md
+      - MCP Tool Reference: api-reference/mcp-tools.md
   - Use Cases:
       - use-cases/index.md
       - Multi-Path Remediation: use-cases/multi-path-remediation.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
       - Effectiveness Monitoring: user-guide/effectiveness.md
       - Audit & Observability: user-guide/audit-and-observability.md
       - Data Lifecycle: user-guide/data-lifecycle.md
+      - Interactive Sessions: user-guide/interactive-sessions.md
       - Configuration Reference: user-guide/configuration.md
       - ConfigMap References:
           - Kubernaut Agent SDK Config: user-guide/configmap-kubernaut-agent.md
@@ -127,6 +128,7 @@ nav:
       - Async Propagation: architecture/async-propagation.md
       - Audit Pipeline: architecture/audit-pipeline.md
       - Data Persistence: architecture/data-persistence.md
+      - API Frontend: architecture/apifrontend.md
       - Security & RBAC: architecture/security-rbac.md
   - Design Decisions:
       - design-decisions/index.md
@@ -136,6 +138,7 @@ nav:
       - Operator CR: api-reference/operator-cr.md
       - DataStorage API: api-reference/datastorage-api.md
       - Kubernaut Agent API: api-reference/kubernaut-agent-api.md
+      - API Frontend API: api-reference/apifrontend-api.md
   - Use Cases:
       - use-cases/index.md
       - Multi-Path Remediation: use-cases/multi-path-remediation.md


### PR DESCRIPTION
## Summary

Addresses all documentation gaps identified in the [v1.5 GA readiness audit](https://github.com/jordigilh/kubernaut-docs/issues/152) across 5 P0 and 4 P1 findings. This PR adds the documentation required for v1.5 GA so that all teams can review and comment.

### P0 — Blocks GA

- **What's New v1.5 release notes** (#154): Comprehensive release notes covering API Frontend, interactive MCP sessions, SAR-based RBAC, session takeover security, DataStorage config, OLM-first disconnected install, and platform hardening. What's Next updated to cross-reference shipped features.
- **Architecture diagrams** (#140): SVG diagram in `architecture-overview.md` and mermaid in `overview.md` updated with API Frontend. New layered agentic architecture SVG on the AF page derived from the v1.5 slide deck using the Kubernaut color palette.
- **API Frontend architecture page** (#152): New `architecture/apifrontend.md` covering protocol stack, session lifecycle (Lease-based locking, SEC-TAKEOVER-001, SessionDrainer), SSE streaming, integration points, and health checks.
- **Interactive MCP sessions guide** (#153): New `user-guide/interactive-sessions.md` with four-phase interactive flow, all 5 MCP tools with request/response examples, session lifecycle, and autonomous vs interactive comparison.
- **SAR-based RBAC migration** (#155): Tool Authorization section in `security-rbac.md` with SAR model, 6 pre-built ClusterRoles, binding examples, caching config, and `rbac_roles.yaml` migration steps. v1.4→v1.5 migration notes in `installation.md`.

### P1 — Required

- **AF API reference** (#156): New `api-reference/apifrontend-api.md` with MCP tool endpoints, SSE streaming event types, A2A endpoints, session management, audit event catalog, and health/metrics.
- **Architecture updates** (#157): Pipeline modes (autonomous vs interactive) table, KA interactive session endpoints, updated topology diagrams.
- **Security RBAC updates** (#158): Lease RBAC for session management, AF RBAC (TokenReview + SAR), added to `security-rbac.md`.
- **Version refs & trust ladder** (#159): Trust ladder updated for v1.5 (Selective Trust available, Interactive Sessions mode added), operator image version templatized.

### New pages

| Page | Navigation |
|---|---|
| `architecture/apifrontend.md` | Architecture > API Frontend |
| `user-guide/interactive-sessions.md` | User Guide > Interactive Sessions |
| `api-reference/apifrontend-api.md` | API Reference > API Frontend API |

### Modified pages

`whats-new/index.md`, `whats-next/index.md`, `architecture/overview.md`, `architecture/security-rbac.md`, `getting-started/architecture-overview.md`, `getting-started/installation.md`, `api-reference/index.md`, `api-reference/kubernaut-agent-api.md`, `user-guide/trust-ladder.md`, `mkdocs.yml`

## Test plan

- [x] `mkdocs build --strict` passes with no warnings
- [ ] Review all new pages for technical accuracy (AF team, KA team, security team)
- [ ] Verify cross-references between new and existing pages
- [ ] Confirm SAR ClusterRole names match Helm chart / Operator
- [ ] Confirm MCP tool names and endpoints match implementation
- [ ] Verify agentic architecture diagram matches the approved slide


Made with [Cursor](https://cursor.com)