### PR TITLE
docs: align documentation with v1.5.0 GA

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -58,8 +58,9 @@ jobs:
             VERSION="v1.5"
           fi
 
-          if [ "$VERSION" = "v1.4" ]; then
+          if [ "$VERSION" = "v1.5" ]; then
             mike deploy --push --update-aliases "$VERSION" latest
+            mike set-default --push latest
           else
             mike deploy --push "$VERSION"
           fi

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  KUBERNAUT_RELEASE: v1.5.0-rc11
+  KUBERNAUT_RELEASE: v1.5.0
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  KUBERNAUT_RELEASE: v1.5.0-rc10
+  KUBERNAUT_RELEASE: v1.5.0-rc11
 
 jobs:
   deploy:

--- a/docs/api-reference/apifrontend-api.md
+++ b/docs/api-reference/apifrontend-api.md
@@ -104,6 +104,22 @@ The AF's A2A agent also uses **5 internal tools** that are SAR-gated but not exp
 
 All internal tools use the AF ServiceAccount ([unified SA model](../architecture/security-rbac.md#unified-sa-model)) and are SAR-gated on the A2A path via `newRBACGuard()`.
 
+When `severityTriage.enabled: true` and a Prometheus URL is configured, 3 additional alert tools are registered: `list_alerts`, `get_alert_details`, `kubernaut_investigate_alert`. See [MCP Tool Reference — Alert tools](mcp-tools.md#alert-tools-registered-when-severitytriageenabled-true--prometheus-configured).
+
+### A2A Streaming Events {: #a2a-streaming-events }
+
+A2A streaming responses use `TaskStatusUpdateEvent` messages, each tagged with `metadata.type` to classify the event:
+
+| `metadata.type` | Purpose | `status.message` |
+|---|---|---|
+| `reasoning` | LLM inner thoughts / investigation deltas | Set |
+| `status` | Orchestration progress (tool starts, phase transitions) | Set |
+| `output` | Final LLM answer | Set |
+| `investigation` | Investigation-specific events from KA | Set |
+| `keepalive` | Proxy idle-timeout prevention | **Not set** (metadata-only) |
+
+**Keepalive events** — emitted every 5 s during long-running KA tool executions. Metadata: `{"type":"keepalive", "dot":"."}`. No `status.message` is set, so clients that render only `status.message` will not display keepalive noise.
+
 ### Agent Card Discovery
 
 ```

--- a/docs/api-reference/apifrontend-api.md
+++ b/docs/api-reference/apifrontend-api.md
@@ -104,7 +104,7 @@ The AF's A2A agent also uses **5 internal tools** that are SAR-gated but not exp
 
 All internal tools use the AF ServiceAccount ([unified SA model](../architecture/security-rbac.md#unified-sa-model)) and are SAR-gated on the A2A path via `newRBACGuard()`.
 
-When `severityTriage.enabled: true` and a Prometheus URL is configured, 3 additional alert tools are registered: `list_alerts`, `get_alert_details`, `kubernaut_investigate_alert`. See [MCP Tool Reference — Alert tools](mcp-tools.md#alert-tools-registered-when-severitytriageenabled-true--prometheus-configured).
+When `severityTriage.enabled: true` and a Prometheus URL is configured, 3 additional alert tools are registered: `list_alerts`, `get_alert_details`, `kubernaut_investigate_alert`. See [MCP Tool Reference — Alert tools](mcp-tools.md#alert-tools).
 
 ### A2A Streaming Events {: #a2a-streaming-events }
 

--- a/docs/api-reference/crds.md
+++ b/docs/api-reference/crds.md
@@ -218,6 +218,19 @@ _Appears in:_
 | `catalogStatus`| _[CatalogStatus](#catalogstatus)_| CatalogStatus reflects the DS catalog lifecycle state.|
 
 
+### CatalogStatus
+
+_Underlying type:_ _string_
+
+CatalogStatus reflects the Data Storage catalog lifecycle state of an ActionType or RemediationWorkflow.
+
+| Value | Description |
+|---|---|
+| `Pending` | Not yet registered with Data Storage |
+| `Active` | Successfully registered and available for discovery |
+| `Failed` | Registration failed (see conditions for details) |
+
+
 ### AlignmentFindingStatus
 
 

--- a/docs/api-reference/crds.md
+++ b/docs/api-reference/crds.md
@@ -929,7 +929,7 @@ The spec is **immutable** after creation (CEL validation: `self == oldSelf`).
 
 ### InvestigationSessionStatus
 
-Status is mutable by the AF only (RBAC-restricted).
+Status is mutable by the AF and the AIAnalysis controller (RBAC-restricted). The AA controller sets terminal phases (`Completed`, `Failed`) when a KA investigation ends (#1376).
 
 | Field| Type| Description|
 | ---| ---| ---|
@@ -1150,8 +1150,30 @@ _Appears in:_
 
 | Field| Type| Description|
 | ---| ---| ---|
-| `detectedLabels`| _DetectedLabels_| DetectedLabels contains cluster characteristics computed by KA's<br />LabelDetector during get_namespaced_resource_context or get_cluster_resource_context tool invocations.|
-| `setAt`| _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#time-v1-meta)_| SetAt records when the PostRCAContext was populated.<br />Used as the immutability guard: once SetAt is non-nil, the entire<br />PostRCAContext becomes immutable via CEL validation.|
+| `detectedLabels`| _[DetectedLabels](#detectedlabels)_| DetectedLabels contains cluster characteristics computed by KA's LabelDetector during investigation.|
+| `setAt`| _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#time-v1-meta)_| SetAt records when the PostRCAContext was populated. Immutability guard: once non-nil, the entire PostRCAContext is immutable via CEL validation.|
+
+
+### DetectedLabels
+
+Cluster infrastructure characteristics detected by the Kubernaut Agent's `LabelDetector` during investigation. Stored in `AIAnalysis.status.postRCAContext.detectedLabels` and propagated to DataStorage for workflow scoring.
+
+| Field | Type | Description |
+|---|---|---|
+| `failedDetections` | _string array_ | Field names where detection failed (RBAC, timeout, API error). Valid values: any field name below. Labels with failed detections are stripped before scoring. |
+| `gitOpsManaged` | _boolean_ | ArgoCD/Flux annotations or owner references detected |
+| `gitOpsTool` | _string_ | GitOps tool identifier: `argocd`, `flux` |
+| `pdbProtected` | _boolean_ | PodDisruptionBudget exists for the resource |
+| `hpaEnabled` | _boolean_ | HorizontalPodAutoscaler targets the resource |
+| `stateful` | _boolean_ | Resource is StatefulSet or has PersistentVolumeClaims |
+| `helmManaged` | _boolean_ | Helm release labels detected |
+| `networkIsolated` | _boolean_ | NetworkPolicy exists in the namespace |
+| `serviceMesh` | _string_ | Service mesh sidecar: `istio`, `linkerd` |
+| `resourceQuotaConstrained` | _boolean_ | Namespace has an active ResourceQuota (not scored, available for Rego policies) |
+| `virtualMachine` | _boolean_ | VM/VMI/VMIM/DataVolume in owner chain or target kind (#1378) |
+| `liveMigratable` | _boolean_ | VM has `spec.evictionStrategy=LiveMigrate` (only when `virtualMachine` is true) |
+| `cdiManaged` | _boolean_ | PVC has `cdi.kubevirt.io/storage.import.*` annotations |
+| `storageBackend` | _string_ | StorageClass provisioner mapping: `odf-ceph`, `lvms`, `local` |
 
 
 ### Priority
@@ -1615,7 +1637,7 @@ _Appears in:_
 | `actionType`| _string_| ActionType is the action type from the taxonomy (PascalCase).|
 | `labels`| _[RemediationWorkflowLabels](#remediationworkflowlabels)_| Labels contains mandatory matching/filtering criteria for discovery|
 | `customLabels`| _object (keys:string, values:string)_| CustomLabels contains operator-defined key-value labels for additional filtering|
-| `detectedLabels`| _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#json-v1-apiextensions-k8s-io)_| DetectedLabels contains author-declared infrastructure requirements. Expected keys: `gitOpsManaged`, `gitOpsTool`, `pdbProtected`, `hpaEnabled`, `stateful`, `helmManaged`, `networkIsolated`, `serviceMesh`. See [Detected Labels](../user-guide/workflows.md#detected-labels) for valid values and scoring weights.|
+| `detectedLabels`| _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#json-v1-apiextensions-k8s-io)_| DetectedLabels contains author-declared infrastructure requirements. Expected keys: `gitOpsManaged`, `gitOpsTool`, `pdbProtected`, `hpaEnabled`, `stateful`, `helmManaged`, `networkIsolated`, `serviceMesh`, `resourceQuotaConstrained`, `virtualMachine`, `liveMigratable`, `cdiManaged`, `storageBackend`. See [Detected Labels](../user-guide/workflows.md#detected-labels) for valid values and scoring weights.|
 | `execution`| _[RemediationWorkflowExecution](#remediationworkflowexecution)_| Execution contains execution engine configuration|
 | `dependencies`| _[RemediationWorkflowDependencies](#remediationworkflowdependencies)_| Dependencies declares infrastructure resources required by the workflow|
 | `maintainers`| _[RemediationWorkflowMaintainer](#remediationworkflowmaintainer) array_| Maintainers is optional maintainer information|

--- a/docs/api-reference/mcp-tools.md
+++ b/docs/api-reference/mcp-tools.md
@@ -611,6 +611,8 @@ kubernaut_list_remediations()
 
 ## Persona Access Matrix
 
+The personas below are **predefined bootstrap roles** shipped with the Helm chart. Operators are encouraged to create their own ClusterRoles and ClusterRoleBindings tailored to their operational environment — the predefined set is a starting point, not a prescription.
+
 All tool names below are prefixed with `kubernaut_`.
 
 | Tool | SRE | AI Orch. | CI/CD | Obs. | L3 Audit | Approver |

--- a/docs/api-reference/mcp-tools.md
+++ b/docs/api-reference/mcp-tools.md
@@ -6,6 +6,9 @@ Each tool is SAR-gated via [per-persona ClusterRoles](../architecture/security-r
 All tools return JSON in MCP `CallToolResult` text content. Default timeout is 30 s (configurable per tool).
 RBAC is fail-closed — SAR errors deny the call.
 
+!!! info "Conditional tool surface (#1366)"
+    When [`interactive.enabled`](../user-guide/configuration.md) is `false`, **10 session-dependent tools** are hidden from MCP `tools/list` and the A2A agent, leaving **11 stateless tools** (CRD operations + data/history). Hidden tools: `kubernaut_investigate`, `kubernaut_discover_workflows`, `kubernaut_select_workflow`, `kubernaut_present_decision`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect`, `kubernaut_await_session`.
+
 !!! tip "Building skills on Kubernaut tools"
     When authoring MCP skills or prompts that call these tools, use the **"When to use"** guidance below each tool to select the right one.
     Check the [Persona Access Matrix](#persona-access-matrix) to ensure the caller's ClusterRole includes the tool.
@@ -222,11 +225,12 @@ Backend: **K8s API** (AF ServiceAccount) — operates on `kubernaut.ai/v1alpha1/
     Backend: **KA MCP** — dispatches to the Kubernaut Agent's MCP server.
 
     - `rr_id` (`string`) — Existing RR name (starts investigation on that RR)
+    - `api_version` (`string`) — Kubernetes API group/version, e.g. `apps/v1`, `v1` (required when creating a new RR, #1372)
     - `namespace` (`string`) — Target resource namespace (for creating a new RR + IS)
     - `kind` (`string`) — Target resource kind (required with `namespace`/`name`)
     - `name` (`string`) — Target resource name (required with `namespace`/`name`)
 
-    Provide `rr_id` for an existing RR, **or** `namespace`+`kind`+`name` to create a new RR and InvestigationSession for interactive use. Service accounts cannot start interactive investigations (namespace/kind/name path).
+    Provide `rr_id` for an existing RR, **or** `api_version`+`namespace`+`kind`+`name` to create a new RR and InvestigationSession for interactive use. Service accounts cannot start interactive investigations (namespace/kind/name path).
 
     In A2A mode, blocks until the investigation completes and returns the full RCA summary. On the MCP bridge, returns immediately; live events are streamed in the background via SSE. If the RR already has an active investigation driven by another user, a structured `session_active` result is returned instead of an error.
 
@@ -565,7 +569,7 @@ kubernaut_investigate(rr_id)
 ### Interactive investigation flow (new RR)
 
 ```
-kubernaut_investigate(namespace, kind, name)     # creates RR + IS
+kubernaut_investigate(api_version, namespace, kind, name)  # creates RR + IS
   → kubernaut_message(rr_id, message)            # repeat as needed
     → kubernaut_discover_workflows(rr_id)
       → kubernaut_select_workflow(rr_id, workflow_id)
@@ -637,9 +641,11 @@ All tool names below are prefixed with `kubernaut_`.
 
 ## Internal Tools (A2A Agent Only)
 
-The AF agent uses 5 additional tools inside its A2A agent loop.
+The AF agent uses additional tools inside its A2A agent loop.
 These are **not** exposed on the MCP bridge and cannot be called by external MCP clients.
 However, they **are** SAR-gated on the A2A path via `newRBACGuard()` and are included in per-persona ClusterRoles in `values.yaml`.
+
+### Core internal tools (always registered)
 
 | Tool | Purpose |
 |------|---------|
@@ -647,7 +653,17 @@ However, they **are** SAR-gated on the A2A path via `newRBACGuard()` and are inc
 | `kubectl_list` | List namespaced K8s resources with optional label selector (Secret `.data` redacted). GVR resolved via RESTMapper + static table. |
 | `kubectl_list_events` | List K8s events with reason/object filters |
 | `kubernaut_check_existing_remediation` | Check for duplicate RemediationRequest before creation. Params: `namespace`, `kind`, `name`. |
-| `kubernaut_remediate` | Create a new RemediationRequest CRD. Params: `namespace`, `kind`, `name`, `description`, `rr_id`. |
+| `kubernaut_remediate` | Create a new RemediationRequest CRD. Params: `namespace`, `kind`, `name`, `api_version` (required with namespace/kind/name, #1372), `description`, `rr_id`. |
+
+### Alert tools (registered when `severityTriage.enabled: true` + Prometheus configured)
+
+These tools are only available when the AF has a Prometheus connection configured via `severityTriage.prometheusURL`. They enable the A2A agent to query firing alerts and create alert-driven RemediationRequests.
+
+| Tool | Purpose |
+|------|---------|
+| `list_alerts` | Query Prometheus alerts with optional filters. Params: `namespace`, `severity` (critical/high/medium/low/info/warning), `state` (firing/pending). Returns redacted `AlertSummary` array. |
+| `get_alert_details` | Get details of a specific alert. Params: `alert_name` (required), `namespace` (optional). Returns matching `AlertSummary` array. |
+| `kubernaut_investigate_alert` | Alert-first RR creation with scope validation. Params: `alert_name`, `api_version`, `kind`, `name` (all required), `namespace` (optional for cluster-scoped). Validates alert exists in Prometheus and checks namespace/cluster scope via RESTMapper before creating the RR (#1372). |
 
 !!! note "KA kubectl tools have `api_group`"
     The **Kubernaut Agent's** kubectl tools (`kubectl_get`, `kubectl_list` in KA) support an `api_group` parameter for kind disambiguation (#1311). The **AF's** internal `kubectl_get`/`kubectl_list` do not — they resolve GVR via RESTMapper and a static GVK table.

--- a/docs/api-reference/mcp-tools.md
+++ b/docs/api-reference/mcp-tools.md
@@ -629,6 +629,7 @@ All tool names below are prefixed with `kubernaut_`.
 | `cancel` | :material-check: | :material-check: | | | | |
 | `status` | :material-check: | :material-check: | | | | |
 | `reconnect` | :material-check: | :material-check: | | | | |
+| `takeover` | :material-check: | :material-check: | | | | |
 | `discover_workflows` | :material-check: | :material-check: | | | | |
 | `select_workflow` | :material-check: | :material-check: | | | | |
 | `present_decision` | :material-check: | :material-check: | | | | |

--- a/docs/api-reference/mcp-tools.md
+++ b/docs/api-reference/mcp-tools.md
@@ -655,7 +655,7 @@ However, they **are** SAR-gated on the A2A path via `newRBACGuard()` and are inc
 | `kubernaut_check_existing_remediation` | Check for duplicate RemediationRequest before creation. Params: `namespace`, `kind`, `name`. |
 | `kubernaut_remediate` | Create a new RemediationRequest CRD. Params: `namespace`, `kind`, `name`, `api_version` (required with namespace/kind/name, #1372), `description`, `rr_id`. |
 
-### Alert tools (registered when `severityTriage.enabled: true` + Prometheus configured)
+### Alert tools (registered when `severityTriage.enabled: true` + Prometheus configured) {: #alert-tools }
 
 These tools are only available when the AF has a Prometheus connection configured via `severityTriage.prometheusURL`. They enable the A2A agent to query firing alerts and create alert-driven RemediationRequests.
 

--- a/docs/architecture/apifrontend.md
+++ b/docs/architecture/apifrontend.md
@@ -149,6 +149,17 @@ When User B connects to a session owned by User A:
 3. An audit event is emitted recording the takeover
 4. User B starts a fresh investigation in the same session context
 
+### Jump-In session upgrade (#1390) {: #jump-in }
+
+When an operator calls `kubernaut_investigate` for an RR that already has a running **autonomous** investigation, the KA upgrades the session to interactive **in-place** rather than cancelling and recreating it. This preserves the LLM context accumulated during the autonomous RCA phase.
+
+1. KA sets an `interactiveUpgrade` atomic flag on the session
+2. The running investigation goroutine sees the flag at its next `InteractiveHold` check and pauses for operator input
+3. The AA controller detects the IS CRD and sets `Interactive=true` + `SetActivePhase` (no cancel)
+4. Session ID and correlation ID are preserved throughout
+
+If the autonomous session has already completed (`ErrSessionTerminal`), the system falls back to `ForceTransitionToUserDriving` to start a fresh interactive session.
+
 ### Disconnect handling (DD-INTERACTIVE-002)
 
 The `SessionClosedHandler` monitors MCP connection closures via the `DelegatingEventStore`. On disconnect, it triggers session release and reconstruction.
@@ -195,6 +206,15 @@ Supported providers: `vertex_ai` (Claude on Vertex AI — requires `vertexProjec
 **InstructionProvider** (#1276) — The A2A agent's system prompt is dynamically generated per-request by the `InstructionProvider`. This replaces the static `Instruction` string and injects the controller namespace, available tool names, and persona context into the LLM prompt at runtime.
 
 **KA bearer token** — The `kaBearerTokenFile` config field provides the AF with a bearer token for authenticating to the KA MCP server (#1287). When set, the AF includes this token in the `Authorization` header of all KA MCP requests.
+
+**Rate limiters** (#1392) — Two rate limiters protect the AF:
+
+- **ProviderLimiter** — Rate-limits JWKS endpoint fetches. When the limit is hit, cached keys are returned instead of fetching new ones.
+- **LLMSemaphore** — Bounds concurrent LLM requests. Requests exceeding capacity are rejected with `ErrLLMCapacity` (HTTP 429).
+
+**Re-invocation loop** (#1392) — The `StreamingExecutor` re-invokes the LLM agent when a turn ends with text-only output (no tool calls), up to `MaxReinvocations`. This handles cases where the LLM produces reasoning text before deciding on a tool call.
+
+**JWT ClaimMappings** (#1392) — CEL expressions for extracting username and groups from JWT claims (e.g., `claims.email`, `claims.roles`). Falls back to hardcoded paths (`preferred_username`/`sub`/`groups`) when expressions are empty, preserving backward compatibility.
 
 See [AF LLM Configuration](../user-guide/configuration.md#af-llm-configuration-v15) for the full field reference.
 

--- a/docs/architecture/apifrontend.md
+++ b/docs/architecture/apifrontend.md
@@ -11,7 +11,7 @@ The AF sits between external clients and the Kubernaut Engine, handling:
 - **Protocol translation** — MCP tool calls and A2A tasks are translated into internal Kubernaut API calls
 - **Authentication** — OIDC/OAuth2 via JWKS validation with JWT claim extraction
 - **Authorization** — Kubernetes-native SAR-based tool authorization (PR #1222); fail-closed with TTL cache
-- **MCP bridge** — Dispatches 21 `kubernaut_*` MCP tools to their backends (K8s API, KA MCP, DataStorage) with per-tool routing
+- **MCP bridge** — Dispatches 21 `kubernaut_*` MCP tools to their backends (K8s API, KA MCP, DataStorage) with per-tool routing. When `interactive.enabled: false` (#1366), 10 session-dependent tools are hidden, leaving 11 stateless tools for CRD and data operations only.
 - **Streaming** — Relays Server-Sent Events from KA's SSE endpoint to MCP clients
 
 ## Agentic Architecture
@@ -197,6 +197,22 @@ Supported providers: `vertex_ai` (Claude on Vertex AI — requires `vertexProjec
 **KA bearer token** — The `kaBearerTokenFile` config field provides the AF with a bearer token for authenticating to the KA MCP server (#1287). When set, the AF includes this token in the `Authorization` header of all KA MCP requests.
 
 See [AF LLM Configuration](../user-guide/configuration.md#af-llm-configuration-v15) for the full field reference.
+
+## A2A Streaming Events
+
+A2A streaming uses `TaskStatusUpdateEvent` messages classified by `metadata.type`:
+
+| `metadata.type` | Purpose | `status.message` |
+|---|---|---|
+| `reasoning` | LLM inner thoughts / investigation deltas | Set (sanitized text) |
+| `status` | Orchestration progress (tool starts, phase transitions) | Set |
+| `output` | Final LLM answer | Set |
+| `investigation` | Investigation-specific events from KA | Set |
+| `keepalive` | Proxy idle-timeout prevention | **Not set** (metadata-only) |
+
+**Keepalive events** are emitted every **5 seconds** during long-running KA tool executions. They carry `{"type":"keepalive", "dot":"."}` in metadata but no `status.message`, preventing them from polluting the A2A task history. Clients that only render `status.message` will not see keepalive dots (by design).
+
+A2A integrators should inspect `metadata.type` to distinguish ephemeral events from history-worthy messages.
 
 ## Health Checks
 

--- a/docs/architecture/kubernaut-agent-investigation.md
+++ b/docs/architecture/kubernaut-agent-investigation.md
@@ -200,17 +200,23 @@ This fingerprint uniquely identifies the current configuration state. When sent 
 
 Probes the cluster to detect infrastructure characteristics of the root owner:
 
-| Label | Detection Method |
-|---|---|
-| `gitOpsManaged` | ArgoCD/Flux annotations or owner references |
-| `gitOpsTool` | Which GitOps tool (`argocd`, `flux`) |
-| `helmManaged` | Helm release labels |
-| `pdbProtected` | PodDisruptionBudget exists for the resource |
-| `hpaEnabled` | HorizontalPodAutoscaler targets the resource |
-| `stateful` | Resource is StatefulSet or has PersistentVolumeClaims |
-| `networkIsolated` | NetworkPolicy exists in the namespace |
-| `serviceMesh` | Istio/Linkerd sidecar annotations |
-| `resourceQuotaConstrained` | Namespace has an active `ResourceQuota` |
+| Label | Detection Method | Category |
+|---|---|---|
+| `gitOpsManaged` | ArgoCD/Flux annotations or owner references | GitOps |
+| `gitOpsTool` | Which GitOps tool (`argocd`, `flux`) | GitOps |
+| `helmManaged` | Helm release labels | Workload |
+| `pdbProtected` | PodDisruptionBudget exists for the resource | Protection |
+| `hpaEnabled` | HorizontalPodAutoscaler targets the resource | Protection |
+| `stateful` | Resource is StatefulSet or has PersistentVolumeClaims | Workload |
+| `networkIsolated` | NetworkPolicy exists in the namespace | Security |
+| `serviceMesh` | Istio/Linkerd sidecar annotations | Security |
+| `resourceQuotaConstrained` | Namespace has an active `ResourceQuota` | Constraints |
+| `virtualMachine` | VM/VMI/VMIM/DataVolume in owner chain or target kind (#1378) | CNV |
+| `liveMigratable` | VM has `spec.evictionStrategy=LiveMigrate` (only when `virtualMachine` is true) | CNV |
+| `cdiManaged` | PVC has `cdi.kubevirt.io/storage.import.*` annotations | CNV |
+| `storageBackend` | StorageClass provisioner mapping: `odf-ceph`, `lvms`, `local` | CNV |
+
+CNV detection uses a RESTMapper pre-check and skips gracefully on non-CNV/KubeVirt clusters.
 
 When `resourceQuotaConstrained` is detected, the `LabelDetector` also surfaces **`quota_details`** as a structured `map[string]QuotaResourceUsage` in the resource context response, containing per-resource `hard` and `used` values from all `ResourceQuota` objects in the namespace (e.g., `cpu: {hard: "4", used: "2.5"}`). This gives the LLM visibility into capacity constraints during workflow selection — for example, preferring a scale-down workflow over scale-up when the namespace is near its quota.
 

--- a/docs/architecture/workflow-selection.md
+++ b/docs/architecture/workflow-selection.md
@@ -129,15 +129,21 @@ final_score = LEAST((5.0 + detected_label_boost + custom_label_boost - label_pen
 |---|---|---|
 | `gitOpsManaged` | +0.10 | -0.10 |
 | `gitOpsTool` | +0.10 | -0.10 |
+| `virtualMachine` | +0.08 | -- |
 | `pdbProtected` | +0.05 | -- |
 | `serviceMesh` | +0.05 | -- |
+| `storageBackend` | +0.05 | -- |
+| `liveMigratable` | +0.04 | -- |
 | `networkIsolated` | +0.03 | -- |
+| `cdiManaged` | +0.03 | -- |
 | `helmManaged` | +0.02 | -- |
 | `stateful` | +0.02 | -- |
 | `hpaEnabled` | +0.02 | -- |
 
-**Maximum boost**: +0.39 (all labels exact match)
+**Maximum boost**: +0.59 (all labels exact match)
 **Maximum penalty**: -0.20 (GitOps mismatch only)
+
+`resourceQuotaConstrained` is detected and available for Rego policies but does not participate in workflow scoring.
 
 ### Wildcard Weighting
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -216,6 +216,9 @@ The API Frontend service provides the REST API surface for external integrations
 | `apifrontend.config.server.healthPort` | Health check port | `8081` |
 | `apifrontend.config.session.disconnectTTL` | TTL before disconnected sessions are cleaned up | `10m` |
 | `apifrontend.config.session.retentionTTL` | How long completed sessions are retained | `720h` |
+| `apifrontend.config.interactive.enabled` | Enable interactive session MCP tools. When `false`, 10 session-dependent tools are hidden from MCP enumeration and the A2A agent tool list, leaving 11 stateless CRD/data tools (#1366). | `true` |
+| `apifrontend.config.severityTriage.enabled` | Enable severity triage. Required for alert tools (`list_alerts`, `get_alert_details`, `kubernaut_investigate_alert`). | `false` |
+| `apifrontend.config.severityTriage.prometheusURL` | Prometheus API URL for alert queries. Required when `severityTriage.enabled: true`. | `""` |
 | `apifrontend.config.severityTriage.cacheTTLSeconds` | Severity triage cache TTL | `30` |
 | `apifrontend.config.severityTriage.llmConfidence` | LLM confidence threshold for severity triage | `0.7` |
 | `apifrontend.resources.requests.memory` | Memory request | `64Mi` |

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -161,6 +161,17 @@ Image paths are constructed as `{registry}{separator}{namespace}{separator}{serv
 | `kubernautAgent.sdkConfigContent` | SDK config YAML content (via `--set-file`). The chart derives the Kubernetes ConfigMap objects that back the Agent SDK volumes from this file (**v1.4+**: split static + reloadable bundles). | `""` |
 | `kubernautAgent.existingSdkConfigMap` | Pre-existing ConfigMap name for SDK config. Takes priority over `sdkConfigContent`. | `""` |
 
+#### MCP Session Resilience (v1.5+) {: #ka-mcp-resilience }
+
+These settings are part of the KA interactive config (`interactive:` block in the SDK config file):
+
+| Parameter | Description | Default |
+|---|---|---|
+| `interactive.mcpKeepAlive` | Server-side SSE ping interval. Keeps MCP streams alive through proxy/router idle timeouts (e.g., OpenShift HAProxy 30s default). `0` disables. (#1387) | `15s` |
+| `interactive.mcpSessionTimeout` | Auto-close idle MCP sessions that the AF abandoned without a proper disconnect. `0` means never. (#1387) | `10m` |
+
+On the AF side, the `PooledMCPClient` performs a **Ping-on-Acquire** health check (2s bounded) before reusing a cached MCP session. Dead sessions are evicted and transparently replaced via the factory (#1387).
+
 Kubernaut Agent uses two ConfigMaps: a **service config** (ports, logging, auth secret references) and an **SDK config** (LLM settings, toolsets, MCP servers). From **v1.4**, the SDK surface is supplied as **two** mounted ConfigMaps: one **static** (read at startup) and one **hot-reloadable** (watched for AI/tool/integration changes — no pod restart required for supported fields — see **[Kubernaut Agent SDK config](configmap-kubernaut-agent.md#hot-reload)**). Helm values and chart templates reflect that split — follow **`values.schema.json`** and [`configmap-kubernaut-agent.md`](configmap-kubernaut-agent.md) when upgrading.
 
 The SDK config bundle is provided in one of two ways:
@@ -227,6 +238,8 @@ The API Frontend service provides the REST API surface for external integrations
 | `apifrontend.resources.limits.cpu` | CPU limit | `500m` |
 | `apifrontend.config.auth.issuerURL` | OIDC issuer URL for token validation | `""` |
 | `apifrontend.config.auth.audience` | Expected OIDC audience | `""` |
+| `apifrontend.config.auth.jwtProviders[].claimMappings.username` | CEL expression to extract username from JWT claims (e.g., `claims.email`). Falls back to `preferred_username` / `sub` when empty (#1392). | `""` |
+| `apifrontend.config.auth.jwtProviders[].claimMappings.groups` | CEL expression to extract groups from JWT claims (e.g., `claims.roles`). Falls back to `groups` claim when empty (#1392). | `""` |
 | `apifrontend.config.rbac.sarCacheTTL` | SAR result cache TTL | `30s` |
 
 #### AF LLM Configuration (v1.5+)

--- a/docs/user-guide/interactive-sessions.md
+++ b/docs/user-guide/interactive-sessions.md
@@ -37,7 +37,7 @@ The AF decomposes the Kubernaut Agent's single `kubernaut_investigate` tool (whi
 
 | Tool | Description |
 |---|---|
-| `kubernaut_investigate` | Start a new investigation — by existing RR (`rr_id`) or by creating one (`namespace` + `kind` + `name`) |
+| `kubernaut_investigate` | Start a new investigation — by existing RR (`rr_id`) or by creating one (`api_version` + `namespace` + `kind` + `name`) |
 | `kubernaut_await_session` | Wait for an active investigation session to become ready |
 | `kubernaut_message` | Send a follow-up message in a multi-turn conversation |
 | `kubernaut_complete` | Mark the investigation as complete (maps to KA `action=complete`) |
@@ -62,6 +62,7 @@ Start an interactive investigation. Provide either an existing RR name **or** ta
 
 ```json
 {
+  "api_version": "apps/v1",
   "namespace": "production",
   "kind": "Deployment",
   "name": "checkout-service"
@@ -176,3 +177,6 @@ Kubernaut supports both modes simultaneously:
 | **Pipeline** | Full 6-stage pipeline | Same pipeline, operator-driven at selection stage |
 
 Both modes produce the same CRDs, audit events, and effectiveness assessments. An investigation started autonomously (from an alert) can be joined mid-flight by an operator via `kubernaut_await_session` followed by `kubernaut_investigate`.
+
+!!! note "Interactive-Autonomous parity (#1377)"
+    As of v1.5.0-rc11, the interactive and autonomous pipelines share the same KA tool set, enrichment pipeline, and scoring logic. The KA agent uses the same `kubernaut_investigate` tool internally for both modes — the only difference is whether the AF or an alert webhook initiates the investigation, and whether a `leaseHolder` is set on the `InvestigationSession`.

--- a/docs/user-guide/interactive-sessions.md
+++ b/docs/user-guide/interactive-sessions.md
@@ -176,7 +176,7 @@ Kubernaut supports both modes simultaneously:
 | **Visibility** | Post-hoc via kubectl, notifications | Real-time SSE streaming |
 | **Pipeline** | Full 6-stage pipeline | Same pipeline, operator-driven at selection stage |
 
-Both modes produce the same CRDs, audit events, and effectiveness assessments. An investigation started autonomously (from an alert) can be joined mid-flight by an operator via `kubernaut_await_session` followed by `kubernaut_investigate`.
+Both modes produce the same CRDs, audit events, and effectiveness assessments. An investigation started autonomously (from an alert) can be joined mid-flight by an operator via `kubernaut_investigate` — the KA upgrades the running session to interactive **in-place** (Jump-In, #1390), preserving all LLM context from the autonomous RCA phase. See [Jump-In session upgrade](../architecture/apifrontend.md#jump-in) for details.
 
 !!! note "Interactive-Autonomous parity (#1377)"
-    As of v1.5.0-rc11, the interactive and autonomous pipelines share the same KA tool set, enrichment pipeline, and scoring logic. The KA agent uses the same `kubernaut_investigate` tool internally for both modes — the only difference is whether the AF or an alert webhook initiates the investigation, and whether a `leaseHolder` is set on the `InvestigationSession`.
+    As of v1.5.0, the interactive and autonomous pipelines share the same KA tool set, enrichment pipeline, and scoring logic. The KA agent uses the same `kubernaut_investigate` tool internally for both modes — the only difference is whether the AF or an alert webhook initiates the investigation, and whether a `leaseHolder` is set on the `InvestigationSession`.

--- a/docs/user-guide/rego-reference.md
+++ b/docs/user-guide/rego-reference.md
@@ -14,7 +14,7 @@ All policies are deployed as ConfigMaps and support hot-reload. See [Rego Polici
 
 ## Signal Processing Policy
 
-All SP classification rules live in a single `policy.rego` file under `package signalprocessing` ([ADR-060](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/docs/architecture/decisions/ADR-060-unified-signalprocessing-rego-policy.md)). The evaluator sends a common typed input struct and queries four named rules. Each rule group is documented below.
+All SP classification rules live in a single `policy.rego` file under `package signalprocessing` ([ADR-060](https://github.com/jordigilh/kubernaut/blob/v1.5.0/docs/architecture/decisions/ADR-060-unified-signalprocessing-rego-policy.md)). The evaluator sends a common typed input struct and queries four named rules. Each rule group is documented below.
 
 ### Common Input Schema
 
@@ -560,11 +560,11 @@ reason := f.reason if { some f in risk_factors; f.score == max_risk_score }
 
 | Component | Source File |
 |---|---|
-| SP unified evaluator | [`pkg/signalprocessing/evaluator/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/pkg/signalprocessing/evaluator/evaluator.go) |
-| SP policy input types | [`pkg/signalprocessing/evaluator/types.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/pkg/signalprocessing/evaluator/types.go) |
-| SP signal mode classifier | [`pkg/signalprocessing/classifier/signalmode.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/pkg/signalprocessing/classifier/signalmode.go) |
-| SP example policy | [`charts/kubernaut/examples/signalprocessing-policy.rego`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/charts/kubernaut/examples/signalprocessing-policy.rego) |
-| SP deploy policies | [`deploy/signalprocessing/policies/`](https://github.com/jordigilh/kubernaut/tree/v1.5.0-rc11/deploy/signalprocessing/policies) |
-| AA approval evaluator | [`pkg/aianalysis/rego/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/pkg/aianalysis/rego/evaluator.go) |
-| AA input builder | [`pkg/aianalysis/handlers/analyzing.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/pkg/aianalysis/handlers/analyzing.go) |
-| AA approval policy (test) | [`test/unit/aianalysis/testdata/policies/approval.rego`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/test/unit/aianalysis/testdata/policies/approval.rego) |
+| SP unified evaluator | [`pkg/signalprocessing/evaluator/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0/pkg/signalprocessing/evaluator/evaluator.go) |
+| SP policy input types | [`pkg/signalprocessing/evaluator/types.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0/pkg/signalprocessing/evaluator/types.go) |
+| SP signal mode classifier | [`pkg/signalprocessing/classifier/signalmode.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0/pkg/signalprocessing/classifier/signalmode.go) |
+| SP example policy | [`charts/kubernaut/examples/signalprocessing-policy.rego`](https://github.com/jordigilh/kubernaut/blob/v1.5.0/charts/kubernaut/examples/signalprocessing-policy.rego) |
+| SP deploy policies | [`deploy/signalprocessing/policies/`](https://github.com/jordigilh/kubernaut/tree/v1.5.0/deploy/signalprocessing/policies) |
+| AA approval evaluator | [`pkg/aianalysis/rego/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0/pkg/aianalysis/rego/evaluator.go) |
+| AA input builder | [`pkg/aianalysis/handlers/analyzing.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0/pkg/aianalysis/handlers/analyzing.go) |
+| AA approval policy (test) | [`test/unit/aianalysis/testdata/policies/approval.rego`](https://github.com/jordigilh/kubernaut/blob/v1.5.0/test/unit/aianalysis/testdata/policies/approval.rego) |

--- a/docs/user-guide/rego-reference.md
+++ b/docs/user-guide/rego-reference.md
@@ -14,7 +14,7 @@ All policies are deployed as ConfigMaps and support hot-reload. See [Rego Polici
 
 ## Signal Processing Policy
 
-All SP classification rules live in a single `policy.rego` file under `package signalprocessing` ([ADR-060](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc10/docs/architecture/decisions/ADR-060-unified-signalprocessing-rego-policy.md)). The evaluator sends a common typed input struct and queries four named rules. Each rule group is documented below.
+All SP classification rules live in a single `policy.rego` file under `package signalprocessing` ([ADR-060](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/docs/architecture/decisions/ADR-060-unified-signalprocessing-rego-policy.md)). The evaluator sends a common typed input struct and queries four named rules. Each rule group is documented below.
 
 ### Common Input Schema
 
@@ -560,11 +560,11 @@ reason := f.reason if { some f in risk_factors; f.score == max_risk_score }
 
 | Component | Source File |
 |---|---|
-| SP unified evaluator | [`pkg/signalprocessing/evaluator/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc10/pkg/signalprocessing/evaluator/evaluator.go) |
-| SP policy input types | [`pkg/signalprocessing/evaluator/types.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc10/pkg/signalprocessing/evaluator/types.go) |
-| SP signal mode classifier | [`pkg/signalprocessing/classifier/signalmode.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc10/pkg/signalprocessing/classifier/signalmode.go) |
-| SP example policy | [`charts/kubernaut/examples/signalprocessing-policy.rego`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc10/charts/kubernaut/examples/signalprocessing-policy.rego) |
-| SP deploy policies | [`deploy/signalprocessing/policies/`](https://github.com/jordigilh/kubernaut/tree/v1.5.0-rc10/deploy/signalprocessing/policies) |
-| AA approval evaluator | [`pkg/aianalysis/rego/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc10/pkg/aianalysis/rego/evaluator.go) |
-| AA input builder | [`pkg/aianalysis/handlers/analyzing.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc10/pkg/aianalysis/handlers/analyzing.go) |
-| AA approval policy (test) | [`test/unit/aianalysis/testdata/policies/approval.rego`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc10/test/unit/aianalysis/testdata/policies/approval.rego) |
+| SP unified evaluator | [`pkg/signalprocessing/evaluator/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/pkg/signalprocessing/evaluator/evaluator.go) |
+| SP policy input types | [`pkg/signalprocessing/evaluator/types.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/pkg/signalprocessing/evaluator/types.go) |
+| SP signal mode classifier | [`pkg/signalprocessing/classifier/signalmode.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/pkg/signalprocessing/classifier/signalmode.go) |
+| SP example policy | [`charts/kubernaut/examples/signalprocessing-policy.rego`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/charts/kubernaut/examples/signalprocessing-policy.rego) |
+| SP deploy policies | [`deploy/signalprocessing/policies/`](https://github.com/jordigilh/kubernaut/tree/v1.5.0-rc11/deploy/signalprocessing/policies) |
+| AA approval evaluator | [`pkg/aianalysis/rego/evaluator.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/pkg/aianalysis/rego/evaluator.go) |
+| AA input builder | [`pkg/aianalysis/handlers/analyzing.go`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/pkg/aianalysis/handlers/analyzing.go) |
+| AA approval policy (test) | [`test/unit/aianalysis/testdata/policies/approval.rego`](https://github.com/jordigilh/kubernaut/blob/v1.5.0-rc11/test/unit/aianalysis/testdata/policies/approval.rego) |

--- a/docs/user-guide/workflows.md
+++ b/docs/user-guide/workflows.md
@@ -425,18 +425,28 @@ detectedLabels:
   stateful: "true"
   networkIsolated: "true"
   serviceMesh: "istio"       # istio | linkerd | "*"
+  resourceQuotaConstrained: "true"
+  virtualMachine: "true"
+  liveMigratable: "true"
+  cdiManaged: "true"
+  storageBackend: "odf-ceph" # odf-ceph | lvms | local | "*"
 ```
 
-| Label | Type | Valid Values |
-|---|---|---|
-| `gitOpsManaged` | boolean | `"true"` only |
-| `gitOpsTool` | string | `argocd`, `flux`, `"*"` |
-| `pdbProtected` | boolean | `"true"` only |
-| `hpaEnabled` | boolean | `"true"` only |
-| `stateful` | boolean | `"true"` only |
-| `helmManaged` | boolean | `"true"` only |
-| `networkIsolated` | boolean | `"true"` only |
-| `serviceMesh` | string | `istio`, `linkerd`, `"*"` |
+| Label | Type | Valid Values | Category |
+|---|---|---|---|
+| `gitOpsManaged` | boolean | `"true"` only | GitOps management |
+| `gitOpsTool` | string | `argocd`, `flux`, `"*"` | GitOps management |
+| `pdbProtected` | boolean | `"true"` only | Workload protection |
+| `hpaEnabled` | boolean | `"true"` only | Workload protection |
+| `stateful` | boolean | `"true"` only | Workload characteristics |
+| `helmManaged` | boolean | `"true"` only | Workload characteristics |
+| `networkIsolated` | boolean | `"true"` only | Security posture |
+| `serviceMesh` | string | `istio`, `linkerd`, `"*"` | Security posture |
+| `resourceQuotaConstrained` | boolean | `"true"` only | Resource constraints |
+| `virtualMachine` | boolean | `"true"` only | Virtualization (CNV) |
+| `liveMigratable` | boolean | `"true"` only | Virtualization (CNV) |
+| `cdiManaged` | boolean | `"true"` only | Virtualization (CNV) |
+| `storageBackend` | string | `odf-ceph`, `lvms`, `local`, `"*"` | Virtualization (CNV) |
 
 Workflows that declare detected labels earn scoring boosts when the target resource matches -- see [Workflow Search and Scoring](#workflow-search-and-scoring).
 
@@ -798,14 +808,21 @@ The base score is 0.5 (5.0/10.0). Boosts increase it, penalties decrease it. The
 |---|---|---|---|
 | `gitOpsManaged` | +0.10 | -- | -- |
 | `gitOpsTool` | +0.10 | +0.05 | +0.05 |
+| `virtualMachine` | +0.08 | -- | -- |
 | `pdbProtected` | +0.05 | -- | -- |
 | `serviceMesh` | +0.05 | +0.025 | +0.025 |
+| `storageBackend` | +0.05 | +0.025 | +0.025 |
+| `liveMigratable` | +0.04 | -- | -- |
 | `networkIsolated` | +0.03 | -- | -- |
+| `cdiManaged` | +0.03 | -- | -- |
 | `helmManaged` | +0.02 | -- | -- |
 | `stateful` | +0.02 | -- | -- |
 | `hpaEnabled` | +0.02 | -- | -- |
 
-Maximum possible boost: **0.39** (all labels match exactly).
+Maximum possible boost: **0.59** (all labels match exactly).
+
+!!! note "`resourceQuotaConstrained` is not scored"
+    The `resourceQuotaConstrained` label is detected and stored but does not contribute to workflow scoring. It is available for Rego policy evaluation via `input.analysis.detectedLabels`.
 
 **Penalty rules** (high-impact only):
 

--- a/docs/whats-next/index.md
+++ b/docs/whats-next/index.md
@@ -6,51 +6,13 @@ hide:
 
 # What's Next
 
-The features below are planned for future Kubernaut releases. For features that shipped in v1.5 (Interactive MCP Sessions, API Frontend, SAR-based tool authorization), see [What's New: v1.5](../whats-new/index.md#v15).
+The features below are planned for future Kubernaut releases. For features that shipped in v1.5 (Interactive MCP Sessions, API Frontend, SAR-based tool authorization, severity triage pipeline), see [What's New: v1.5](../whats-new/index.md#v15).
 
-## Backstage Console
+## v1.5.x — Custom Agent Injection & ITSM (upcoming)
 
-A Backstage plugin providing an operator dashboard for investigation management, workflow oversight, and approve/reject/override controls through a web UI.
+### Custom Agent Injection
 
-!!! example "Conceptual mockups"
-    The following mockups show the planned Backstage console experience. Designs are subject to change.
-
-### Fleet Overview
-
-Natural language query bar for intent-driven navigation. KPI cards (active investigations, resolved, critical alerts, avg resolution time), cluster health grid, and a filtered alerts table — all driven by the operator's query.
-
-<div style="max-width:100%;overflow-x:auto;margin:1rem 0">
-<img src="../assets/images/backstage-console-fleet.svg" alt="Backstage Console — Fleet Overview" style="width:100%">
-</div>
-
-### Investigation View
-
-Chat-style investigation transcript showing the Kubernaut Agent's live reasoning, tool calls, and root cause analysis. Operators can follow the AI's investigation in real time and intervene when needed.
-
-<div style="max-width:100%;overflow-x:auto;margin:1rem 0">
-<img src="../assets/images/backstage-investigation.svg" alt="Backstage Console — Investigation View" style="width:100%">
-</div>
-
-### Workflow Catalog
-
-Searchable workflow catalog with natural language filtering, KPI metrics, and a table showing workflow status, action types, match count, and effectiveness scores.
-
-<div style="max-width:100%;overflow-x:auto;margin:1rem 0">
-<img src="../assets/images/backstage-workflows.svg" alt="Backstage Console — Workflow Catalog" style="width:100%">
-</div>
-
-## Expanded Tool Surface
-
-!!! note "v1.5 ships both MCP and A2A tool surfaces"
-    v1.5 ships a unified tool surface on the API Frontend. See [What's New: v1.5](../whats-new/index.md#v15).
-
-    - **API Frontend MCP** — 21 `kubernaut_*` MCP tools on `POST /mcp` spanning CRD operations, investigation, interactive session lifecycle, data/history, and presentation. SAR-gated via 6 per-persona ClusterRoles.
-    - **KA MCP (direct)** — 3 tools on the Kubernaut Agent (`kubernaut_investigate`, `kubernaut_select_workflow`, `kubernaut_complete_no_action`) with Lease-based session management for direct client connections.
-    - **Internal (ADK-only)** — 5 tools (`kubectl_get`, `kubectl_list`, `kubectl_list_events`, `kubernaut_check_existing_remediation`, `kubernaut_remediate`) internal to the AF's LLM agent for cluster context and RR creation.
-
-The items below are planned expansions beyond the v1.5 surface.
-
-## Declarative Recipes
+Pluggable investigation and remediation agents via the **AgenticWorkflow CRD**, enabling operators to inject domain-specific automation into the Kubernaut pipeline ([#1242](https://github.com/jordigilh/kubernaut/issues/1242), [#883](https://github.com/jordigilh/kubernaut/issues/883), [#711](https://github.com/jordigilh/kubernaut/issues/711)).
 
 SREs define reusable agentic workflows as declarative [Goose recipes](https://block.github.io/goose/docs/guides/recipes/) — YAML-based configurations that package instructions, MCP extensions, and parameters into shareable, reproducible agent behaviors. Kubernaut injects them at three pipeline points via the Goose runtime, each calling external MCP tools. Each injection point accepts multiple stacked recipes.
 
@@ -58,33 +20,41 @@ SREs define reusable agentic workflows as declarative [Goose recipes](https://bl
 <img src="../assets/images/recipe-injection.svg" alt="Declarative Recipes — 3 pipeline injection points" style="width:100%">
 </div>
 
-### Injection 1: Pre-Investigation (Kubernaut Agent)
+#### Injection 1: Pre-Investigation (Kubernaut Agent)
 
 Context injected into the LLM prompt before analysis begins.
 
 **Example: `check-maintenance-window`** — Calls a CMDB MCP server to check if the resource is in a maintenance window or had recent deployments. The result is injected into the investigation context before the LLM starts. If under maintenance, alerting is skipped and the RCA is annotated as expected downtime.
 
-### Injection 2: Pre-Workflow Selection (Kubernaut Agent)
+#### Injection 2: Pre-Workflow Selection (Kubernaut Agent)
 
 Constraints injected to bias workflow choice.
 
 **Example: `enforce-cost-guardrails`** — Calls a Cost/Resource MCP for budget utilization and scaling limits for the namespace. Returns constraints such as "do not select scale-up workflows", nudging the LLM toward restart/rollback over resource-intensive remediations.
 
-### Injection 3: EM Direct Execution (via Goose)
+#### Injection 3: EM Direct Execution (via Goose)
 
 Recipe runs via Kubernaut Agent endpoint at effectiveness assessment time.
 
 **Example: `verify-business-slo`** — Calls an SLO/Business Metrics MCP to check p95 latency, error rate, and order throughput against SLO budget. Returns a structured pass/fail verdict with business impact data, replacing the default Kubernetes health check with SRE-defined assessment SOPs.
 
-## Fleet Operations
+### ServiceNow Incident Triage
 
-Hub-and-spoke deployment using [OCM](https://open-cluster-management.io/) (Open Cluster Management) — 7 steps from alert to remediation, zero remote footprint.
+Consume ServiceNow incidents as signals through the API Frontend, enabling Kubernaut to investigate and remediate ITSM tickets alongside Kubernetes alerts ([#1338](https://github.com/jordigilh/kubernaut/issues/1338)).
+
+---
+
+## v1.6 — Fleet Management (next)
+
+### Fleet Operations
+
+Hub-and-spoke deployment using [ACM/OCM](https://open-cluster-management.io/) (Open Cluster Management) — policy-driven remediation across fleet-scale Kubernetes environments, 7 steps from alert to remediation, zero remote footprint.
 
 <div style="max-width:100%;overflow-x:auto;margin:1rem 0">
 <img src="../assets/images/fleet-operations.svg" alt="Fleet Operations — Hub-and-spoke remediation flow" style="width:100%">
 </div>
 
-### Remediation flow
+#### Remediation flow
 
 1. Remote Prometheus forwards metrics to Thanos on hub
 2. Alertmanager fires alert → Kubernaut Engine triggers pipeline
@@ -97,15 +67,38 @@ Hub-and-spoke deployment using [OCM](https://open-cluster-management.io/) (Open 
 !!! tip "Zero persistent credentials"
     Remediation uses ephemeral ServiceAccounts with OCM-managed lifecycle — no long-lived secrets stored on remote clusters.
 
-## Natural Language Signal Intake
+### Kubernaut Console
 
-Accept signals described in plain language — not just structured Prometheus alerts or Kubernetes events. Operators, chat bots, and external agents can trigger investigations by describing symptoms conversationally. Kubernaut resolves the intent (cluster, service, symptom) and opens an investigation automatically. Operators, chat bots, and external agents can trigger investigations by describing symptoms conversationally. See [Interactive Sessions](../user-guide/interactive-sessions.md) for examples.
+Web UI for interactive investigation, remediation monitoring, and workflow management.
 
-## Observe Mode (Trust Ladder Stage 2)
+!!! example "Conceptual mockups"
+    The following mockups show the planned Kubernaut Console experience. Designs are subject to change.
 
-Building on v1.4's global dry-run mode, a future release will add operator dashboard visibility through the Backstage console and a guided onboarding path for new clusters.
+#### Fleet Overview
+
+Natural language query bar for intent-driven navigation. KPI cards (active investigations, resolved, critical alerts, avg resolution time), cluster health grid, and a filtered alerts table — all driven by the operator's query.
+
+<div style="max-width:100%;overflow-x:auto;margin:1rem 0">
+<img src="../assets/images/backstage-console-fleet.svg" alt="Kubernaut Console — Fleet Overview" style="width:100%">
+</div>
+
+#### Investigation View
+
+Chat-style investigation transcript showing the Kubernaut Agent's live reasoning, tool calls, and root cause analysis. Operators can follow the AI's investigation in real time and intervene when needed.
+
+<div style="max-width:100%;overflow-x:auto;margin:1rem 0">
+<img src="../assets/images/backstage-investigation.svg" alt="Kubernaut Console — Investigation View" style="width:100%">
+</div>
+
+#### Workflow Catalog
+
+Searchable workflow catalog with natural language filtering, KPI metrics, and a table showing workflow status, action types, match count, and effectiveness scores.
+
+<div style="max-width:100%;overflow-x:auto;margin:1rem 0">
+<img src="../assets/images/backstage-workflows.svg" alt="Kubernaut Console — Workflow Catalog" style="width:100%">
+</div>
 
 ---
 
 !!! info "Subject to change"
-    Features listed here are planned but may change. See the [Kubernaut milestones](https://github.com/jordigilh/kubernaut/milestones) for the latest status.
+    Features listed here are planned but may change. See the [Kubernaut milestones](https://github.com/jordigilh/kubernaut/milestones) for the latest status. For the full roadmap including Collective Intelligence and Operational Expansion (cost, security, non-K8s), see [ROADMAP.md](https://github.com/jordigilh/kubernaut/blob/main/docs/roadmap/ROADMAP.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,7 @@ theme:
 
 extra:
   chart_version: "1.5.0-rc2"
-  image_tag: "v1.5.0-rc11"
+  image_tag: "v1.5.0"
   operator_image_tag: "1.5.0-rc2"
   version:
     provider: mike

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,7 @@ theme:
 
 extra:
   chart_version: "1.5.0-rc2"
-  image_tag: "v1.5.0-rc10"
+  image_tag: "v1.5.0-rc11"
   operator_image_tag: "1.5.0-rc2"
   version:
     provider: mike

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,16 +1,8 @@
 {% extends "base.html" %}
 
 {% block outdated %}
-  {% if "rc" in config.extra.image_tag %}
-    <strong>Release Candidate</strong> — This is pre-release documentation for {{ config.extra.image_tag }}.
-    Content may change before GA.
-    <a href="{{ '../' ~ base_url }}">
-      <strong>View stable documentation.</strong>
-    </a>
-  {% else %}
-    You're not viewing the latest version.
-    <a href="{{ '../' ~ base_url }}">
-      <strong>Click here to go to latest.</strong>
-    </a>
-  {% endif %}
+  You're viewing an older version of the documentation.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to latest.</strong>
+  </a>
 {% endblock %}


### PR DESCRIPTION
## Summary

Aligns the documentation with the v1.5.0 GA release, covering the full delta from rc10 through rc11, rc12, and GA.

### rc10 → rc11 changes

- **CNV/KubeVirt DetectedLabels** — Add `virtualMachine`, `liveMigratable`, `cdiManaged`, `storageBackend` labels to workflows, investigation, scoring, and CRD docs (#1378). Add `DetectedLabels` type reference. Update max scoring boost from 0.39 to 0.59.
- **Alert ADK tools + `api_version`** — Document 3 alert tools (`list_alerts`, `get_alert_details`, `kubernaut_investigate_alert`) in the internal tools section (#1372). Add `api_version` as a required parameter for `kubernaut_investigate` and `kubernaut_remediate`.
- **Conditional tool surface** — Document `interactive.enabled` config flag (#1366) that hides 10 session-dependent MCP tools (21 → 11). Add `severityTriage.enabled` and `prometheusURL` config fields.
- **IS lifecycle ownership** — Fix `InvestigationSession` status ownership: AIAnalysis controller also sets terminal phases (#1376).
- **A2A streaming events** — Document `metadata.type` taxonomy (`reasoning`, `status`, `output`, `investigation`, `keepalive`) and keepalive contract.
- **Persona access matrix** — Add `kubernaut_takeover` row. Clarify personas are predefined bootstraps, not prescriptive.

### rc11 → v1.5.0 GA changes

- **Jump-In session upgrade** (#1390) — Document in-place autonomous-to-interactive upgrade replacing the cancel-and-recreate takeover pattern.
- **MCP session resilience** (#1387) — Add `mcpKeepAlive` (15s default) and `mcpSessionTimeout` (10m default) KA config. Document AF Ping-on-Acquire health checks.
- **AF wiring completeness** (#1392) — Document CEL `claimMappings` for JWT identity extraction, LLM rate limiters (`ProviderLimiter`, `LLMSemaphore`), and the re-invocation loop.

### Cross-cutting

- **Version bump** — All references updated from `v1.5.0-rc10` → `v1.5.0`.
- **Default version** — v1.5 is now the `latest` alias in mike. RC banner removed from the outdated block.
- **What's Next** — Restructured around upstream roadmap: v1.5.x (Custom Agent Injection, ServiceNow ITSM) and v1.6 (Fleet Management, Kubernaut Console). Removed shipped/dropped items.
- **Anchor fixes** — Resolved broken `#alert-tools` and `#catalogstatus` cross-references. Added missing `CatalogStatus` type definition.

## Test plan

- [ ] `mkdocs serve` renders without broken anchor warnings
- [ ] Verify all cross-file links resolve correctly
- [ ] Review Persona Access Matrix against demo cluster ClusterRoles
- [ ] Spot-check DetectedLabels tables are consistent across workflows.md, workflow-selection.md, kubernaut-agent-investigation.md, crds.md
- [ ] Confirm deploy workflow sets v1.5 as latest default