### PR TITLE
docs: align air-gapped install guide and cross-cutting docs with operator v1.5.1

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  KUBERNAUT_RELEASE: v1.5.0
+  KUBERNAUT_RELEASE: v1.5.1
 
 jobs:
   deploy:

--- a/docs/api-reference/operator-cr.md
+++ b/docs/api-reference/operator-cr.md
@@ -201,6 +201,8 @@ The `Kubernaut` custom resource (`kubernaut.ai/v1alpha1`) is the single deployme
 | `shutdown` | [APIFrontendShutdownSpec](#apifrontendshutdownspec) | no | — | Graceful shutdown |
 | `externalURL` | string | no | auto-derived | A2A agent card discovery URL (must be HTTPS when set) |
 | `rbac` | [APIFrontendRBACSpec](#apifrontendrbacspec) | no | — | SAR-based tool authorization and role bindings |
+| `route` | [APIFrontendRouteSpec](#apifrontendroutespec) | no | — | OCP Route creation |
+| `spire` | [APIFrontendSPIRESpec](#apifrontendspirespec) | no | — | SPIRE/kagenti integration for A2A workload identity |
 | `logging` | LoggingSpec | no | — | Log level |
 | `resources` | ResourceRequirements | no | — | CPU/memory requests and limits |
 
@@ -208,8 +210,10 @@ The `Kubernaut` custom resource (`kubernaut.ai/v1alpha1`) is the single deployme
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `issuerURL` | string | — | OIDC issuer URL (e.g., `https://login.kubernaut.ai/realms/kubernaut`) |
-| `audience` | string | `kubernaut-apifrontend` | Expected JWT audience claim |
+| `issuerURL` | string | — | OIDC issuer URL (e.g., `https://login.kubernaut.ai/realms/kubernaut`). Must match the `iss` claim in tokens. |
+| `audience` | string | `kubernaut-apifrontend` | Expected JWT audience claim. Must match the `aud` claim in tokens (typically the Keycloak realm URL). |
+| `jwksURL` | string | — | Cluster-internal JWKS endpoint URL for token validation (e.g., `http://keycloak-service.keycloak:8080/realms/kagenti/protocol/openid-connect/certs`). Bypasses OIDC discovery — use when the issuer URL is external but JWKS must be fetched internally. |
+| `allowInsecureIssuers` | bool | `false` | Allow insecure (HTTP or self-signed TLS) issuer verification. Set `true` for development or self-signed Keycloak deployments. **Must be `false` in production.** |
 | `jwtProviders` | [][JWTProviderSpec](#jwtproviderspec) | — | One or more OIDC JWT providers |
 | `allowInsecureJWKS` | bool | `false` | Permit HTTP JWKS URLs for dev/test. **Must be `false` in production.** |
 
@@ -259,7 +263,22 @@ spec:
 |---|---|---|---|
 | `ipRequestsPerSec` | *int | `50` | Per-IP requests per second |
 | `userRequestsPerSec` | *int | `20` | Per-user requests per second |
+| `toolCallsPerMinute` | *int | `60` | Maximum tool calls per user per minute |
 | `maxConcurrentSessions` | *int | `100` | Maximum concurrent MCP/A2A sessions |
+
+### APIFrontendRouteSpec {: #apifrontendroutespec }
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | *bool | `false` | Create an OCP Route for the API Frontend |
+| `hostname` | string | — | Custom route hostname. When empty, OCP derives the hostname from the route name and cluster ingress domain. |
+
+### APIFrontendSPIRESpec {: #apifrontendspirespec }
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `false` | Enable SPIRE integration via kagenti. When `true`, the operator labels the namespace with `kagenti-enabled=true` and creates an `AgentRuntime` CR. |
+| `className` | string | — | SPIRE class name provisioned by kagenti (e.g., `zero-trust-workload-identity-manager-spire`). Must match the `SPIREClusterConfig` deployed by kagenti. |
 
 ### APIFrontendShutdownSpec {: #apifrontendshutdownspec }
 

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -501,8 +501,60 @@ The AF auto-detects its authentication mode from the configuration:
 
 This removes the need for an explicit `authMode` toggle — the AF infers the correct strategy from which providers are present in the configuration.
 
+## Keycloak OIDC Configuration {: #keycloak-oidc }
+
+When using Keycloak as the OIDC provider (common with kagenti deployments), additional configuration is needed to ensure the API Frontend can authorize tool calls via SAR.
+
+### Groups Client Scope {: #keycloak-groups-scope }
+
+The AF uses Kubernetes SubjectAccessReview (SAR) to authorize tool access based on OIDC group claims in the user's JWT. Keycloak must include group membership in issued tokens.
+
+1. In the Keycloak admin console, navigate to the target realm (e.g., `kagenti`)
+2. Go to **Client scopes** > **Create client scope**: name `groups`, protocol `openid-connect`
+3. Under the new scope, go to **Mappers** > **Create mapper**:
+
+| Setting | Value |
+|---|---|
+| Name | `groups` |
+| Mapper type | `Group Membership` |
+| Token claim name | `groups` |
+| Full group path | `off` |
+| Add to ID token | `on` |
+| Add to access token | `on` |
+| Add to userinfo | `on` |
+
+4. Go to **Clients** > `kagenti` > **Client scopes** > **Add client scope** > add `groups` as a **Default** scope
+
+The group names in the token must match the `groups` array in `spec.apiFrontend.rbac.roleBindings` (Operator CR) or `apifrontend.config.rbac.roleBindings` (Helm values).
+
+### Audience Mapper {: #keycloak-audience-mapper }
+
+For kagenti to successfully authenticate with the API Frontend via SPIFFE identity, add an `oidc-audience-mapper` protocol mapper to the `kagenti` client:
+
+| Setting | Value |
+|---|---|
+| `included.custom.audience` | `spiffe://<trust-domain>/ns/kubernaut-system/sa/apifrontend` |
+| `access.token.claim` | `true` |
+| `id.token.claim` | `false` |
+
+Assign this scope as a default scope to the `kagenti` client. The trust domain must match your SPIRE deployment.
+
+### Stale Token Warning {: #keycloak-stale-tokens }
+
+!!! warning "Users must re-authenticate after scope changes"
+    Users must log out and log back in after being added to a group (or after the `groups` scope is first created) to receive a fresh token with the `groups` claim. Stale tokens issued before the scope was added will have an empty or missing `groups` array. SAR checks will fail with `403 Forbidden` for all tool calls, even if the user's group has a valid `roleBinding`.
+
+    To verify a token contains the expected groups:
+
+    ```bash
+    echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq '.groups'
+    ```
+
+    If `groups` is `null` or empty, the user must re-authenticate.
+
 ## Next Steps
 
 - [Installation](../getting-started/installation.md#signal-source-authentication) -- Configure AlertManager and other signal sources
 - [Configuration Reference](../user-guide/configuration.md) -- Helm values for all services
+- [Disconnected Installation](../operations/disconnected-install.md) -- Air-gapped installation with Keycloak integration
 - [Troubleshooting](../operations/troubleshooting.md) -- Diagnose RBAC-related issues

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -30,10 +30,10 @@ For complete installation instructions, see the [Kubernaut Operator Installation
 | Requirement | Version | Notes |
 |---|---|---|
 | OpenShift | 4.18+ | OLM and operator-framework support required |
-| PostgreSQL | 15+ | **BYO** — the operator does not deploy a database; provide connection details via `spec.postgresql` |
+| PostgreSQL | 15+ | **BYO** — the operator does not deploy a database; provide connection details via `spec.postgresql`. TLS is required (`sslMode`: `require`, `verify-ca`, or `verify-full`). See [PostgreSQL TLS](../operations/disconnected-install.md#postgresql-tls). |
 | Valkey / Redis | 7+ | **BYO** — provide connection details via `spec.valkey` |
-| LLM provider | — | Any [supported provider](../user-guide/configmap-kubernaut-agent.md#supported-providers) with JSON structured output |
-| LLM credentials Secret | — | Secret containing the LLM API key (e.g. `OPENAI_API_KEY`) |
+| LLM provider | — | Any [supported provider](../operations/disconnected-install.md#llm-configuration-reference) with JSON structured output (9 providers for KA, 3 for AF) |
+| LLM credentials Secret | — | Secret containing the LLM API key — see [Credential Secret Format](../operations/disconnected-install.md#llm-configuration-reference) for the expected keys per provider |
 | SP classification policy | — | ConfigMap with key `policy.rego` — see [Rego Policies](../user-guide/policies.md) |
 | AA approval policy | — | ConfigMap with key `approval.rego` — see [Approval Policy](../user-guide/configmap-approval.md) |
 
@@ -71,7 +71,32 @@ spec:
 ```
 
 !!! note "Disconnected installs"
-    For air-gapped environments, mirror all component images and set `RELATED_IMAGE_*` environment variables on the operator Deployment. See the [operator installation guide](https://github.com/jordigilh/kubernaut-operator/tree/main/docs/installation) for the full image list.
+    For air-gapped environments, see the [Disconnected Installation Guide](../operations/disconnected-install.md) for mirroring images via `oc-mirror` and installing via OLM or direct manifest. IDMS transparently redirects image pulls — no `RELATED_IMAGE_*` patching is needed.
+
+#### Tool RBAC Role Bindings
+
+When `spec.apiFrontend.enabled: true` (default), configure `spec.apiFrontend.rbac.roleBindings` to map OIDC groups to per-persona tool roles. Without these bindings, authenticated users cannot invoke MCP tools (SAR denies every call). See [Security & RBAC: Tool Authorization](../architecture/security-rbac.md#tool-authorization-v15) for details.
+
+```yaml
+spec:
+  apiFrontend:
+    rbac:
+      roleBindings:
+        - role: sre
+          groups: ["platform-engineering"]
+        - role: ai-orchestrator
+          groups: ["platform-engineering"]
+        - role: remediation-approver
+          groups: ["change-mgmt"]
+```
+
+#### OCP AlertManager Integration
+
+For alert-driven scenarios on OpenShift, configure AlertManager to route alerts to the Gateway webhook. The Gateway authenticates signal sources via Kubernetes TokenReview + SAR. See the [AlertManager configuration](../operations/disconnected-install.md#alertmanager-ocp) for the full setup.
+
+#### Demo Workflows and Scenarios
+
+To seed the workflow catalog with sample ActionTypes and RemediationWorkflows, clone the [kubernaut-demo-scenarios](https://github.com/jordigilh/kubernaut-demo-scenarios) repository and run the seeding scripts. See [Seed Demo Workflows](../operations/disconnected-install.md#seed-demo-workflows) for step-by-step instructions.
 
 ### What the Operator manages
 

--- a/docs/operations/disconnected-install.md
+++ b/docs/operations/disconnected-install.md
@@ -1,32 +1,33 @@
 # Disconnected (Air-Gapped) Installation
 
-Kubernaut supports two deployment methods for disconnected OpenShift clusters. The **Kubernaut Operator** (OLM) is the production method; the **Helm chart** is available for development and testing only.
+This guide covers deploying Kubernaut in a disconnected OpenShift cluster. The **Kubernaut Operator** is the production method; the **Helm chart** is available for development and testing only.
 
 | Method | Mirroring | Image redirection | Install |
 |---|---|---|---|
-| **Operator (OLM)** | `oc-mirror` reads the operator catalog and discovers all images automatically from `relatedImages` | IDMS/ICSP — transparent CRI-O rewrite, no application-level changes | OperatorHub / `Subscription` CR |
+| **Operator (OLM)** | `oc-mirror` reads the operator catalog and discovers all images automatically from `relatedImages` | IDMS — transparent CRI-O rewrite | OperatorHub / `Subscription` CR |
+| **Operator (Direct Manifest)** | Manual `ImageSetConfiguration` listing every image by `@sha256:` digest | IDMS — transparent CRI-O rewrite | `oc apply -f install.yaml` |
 | **Helm chart** | Manual `ImageSetConfiguration` listing every image | `values-airgap.yaml` overlay overriding image refs | `helm install` with layered overlays |
 
 !!! warning "Production deployments"
-    The Kubernaut Operator is the only supported production deployment method for disconnected environments. The Helm chart path is retained for development and testing only.
+    The Kubernaut Operator (OLM or direct manifest) is the only supported production deployment method for disconnected environments. The Helm chart path is retained for development and testing only.
 
 ## Prerequisites
 
 | Requirement | Details |
 |---|---|
-| **Bastion host** | A machine with access to both the public internet and your mirror registry. Used to run `oc-mirror`. |
-| **Mirror registry** | A container registry accessible from the disconnected cluster (Quay, Harbor, Nexus, or the OCP integrated registry). |
-| **`oc` CLI + `oc-mirror` v2** | OpenShift CLI 4.18+. `oc-mirror` v1 is deprecated as of OCP 4.18; use v2. Install per [OCP documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/disconnected_environments/installing-mirroring-disconnected). |
-| **Cluster admin access** | `cluster-admin` privileges on the target disconnected cluster. |
-| **PostgreSQL 15+** | **BYO** — the operator does not deploy a database. Provide connection details via `spec.postgresql` in the Kubernaut CR. |
-| **Valkey / Redis 7+** | **BYO** — provide connection details via `spec.valkey` in the Kubernaut CR. |
+| **Bastion host** | Access to both the public internet and the mirror registry |
+| **Mirror registry** | Quay, Harbor, Nexus, or OCP internal registry accessible from the disconnected cluster |
+| **`oc` CLI + `oc-mirror` v2** | OpenShift CLI 4.16+. `oc-mirror` v1 is deprecated as of OCP 4.18; use v2. |
+| **Cluster admin access** | `cluster-admin` privileges on the target disconnected cluster |
+| **PostgreSQL 15+** | **BYO** — the operator does not deploy a database. Provide connection details via `spec.postgresql` in the Kubernaut CR. **Must have a PVC for production** (see [Step 3.3](#step-33-provision-persistent-storage)). |
+| **Valkey / Redis 7+** | **BYO** — provide connection details via `spec.valkey`. **Must have a PVC for production** (see [Step 3.3](#step-33-provision-persistent-storage)). |
 
 !!! info "LLM endpoint"
-    The Kubernaut Agent requires an LLM. In a disconnected environment, deploy a locally hosted LLM accessible from inside the cluster — either **Ollama** or any **OpenAI-compatible endpoint** (vLLM, LocalAI, TGI). Configure the endpoint in your SDK config file (see [Kubernaut Agent SDK Config](../user-guide/configmap-kubernaut-agent.md)). LangChainGo subprocess mode (`local`) is explicitly not supported for security reasons.
+    The Kubernaut Agent requires an LLM. In a disconnected environment, deploy a locally hosted LLM accessible from inside the cluster — either **Ollama** or any **OpenAI-compatible endpoint** (vLLM, LocalAI, TGI). See [LLM Configuration Reference](#llm-configuration-reference) for all supported providers.
 
 ---
 
-## Operator (OLM) — Production
+## Operator (OLM) — Production {: #operator-olm }
 
 The operator catalog contains the bundle metadata (CSV, CRDs) and declares every operand image in `relatedImages`. The `oc-mirror` tool reads the catalog, discovers all images, and mirrors them in one pass. On the disconnected cluster, an `ImageDigestMirrorSet` (IDMS) transparently redirects image pulls from the source registries to your mirror at the CRI-O level.
 
@@ -52,11 +53,11 @@ For reference, the full set (17 images) is:
 | | `quay.io/kubernaut-ai/effectivenessmonitor` | Post-remediation effectiveness verification |
 | | `quay.io/kubernaut-ai/kubernautagent` | LLM integration service |
 | | `quay.io/kubernaut-ai/authwebhook` | Admission controller for CRD authorization |
-| | `quay.io/kubernaut-ai/apifrontend` | API Frontend service (new in v1.5) |
+| | `quay.io/kubernaut-ai/apifrontend` | API Frontend service (v1.5+) |
 | | `quay.io/kubernaut-ai/db-migrate` | Database schema migration |
 | **Init images** | | |
 | | `registry.redhat.io/rhel10/postgresql-16` | PostgreSQL client for init containers |
-| | `registry.access.redhat.com/ubi10/ubi-minimal` | Minimal UBI for init containers |
+| | `registry.access.redhat.com/ubi10/ubi-minimal` | Minimal UBI for CA-bundle init containers |
 
 ### Step 1: Get the ImageSetConfiguration
 
@@ -67,8 +68,6 @@ curl -fsSL \
   https://raw.githubusercontent.com/jordigilh/kubernaut-operator/main/hack/airgap/imageset-config.yaml \
   -o imageset-config.yaml
 ```
-
-The manifest references the operator catalog and all operand images by `@sha256:` digest, which is required for IDMS redirection. `oc-mirror` reads the catalog index, finds the bundle for the specified channel, parses the CSV, and discovers every image from `relatedImages` automatically.
 
 !!! tip "Why digests instead of tags?"
     IDMS only redirects **digest-based** image references — not tags. The operator CSV `relatedImages` already pins all operand images by digest. Using the upstream manifest ensures your mirror contains the exact images the operator expects, and IDMS can redirect them transparently.
@@ -116,24 +115,24 @@ This creates:
 - An `ImageDigestMirrorSet` that tells CRI-O to redirect pulls from `quay.io/kubernaut-ai/*` and `registry.redhat.io/*` to your mirror registry
 - A `CatalogSource` pointing at the mirrored operator catalog in your internal registry
 
-!!! note
-    IDMS only redirects **digest-based** image references. All images in the operator CSV use `@sha256:` digests, so this works transparently.
+Verify:
+
+```bash
+oc get imagedigestmirrorset
+```
 
 ### Step 4: Configure the global pull secret
 
 Add your mirror registry credentials so every node can pull from it:
 
 ```bash
-# Export current pull secret
 oc get secret/pull-secret -n openshift-config \
   -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d > pull-secret.json
 
-# Add mirror registry credentials
 oc registry login --registry=<mirror-registry> \
   --auth-basic=<username>:<password> \
   --to=pull-secret.json
 
-# Update the cluster
 oc set data secret/pull-secret -n openshift-config \
   --from-file=.dockerconfigjson=pull-secret.json
 ```
@@ -152,10 +151,8 @@ Navigate to **Operators > OperatorHub**, search for "Kubernaut", and click **Ins
 **Option B: CLI**
 
 ```bash
-# Create the operator namespace
 oc create namespace kubernaut
 
-# Create the OperatorGroup
 cat <<EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -167,7 +164,6 @@ spec:
     - kubernaut
 EOF
 
-# Create the Subscription
 cat <<EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -192,64 +188,7 @@ Wait for the operator to reach `Succeeded`:
 oc get csv -n kubernaut -w
 ```
 
-### Step 6: Provision secrets and create the Kubernaut CR
-
-Pre-create the required secrets for your BYO PostgreSQL, Valkey, and LLM:
-
-```bash
-oc create namespace kubernaut-system
-
-# PostgreSQL connection
-oc create secret generic kubernaut-postgresql \
-  --from-literal=username=slm_user \
-  --from-literal=password=<your-pg-password> \
-  --from-literal=db-secrets.yaml="$(printf 'username: slm_user\npassword: %s' "<your-pg-password>")" \
-  -n kubernaut-system
-
-# Valkey connection
-oc create secret generic kubernaut-valkey \
-  --from-literal=valkey-secrets.yaml="$(printf 'password: %s' "<your-valkey-password>")" \
-  -n kubernaut-system
-
-# LLM credentials (for local LLM, the key may be a placeholder)
-oc create secret generic kubernaut-llm \
-  --from-literal=OPENAI_API_KEY=<your-local-llm-key> \
-  -n kubernaut-system
-```
-
-Create the Kubernaut CR:
-
-```yaml
-apiVersion: kubernaut.ai/v1alpha1
-kind: Kubernaut
-metadata:
-  name: kubernaut
-  namespace: kubernaut-system
-spec:
-  postgresql:
-    host: postgres.database.svc.cluster.local
-    secretName: kubernaut-postgresql
-  valkey:
-    host: valkey.cache.svc.cluster.local
-    secretName: kubernaut-valkey
-  kubernautAgent:
-    llm:
-      provider: openai
-      model: llama3
-      endpoint: http://ollama.internal.svc:11434
-      credentialsSecretName: kubernaut-llm
-  signalProcessing:
-    policy:
-      configMapName: signalprocessing-policy   # must contain key: policy.rego
-  aiAnalysis:
-    policy:
-      configMapName: aianalysis-policies        # must contain key: approval.rego
-```
-
-No image overrides are needed — the operator reads `RELATED_IMAGE_*` env vars set by OLM, and IDMS transparently redirects them to the mirror registry.
-
-!!! note "PostgreSQL TLS"
-    The default `sslMode` is `verify-full` (v1.5+). If your PostgreSQL instance does not use TLS, set `spec.postgresql.sslMode: disable` in the CR.
+Then proceed to [Step 3: Provision Prerequisites](#step-3-provision-prerequisites) below.
 
 ### Per-component image overrides (optional)
 
@@ -270,46 +209,1177 @@ The operator resolves images in this order:
 2. `RELATED_IMAGE_<SUFFIX>` env var — set by OLM, rewritten by IDMS
 3. Error if neither is set
 
-### Step 7: Verify the installation
+---
 
-```bash
-# Operator status
-oc get csv -n kubernaut
+## Operator (Direct Manifest) — Production {: #operator-direct }
 
-# Kubernaut CR status
-oc get kubernaut -n kubernaut-system
+For environments where OLM is not available or not desired, the operator can be installed directly from a manifest file. This method has been **validated on OCP 4.18+ with operator v1.5.1** in fully air-gapped environments.
 
-# All pods should be Running
-oc get pods -n kubernaut-system
+When using `oc mirror`, the generated `ImageDigestMirrorSet` (IDMS) instructs CRI-O to transparently redirect image pulls to your mirror registry. This means you do **not** need to manually rewrite image references in manifests or `RELATED_IMAGE_*` env vars — the original image references work as-is once IDMS is applied.
+
+### Image Inventory (v1.5.1)
+
+#### Operator Image
+
+| Component | Source Image |
+|---|---|
+| kubernaut-operator | `quay.io/kubernaut-ai/kubernaut-operator@sha256:586e5344ec3897fa2e80bab5207f1eca1611fdc4c6db80113247a1539c7941b7` |
+
+#### Kubernaut v1.5.1 Component Images
+
+| Component | Source Image |
+|---|---|
+| gateway | `quay.io/kubernaut-ai/gateway@sha256:8ef1d69db4508bfa0ab86e7f22100952ddae85c6e22d81293580d9defaf94004` |
+| datastorage | `quay.io/kubernaut-ai/datastorage@sha256:f10d8c98017c7df35133dc98f0e26e36054ec4584ac5c230b0252d3a5c9a0b44` |
+| aianalysis | `quay.io/kubernaut-ai/aianalysis@sha256:b31b8aaba5f4f3d5df1639213bca23c63438e257704ee0ac6d5f1d9ec82314b0` |
+| signalprocessing | `quay.io/kubernaut-ai/signalprocessing@sha256:de7393f8d0cbd07fadacf13ae0b9504cec321c09e1614c6839ccf1c65ec4d86e` |
+| remediationorchestrator | `quay.io/kubernaut-ai/remediationorchestrator@sha256:54778cdfd8e3a7fcef4cd871479c6101e566be0aa8fd0d5e37ed1a0c685eecb8` |
+| workflowexecution | `quay.io/kubernaut-ai/workflowexecution@sha256:47369cf7ab80bf398edca84ff4097028988303cfcc94a8a760cd4235faa7f008` |
+| effectivenessmonitor | `quay.io/kubernaut-ai/effectivenessmonitor@sha256:96aa70fcbd7d752632f18cd7ee57c009c99ab5667d7f070fbf33fd4e163e9752` |
+| notification | `quay.io/kubernaut-ai/notification@sha256:e1c4a270651fe05ca4c2d8e9588ebfb723584d5d0e80620af0cf7cf27ad643dd` |
+| kubernautagent | `quay.io/kubernaut-ai/kubernautagent@sha256:e4bf7bfbe1a3351266b9045ae19b4b012e12fd5a52b9f6559824918215dac184` |
+| authwebhook | `quay.io/kubernaut-ai/authwebhook@sha256:67b4093ca3d686077dd7816de88ce97ce729a32513e8e9fbe93433dae1434688` |
+| apifrontend | `quay.io/kubernaut-ai/apifrontend@sha256:54b57237ddbaa9d39cd6d7abf4fdabbc55406f1ef824fc020154ec5d20789946` |
+| db-migrate | `quay.io/kubernaut-ai/db-migrate@sha256:d94cdefac33c895524743697575425d3a458a97dc9c544deaa72b852b61637b3` |
+
+#### Infrastructure Dependencies (BYO PostgreSQL & Valkey)
+
+| Component | Source Image |
+|---|---|
+| postgresql-16 | `registry.redhat.io/rhel10/postgresql-16@sha256:877ac0f8207ada1559ef73b70e92616255b95d3b6ef6a1af314c0f67edfde96e` |
+| valkey-8 | `registry.redhat.io/rhel10/valkey-8@sha256:7b478930b2d186a61c3af408c3228f3da5104c759b8bd52d62c683e33bdb9ee2` |
+
+> The `postgresql-16` image is also used as a `wait-for-postgres` init container by the operator.
+
+#### Init Container Images
+
+| Component | Source Image |
+|---|---|
+| ubi-minimal | `registry.access.redhat.com/ubi10/ubi-minimal@sha256:7dc60d7777e010c50f5e041ff069112b379c3d5eef2823d20871c67cf663f10c` |
+
+### Step 1: Mirror All Images
+
+#### 1.1 Create the ImageSetConfiguration
+
+Save the following as `imageset-config.yaml`:
+
+```yaml
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+mirror:
+  additionalImages:
+    # Operator
+    - name: quay.io/kubernaut-ai/kubernaut-operator@sha256:586e5344ec3897fa2e80bab5207f1eca1611fdc4c6db80113247a1539c7941b7
+    # Kubernaut v1.5.1 components
+    - name: quay.io/kubernaut-ai/gateway@sha256:8ef1d69db4508bfa0ab86e7f22100952ddae85c6e22d81293580d9defaf94004
+    - name: quay.io/kubernaut-ai/datastorage@sha256:f10d8c98017c7df35133dc98f0e26e36054ec4584ac5c230b0252d3a5c9a0b44
+    - name: quay.io/kubernaut-ai/aianalysis@sha256:b31b8aaba5f4f3d5df1639213bca23c63438e257704ee0ac6d5f1d9ec82314b0
+    - name: quay.io/kubernaut-ai/signalprocessing@sha256:de7393f8d0cbd07fadacf13ae0b9504cec321c09e1614c6839ccf1c65ec4d86e
+    - name: quay.io/kubernaut-ai/remediationorchestrator@sha256:54778cdfd8e3a7fcef4cd871479c6101e566be0aa8fd0d5e37ed1a0c685eecb8
+    - name: quay.io/kubernaut-ai/workflowexecution@sha256:47369cf7ab80bf398edca84ff4097028988303cfcc94a8a760cd4235faa7f008
+    - name: quay.io/kubernaut-ai/effectivenessmonitor@sha256:96aa70fcbd7d752632f18cd7ee57c009c99ab5667d7f070fbf33fd4e163e9752
+    - name: quay.io/kubernaut-ai/notification@sha256:e1c4a270651fe05ca4c2d8e9588ebfb723584d5d0e80620af0cf7cf27ad643dd
+    - name: quay.io/kubernaut-ai/kubernautagent@sha256:e4bf7bfbe1a3351266b9045ae19b4b012e12fd5a52b9f6559824918215dac184
+    - name: quay.io/kubernaut-ai/authwebhook@sha256:67b4093ca3d686077dd7816de88ce97ce729a32513e8e9fbe93433dae1434688
+    - name: quay.io/kubernaut-ai/apifrontend@sha256:54b57237ddbaa9d39cd6d7abf4fdabbc55406f1ef824fc020154ec5d20789946
+    - name: quay.io/kubernaut-ai/db-migrate@sha256:d94cdefac33c895524743697575425d3a458a97dc9c544deaa72b852b61637b3
+    # Infrastructure dependencies (PostgreSQL, Valkey)
+    - name: registry.redhat.io/rhel10/postgresql-16@sha256:877ac0f8207ada1559ef73b70e92616255b95d3b6ef6a1af314c0f67edfde96e
+    - name: registry.redhat.io/rhel10/valkey-8@sha256:7b478930b2d186a61c3af408c3228f3da5104c759b8bd52d62c683e33bdb9ee2
+    # Init containers
+    - name: registry.access.redhat.com/ubi10/ubi-minimal@sha256:7dc60d7777e010c50f5e041ff069112b379c3d5eef2823d20871c67cf663f10c
 ```
 
-If any pod is stuck in `ImagePullBackOff`:
+#### 1.2 Configure Registry Authentication
+
+Ensure `~/.docker/config.json` (or `${XDG_RUNTIME_DIR}/containers/auth.json`) includes credentials for **all** source registries (`quay.io`, `registry.redhat.io`, `registry.access.redhat.com`) and the target mirror registry:
 
 ```bash
-oc describe pod <pod-name> -n kubernaut-system | grep -A5 "Events:"
+oc registry login --registry=<MIRROR> \
+  --auth-basic=<username>:<password> \
+  --to=${XDG_RUNTIME_DIR}/containers/auth.json
 ```
 
-Common causes:
+#### 1.3 Mirror the Images
 
-- Image not mirrored — re-run `oc-mirror`
-- Mirror credentials missing from global pull secret — re-run [Step 4](#step-4-configure-the-global-pull-secret)
-- IDMS not applied — check `oc get imagedigestmirrorset`
+Choose the workflow matching your network topology:
 
-Verify the actual image reference a pod is using:
+**Option A: Partially Disconnected** (bastion can reach both internet and mirror):
 
 ```bash
-oc get pod <pod-name> -n kubernaut-system \
-  -o jsonpath='{.spec.containers[0].image}'
+oc mirror -c imageset-config.yaml docker://<MIRROR> --v2
+```
+
+**Option B: Fully Disconnected** (air-gapped transfer required):
+
+```bash
+# On the internet-connected bastion — mirror to disk:
+oc mirror -c imageset-config.yaml file:///path/to/archive --v2
+
+# Transfer /path/to/archive to the disconnected side (USB, S3, sneakernet)
+
+# On the disconnected bastion — load from disk to mirror:
+oc mirror -c imageset-config.yaml --from file:///path/to/archive docker://<MIRROR> --v2
+```
+
+#### 1.4 Apply the Generated IDMS
+
+After mirroring, `oc mirror` generates `ImageDigestMirrorSet` manifests in the results directory:
+
+```bash
+oc apply -f oc-mirror-workspace/results-*/
+```
+
+Verify:
+
+```bash
+oc get imagedigestmirrorset
+```
+
+#### 1.5 Update the Global Pull Secret (if needed)
+
+If your mirror registry requires authentication from cluster nodes:
+
+```bash
+oc get secret/pull-secret -n openshift-config \
+  -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d > pull-secret.json
+
+oc registry login --registry=<MIRROR> \
+  --auth-basic=<username>:<password> \
+  --to=pull-secret.json
+
+oc set data secret/pull-secret -n openshift-config \
+  --from-file=.dockerconfigjson=pull-secret.json
+```
+
+!!! warning
+    Updating the global pull secret triggers a rolling restart of all nodes (MCO rollout, 15--30 min).
+
+### Step 2: Install the Operator
+
+#### 2.1 Download the Install Manifest
+
+From the bastion host, download the operator install manifest:
+
+```bash
+curl -fsSL \
+  https://raw.githubusercontent.com/jordigilh/kubernaut-operator/v1.5.1/dist/install.yaml \
+  -o install.yaml
+```
+
+#### 2.2 Apply the Manifest
+
+With IDMS in place, the original image references in the manifest are transparently redirected to the mirror. No `sed` patching is needed:
+
+```bash
+oc apply -f install.yaml
+```
+
+This creates:
+
+- `kubernaut-operator-system` namespace
+- 11 CRDs (all under `kubernaut.ai`)
+- ServiceAccount, RBAC (ClusterRole, ClusterRoleBinding)
+- Operator Deployment
+
+#### 2.3 Wait for the Operator
+
+```bash
+oc rollout status deployment/kubernaut-operator-controller-manager \
+  -n kubernaut-operator-system --timeout=120s
+```
+
+!!! note
+    If the operator pod shows `ImagePullBackOff`, verify the IDMS is applied (`oc get imagedigestmirrorset`) and that the global pull secret includes the mirror credentials. The `RELATED_IMAGE_*` env vars do **not** need to be changed — IDMS handles the redirect at the CRI-O level.
+
+---
+
+## Step 3: Provision Prerequisites {: #step-3-provision-prerequisites }
+
+These steps apply to both OLM and direct manifest installs.
+
+### 3.1 Create the Kubernaut Namespace
+
+```bash
+oc create namespace kubernaut-system
+```
+
+### 3.2 Create Secrets
+
+#### PostgreSQL
+
+```bash
+oc create secret generic postgresql-secret \
+  --from-literal=POSTGRES_USER=<pg-user> \
+  --from-literal=POSTGRES_PASSWORD=<pg-password> \
+  --from-literal=POSTGRES_DB=action_history \
+  -n kubernaut-system
+```
+
+!!! note
+    The operator validates that the secret contains keys `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB`. The RHEL PostgreSQL 16 container image expects different env var names (`POSTGRESQL_USER`, `POSTGRESQL_PASSWORD`, `POSTGRESQL_DATABASE`), so the PostgreSQL deployment must map these keys via `secretKeyRef` (see [Step 3.5](#step-35-deploy-postgresql-and-valkey)). The operator automatically derives a `datastorage-db-secret` from this secret with the full connection details.
+
+#### Valkey
+
+```bash
+oc create secret generic valkey-secret \
+  --from-literal=valkey-secrets.yaml="$(printf 'password: %s' '<valkey-password>')" \
+  -n kubernaut-system
+```
+
+#### LLM Credentials
+
+The LLM provider and credentials are configured by the operator team. Create a secret matching the provider's expected format:
+
+```bash
+# Example for OpenAI-compatible endpoint:
+oc create secret generic llm-credentials \
+  --from-literal=OPENAI_API_KEY=<your-llm-key> \
+  -n kubernaut-system
+
+# Example for Vertex AI with service account JSON:
+oc create secret generic llm-credentials \
+  --from-file=credentials.json=<path-to-service-account-json> \
+  -n kubernaut-system
+```
+
+See [LLM Configuration Reference](#llm-configuration-reference) for the full credential format per provider.
+
+#### Slack Webhook (Optional)
+
+```bash
+oc create secret generic slack-webhook \
+  --from-literal=webhook-url=https://hooks.slack.com/services/YOUR/WEBHOOK/URL \
+  -n kubernaut-system
+```
+
+### 3.3 Provision Persistent Storage {: #step-33-provision-persistent-storage }
+
+!!! warning "Production requirement"
+    PostgreSQL and Valkey are BYO preconditions. The operator does **not** manage their storage. Without PVCs, data is lost on every pod restart (`emptyDir`), requiring a full database migration cycle.
+
+Create PVCs using the StorageClass available on your cluster:
+
+```bash
+oc get storageclass
+```
+
+Common StorageClass names by platform:
+
+| Platform | StorageClass |
+|---|---|
+| AWS (EBS) | `gp3-csi`, `gp2-csi` |
+| vSphere | `thin-csi` |
+| Bare metal (LVMS) | `lvms-vg1` |
+| ODF/OCS | `ocs-storagecluster-ceph-rbd` |
+| Azure | `managed-premium`, `managed-csi` |
+
+If your cluster has a default StorageClass (marked `(default)` in the output), you can omit the `storageClassName` field.
+
+```bash
+oc apply -f - <<'EOF'
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgresql-data
+  namespace: kubernaut-system
+  labels:
+    app: postgresql
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: <STORAGE_CLASS>     # e.g. gp3-csi, lvms-vg1, thin-csi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: valkey-data
+  namespace: kubernaut-system
+  labels:
+    app: valkey
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: <STORAGE_CLASS>
+EOF
+```
+
+### 3.4 Create Rego Policy ConfigMaps
+
+Kubernaut uses OPA/Rego policies for signal classification and remediation approval. These must be created **before** applying the Kubernaut CR.
+
+#### Signal Processing Policy
+
+```bash
+oc apply -f - <<'POLICYEOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: signalprocessing-policy
+  namespace: kubernaut-system
+data:
+  policy.rego: |
+    package signalprocessing
+    import rego.v1
+
+    # Environment Classification
+    default environment := {"environment": "Unknown", "source": "default"}
+    environment := {"environment": "Production", "source": "namespace-labels"} if {
+        env := input.namespace.labels["kubernaut.ai/environment"]
+        lower(env) == "production"
+    }
+    environment := {"environment": "Staging", "source": "namespace-labels"} if {
+        env := input.namespace.labels["kubernaut.ai/environment"]
+        lower(env) == "staging"
+    }
+    environment := {"environment": "Development", "source": "namespace-labels"} if {
+        env := input.namespace.labels["kubernaut.ai/environment"]
+        lower(env) == "development"
+    }
+    environment := {"environment": "Production", "source": "namespace-name"} if {
+        not input.namespace.labels["kubernaut.ai/environment"]
+        lower(input.namespace.name) == "production"
+    }
+    environment := {"environment": "Production", "source": "namespace-name"} if {
+        not input.namespace.labels["kubernaut.ai/environment"]
+        lower(input.namespace.name) == "prod"
+    }
+
+    # Severity Normalization
+    default severity := "unknown"
+    severity := "critical" if { lower(input.signal.severity) == "critical" }
+    severity := "high"     if { lower(input.signal.severity) == "high" }
+    severity := "medium"   if { lower(input.signal.severity) == "medium" }
+    severity := "medium"   if { lower(input.signal.severity) == "warning" }
+    severity := "low"      if { lower(input.signal.severity) == "low" }
+    severity := "low"      if { lower(input.signal.severity) == "info" }
+
+    # Priority Assignment
+    default priority := {"priority": "P3", "policy_name": "default"}
+    priority := {"priority": "P0", "policy_name": "production-critical"} if {
+        environment.environment == "Production"
+        severity == "critical"
+    }
+    priority := {"priority": "P1", "policy_name": "production-high"} if {
+        environment.environment == "Production"
+        severity == "high"
+    }
+    priority := {"priority": "P1", "policy_name": "staging-critical"} if {
+        environment.environment == "Staging"
+        severity == "critical"
+    }
+    priority := {"priority": "P2", "policy_name": "staging-any"} if {
+        environment.environment == "Staging"
+        severity != "critical"
+    }
+
+    # Custom Labels
+    default labels := {}
+    labels := {"team": [team], "tier": [tier]} if {
+        team := input.namespace.labels["kubernaut.ai/team"]
+        team != ""
+        tier := input.namespace.labels["kubernaut.ai/tier"]
+        tier != ""
+    }
+    labels := {"team": [team]} if {
+        team := input.namespace.labels["kubernaut.ai/team"]
+        team != ""
+        not input.namespace.labels["kubernaut.ai/tier"]
+    }
+POLICYEOF
+```
+
+#### AI Analysis Approval Policy
+
+```bash
+oc apply -f - <<'POLICYEOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aianalysis-policies
+  namespace: kubernaut-system
+data:
+  approval.rego: |
+    package aianalysis.approval
+    import rego.v1
+
+    default require_approval := false
+    default reason := "Auto-approved"
+    default confidence_threshold := 0.8
+
+    confidence_threshold := input.confidence_threshold if {
+        input.confidence_threshold
+    }
+
+    is_high_confidence if { input.confidence >= confidence_threshold }
+    is_production if { lower(input.environment) == "production" }
+    has_remediation_target if {
+        input.remediation_target
+        input.remediation_target.kind != ""
+    }
+    is_sensitive_resource if { input.remediation_target.kind == "Node" }
+    is_sensitive_resource if { input.remediation_target.kind == "StatefulSet" }
+    is_sensitive_resource if { input.target_resource.kind == "Node" }
+    is_sensitive_resource if { input.target_resource.kind == "StatefulSet" }
+
+    require_approval if { is_sensitive_resource }
+    require_approval if { not has_remediation_target }
+    require_approval if { count(input.warnings) > 0 }
+    require_approval if {
+        is_production
+        not is_high_confidence
+    }
+
+    risk_factors contains {"score": 90, "reason": "Missing remediation target"} if {
+        not has_remediation_target
+    }
+    risk_factors contains {"score": 80, "reason": "Sensitive resource kind requires manual approval"} if {
+        is_sensitive_resource
+    }
+    risk_factors contains {"score": 75, "reason": "LLM raised warnings — human review recommended"} if {
+        count(input.warnings) > 0
+    }
+    risk_factors contains {"score": 70, "reason": "Production environment requires manual approval"} if {
+        is_production
+        not is_high_confidence
+    }
+
+    all_scores contains f.score if { some f in risk_factors }
+    max_risk_score := max(all_scores) if { count(all_scores) > 0 }
+    reason := f.reason if { some f in risk_factors; f.score == max_risk_score }
+POLICYEOF
+```
+
+### 3.5 Deploy PostgreSQL and Valkey (if not BYO) {: #step-35-deploy-postgresql-and-valkey }
+
+If PostgreSQL and Valkey are not already available, deploy them in the `kubernaut-system` namespace. The operator expects them at:
+
+- PostgreSQL: `postgresql.kubernaut-system.svc.cluster.local:5432`
+- Valkey: `valkey.kubernaut-system.svc.cluster.local:6379`
+
+#### PostgreSQL
+
+```bash
+oc apply -f - <<'EOF'
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  namespace: kubernaut-system
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: postgresql-tls
+spec:
+  ports:
+  - port: 5432
+    targetPort: 5432
+  selector:
+    app: postgresql
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgresql
+  namespace: kubernaut-system
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: postgresql
+  template:
+    metadata:
+      labels:
+        app: postgresql
+    spec:
+      containers:
+      - name: postgresql
+        image: registry.redhat.io/rhel9/postgresql-16:latest
+        env:
+        - name: POSTGRESQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: postgresql-secret
+              key: POSTGRES_USER
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgresql-secret
+              key: POSTGRES_PASSWORD
+        - name: POSTGRESQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              name: postgresql-secret
+              key: POSTGRES_DB
+        ports:
+        - containerPort: 5432
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/pgsql/data
+        - name: tls
+          mountPath: /etc/tls
+          readOnly: true
+        - name: ssl-config
+          mountPath: /opt/app-root/src/postgresql-cfg
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: postgresql-data
+      - name: tls
+        secret:
+          secretName: postgresql-tls
+          optional: true
+          defaultMode: 0600
+      - name: ssl-config
+        configMap:
+          name: postgresql-ssl-config
+EOF
+```
+
+!!! warning "TLS key permissions"
+    The TLS secret volume **must** use `defaultMode: 0600`. PostgreSQL refuses to start if the private key file has group or world access permissions. Without this setting, the pod will crash with `FATAL: private key file "/etc/tls/tls.key" has group or world access`.
+
+!!! note "Env var mapping"
+    The `env` section maps the operator's secret keys (`POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`) to the RHEL PostgreSQL container's expected names (`POSTGRESQL_USER`, `POSTGRESQL_PASSWORD`, `POSTGRESQL_DATABASE`) via `secretKeyRef`. The `service.beta.openshift.io/serving-cert-secret-name` annotation tells OpenShift's service-CA to auto-provision a `postgresql-tls` TLS secret.
+
+#### Valkey
+
+```bash
+oc apply -f - <<'EOF'
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey
+  namespace: kubernaut-system
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: valkey
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: valkey
+  namespace: kubernaut-system
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: valkey
+  template:
+    metadata:
+      labels:
+        app: valkey
+    spec:
+      containers:
+      - name: valkey
+        image: docker.io/valkey/valkey:8
+        command: ["sh", "-c", "valkey-server --requirepass $(cat /etc/valkey/secrets/valkey-secrets.yaml | grep password | awk '{print $2}') --save 60 1000 --dir /data"]
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        - name: secrets
+          mountPath: /etc/valkey/secrets
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 250m
+            memory: 256Mi
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: valkey-data
+      - name: secrets
+        secret:
+          secretName: valkey-secret
+EOF
+```
+
+Wait for both to become ready:
+
+```bash
+oc rollout status deployment/postgresql deployment/valkey \
+  -n kubernaut-system --timeout=120s
+```
+
+### 3.6 PostgreSQL TLS Configuration {: #postgresql-tls }
+
+The CR field `spec.postgresql.sslMode` controls how operator components connect to PostgreSQL:
+
+| Value | When to use |
+|---|---|
+| `require` | PostgreSQL has TLS enabled (self-signed or CA-signed). Encrypts the connection but does not verify the server certificate. **Recommended for most deployments.** |
+| `verify-ca` | PostgreSQL has TLS with a CA certificate. Verifies the server certificate against the CA but does not check the hostname. |
+| `verify-full` | PostgreSQL has TLS with a CA certificate trusted by the pods. Verifies both the CA and the hostname. |
+
+Create the PostgreSQL SSL configuration ConfigMap:
+
+```bash
+oc apply -f - <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgresql-ssl-config
+  namespace: kubernaut-system
+data:
+  postgresql-ssl.conf: |
+    ssl = on
+    ssl_cert_file = '/etc/tls/tls.crt'
+    ssl_key_file = '/etc/tls/tls.key'
+EOF
+```
+
+Provision TLS certificates:
+
+```bash
+# Option A: Let OCP service-CA auto-provision the cert (annotate the service)
+oc annotate service postgresql \
+  service.beta.openshift.io/serving-cert-secret-name=postgresql-tls \
+  -n kubernaut-system
+
+# Option B: Provide your own TLS cert
+oc create secret tls postgresql-tls \
+  --cert=<path-to-cert.pem> \
+  --key=<path-to-key.pem> \
+  -n kubernaut-system
+```
+
+!!! note
+    PostgreSQL requires single quotes around file paths in its configuration. Use the YAML ConfigMap manifest above. TLS is required — the CRD only supports `sslMode` values `require`, `verify-ca`, and `verify-full`. Use the service-CA annotation (Option A) for the simplest setup, then set `spec.postgresql.sslMode: require` in the Kubernaut CR.
+
+---
+
+## Step 4: Create the Kubernaut CR {: #step-4-create-kubernaut-cr }
+
+!!! warning "Environment-Specific Values"
+    The following fields **must match your target cluster's identity infrastructure**. Mismatched values cause silent authentication failures (401 Unauthorized):
+
+    | Field | What to set | How to verify |
+    |---|---|---|
+    | `spec.apiFrontend.auth.audience` | Keycloak realm URL (e.g. `https://<host>/realms/kagenti`) | Decode a JWT: `echo $TOKEN \| cut -d. -f2 \| base64 -d \| jq '.aud'` |
+    | `spec.apiFrontend.auth.issuerURL` | External Keycloak realm URL | Must match the `iss` claim in tokens |
+    | `spec.apiFrontend.auth.jwksURL` | Cluster-internal Keycloak JWKS endpoint | `curl` from inside the cluster should return a JSON key set |
+    | `spec.apiFrontend.auth.allowInsecureIssuers` | `true` for self-signed Keycloak TLS | Set `false` when Keycloak has a trusted certificate |
+    | `spec.apiFrontend.spire.className` | SPIRE class name deployed by kagenti | `oc get spireclusterconfig` |
+    | `spec.apiFrontend.spire.enabled` | `true` when kagenti is installed | Must be `true` for A2A integration |
+
+Apply the Kubernaut custom resource. Replace `<KEYCLOAK_HOST>` and `<llm-*>` placeholders:
+
+```yaml
+apiVersion: kubernaut.ai/v1alpha1
+kind: Kubernaut
+metadata:
+  name: kubernaut
+  namespace: kubernaut-system
+spec:
+  image:
+    pullPolicy: IfNotPresent
+
+  postgresql:
+    host: postgresql.kubernaut-system.svc.cluster.local
+    port: 5432
+    secretName: postgresql-secret
+    sslMode: require
+
+  valkey:
+    host: valkey.kubernaut-system.svc.cluster.local
+    port: 6379
+    secretName: valkey-secret
+
+  kubernautAgent:
+    llm:
+      provider: "<llm-provider>"          # e.g. openai, vertex_ai, ollama, anthropic
+      model: "<model-name>"               # e.g. llama3, gpt-4o, claude-sonnet-4-6
+      endpoint: "<llm-endpoint>"          # e.g. http://ollama.internal.svc:11434
+      credentialsSecretName: llm-credentials
+      maxRetries: 3
+      timeoutSeconds: 120
+    logging:
+      level: debug
+    maxTurns: 40
+    audit:
+      enabled: true
+    interactive:
+      enabled: true
+      inactivityTimeout: 10m
+      maxConcurrentSessions: 10
+      rateLimitPerUser: 10
+      sessionTTL: 30m
+    safety:
+      anomaly:
+        maxRepeatedFailures: 3
+        maxToolCallsPerTool: 10
+        maxTotalToolCalls: 40
+      sanitization:
+        credentialScrubEnabled: true
+        injectionPatternsEnabled: true
+    summarizer:
+      maxToolOutputSize: 100000
+      threshold: 8000
+    alignmentCheck:
+      enabled: false
+    session:
+      ttl: 30m
+    shutdown:
+      drainSeconds: 15
+
+  apiFrontend:
+    enabled: true
+    auth:
+      issuerURL: "https://<KEYCLOAK_HOST>/realms/kagenti"
+      audience: "https://<KEYCLOAK_HOST>/realms/kagenti"
+      jwksURL: "http://keycloak-service.keycloak:8080/realms/kagenti/protocol/openid-connect/certs"
+      allowInsecureIssuers: true
+    logging:
+      level: debug
+    rateLimit:
+      ipRequestsPerSec: 50
+      userRequestsPerSec: 20
+      toolCallsPerMinute: 60
+      maxConcurrentSessions: 100
+    route:
+      enabled: false
+    shutdown:
+      drainSeconds: 15
+    spire:
+      enabled: true
+      className: zero-trust-workload-identity-manager-spire
+    rbac:
+      sarCacheTTL: "30s"
+      roleBindings:
+        - role: sre
+          groups: ["platform-engineering"]
+        - role: ai-orchestrator
+          groups: ["platform-engineering"]
+        - role: cicd
+          groups: ["platform-engineering"]
+        - role: observability
+          groups: ["platform-engineering"]
+        - role: l3-audit
+          groups: ["platform-engineering"]
+        - role: remediation-approver
+          groups: ["platform-engineering"]
+
+  gateway:
+    enabled: true
+    logging:
+      level: info
+    route:
+      enabled: true
+    config:
+      deduplicationCooldown: 5m
+      k8sRequestTimeout: 15s
+      cors:
+        allowCredentials: false
+        maxAge: 300
+
+  dataStorage:
+    endpointPropagationDelay: 10s
+    logging:
+      level: info
+
+  aiAnalysis:
+    logging:
+      level: info
+    policy:
+      configMapName: aianalysis-policies
+
+  signalProcessing:
+    logging:
+      level: info
+    policy:
+      configMapName: signalprocessing-policy
+
+  remediationOrchestrator:
+    dryRun: false
+    dryRunHoldPeriod: 1h
+    logging:
+      level: info
+    retention:
+      period: 24h
+    effectivenessAssessment:
+      stabilizationWindow: 5m
+    notifications:
+      notifySelfResolved: false
+    timeouts:
+      global: 1h
+      processing: 5m
+      analyzing: 10m
+      awaitingApproval: 15m
+      executing: 30m
+      verifying: 30m
+
+  workflowExecution:
+    cooldownPeriod: 1m
+    logging:
+      level: info
+    workflowNamespace: kubernaut-workflows
+
+  effectivenessMonitor:
+    logging:
+      level: info
+    assessment:
+      stabilizationWindow: 30s
+      validityWindow: 300s
+
+  notification:
+    logging:
+      level: info
+    slack:
+      channel: "#kubernaut-alerts"
+      secretName: slack-webhook
+
+  authWebhook:
+    logging:
+      level: info
+
+  monitoring:
+    enabled: true
+
+  networkPolicies:
+    enabled: true
+
+  ansible:
+    enabled: false
+```
+
+Apply:
+
+```bash
+oc apply -f kubernaut-cr.yaml
+```
+
+The operator will reconcile the CR and create all component deployments, services, ConfigMaps, RBAC, and the `kubernaut-workflows` namespace automatically.
+
+---
+
+## Step 5: kagenti Integration {: #kagenti-integration }
+
+The operator is validated with **kagenti `0.2.0-alpha.36`**. This version uses an envoy-based authbridge sidecar with iptables interception.
+
+!!! note "Prerequisite"
+    kagenti must be installed and healthy before deploying Kubernaut. Verify:
+
+    ```bash
+    oc get pods -n kagenti-system
+    oc get spireclusterconfig    # for kagenti 0.3.x+ with SPIRE CRDs
+    ```
+
+    The SPIRE class name must match `spec.apiFrontend.spire.className` in the Kubernaut CR. The default is `zero-trust-workload-identity-manager-spire`.
+
+### 5.1 Namespace Label and AgentRuntime CR
+
+When `spec.apiFrontend.spire.enabled: true`, the kubernaut-operator automatically:
+
+1. **Labels the namespace** — adds `kagenti-enabled=true` to `kubernaut-system`, triggering the kagenti mutating webhook to inject the authbridge sidecar into API Frontend pods.
+2. **Creates an `AgentRuntime` CR** — provisions an `AgentRuntime` custom resource named `apifrontend` in the `kubernaut-system` namespace, telling the kagenti operator to provision all required resources.
+
+Verify:
+
+```bash
+oc get agentruntime -n kubernaut-system
+# Expected: NAME=apifrontend, PHASE=Active
+```
+
+### 5.2 SecurityContextConstraints
+
+The kagenti sidecar requires the `kagenti-authbridge` SCC:
+
+```bash
+oc patch scc kagenti-authbridge --type=json -p '[
+  {"op": "add", "path": "/groups/-", "value": "system:serviceaccounts:kubernaut-system"}
+]'
+```
+
+### 5.3 Keycloak Group Mapper for Tool Authorization
+
+The API Frontend uses Kubernetes SubjectAccessReview (SAR) to authorize tool access based on OIDC group claims in the user's JWT. Keycloak must include group membership in issued tokens.
+
+**Create a `groups` client scope with a group-membership mapper:**
+
+1. In the Keycloak admin console, navigate to the `kagenti` realm
+2. Go to **Client scopes** > **Create client scope**: name `groups`, protocol `openid-connect`
+3. Under the new scope, go to **Mappers** > **Create mapper**:
+
+| Setting | Value |
+|---|---|
+| Name | `groups` |
+| Mapper type | `Group Membership` |
+| Token claim name | `groups` |
+| Full group path | `off` |
+| Add to ID token | `on` |
+| Add to access token | `on` |
+| Add to userinfo | `on` |
+
+4. Go to **Clients** > `kagenti` > **Client scopes** > **Add client scope** > add `groups` as a **Default** scope
+
+**Create a group for Kubernaut users** (or use an existing one):
+
+```
+Group name: platform-engineering
+```
+
+Assign users to this group in Keycloak. The group name must match the `groups` array in `spec.apiFrontend.rbac.roleBindings` in the CR.
+
+!!! warning "Stale tokens"
+    Users must log out and log back in after being added to a group (or after the `groups` scope is first created) to receive a fresh token with the `groups` claim. Stale tokens issued before the scope was added will have an empty groups array and SAR checks will fail.
+
+### 5.4 Keycloak Audience Mapper
+
+For kagenti to successfully authenticate with the API Frontend, add an `oidc-audience-mapper` protocol mapper:
+
+| Setting | Value |
+|---|---|
+| `included.custom.audience` | `spiffe://<trust-domain>/ns/kubernaut-system/sa/apifrontend` |
+| `access.token.claim` | `true` |
+| `id.token.claim` | `false` |
+
+Assign this scope as a default scope to the `kagenti` client.
+
+### 5.5 Port Configuration
+
+The operator automatically detects the kagenti version:
+
+- **kagenti 0.2.x** (envoy sidecar): AF keeps its listen port at `8443`; metrics shifts to `9092`, health to `8082` to avoid conflict with envoy's `ext_proc` on `:9090`.
+- **kagenti 0.3.x+** (authbridge-proxy): AF shifts to `8444`; the authbridge-proxy takes `8443`.
+
+No manual configuration is needed — the operator detects the version via CRD discovery.
+
+---
+
+## Step 6: Configure AlertManager (OCP) {: #alertmanager-ocp }
+
+To enable alert-driven scenarios, configure OCP AlertManager to route alerts to the Kubernaut Gateway webhook.
+
+!!! note
+    This step requires `spec.gateway.enabled: true` in the Kubernaut CR.
+
+```bash
+oc -n openshift-monitoring create secret generic alertmanager-main \
+  --from-file=alertmanager.yaml=/dev/stdin \
+  --dry-run=client -o yaml <<'EOF' | oc apply -f -
+global:
+  resolve_timeout: 1m
+
+route:
+  receiver: default
+  group_wait: 5s
+  group_interval: 5s
+  repeat_interval: 1m
+  routes:
+    - match_re:
+        namespace: "demo-.*"
+      receiver: gateway-webhook
+      group_by: [alertname, namespace]
+      continue: false
+    - match:
+        alertname: KubeNodeNotReady
+      receiver: gateway-webhook
+      continue: false
+
+receivers:
+  - name: default
+  - name: gateway-webhook
+    webhook_configs:
+      - url: "https://gateway-service.kubernaut-system.svc.cluster.local:8443/api/v1/signals/prometheus"
+        send_resolved: false
+        http_config:
+          authorization:
+            type: Bearer
+            credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          tls_config:
+            insecure_skip_verify: true
+EOF
+```
+
+This routes alerts from `demo-*` namespaces and `KubeNodeNotReady` cluster alerts to the Kubernaut Gateway.
+
+---
+
+## Step 7: Seed Demo Workflows {: #seed-demo-workflows }
+
+### 7.1 Clone the Demo Scenarios Repository
+
+```bash
+git clone https://github.com/jordigilh/kubernaut-demo-scenarios.git
+cd kubernaut-demo-scenarios
+```
+
+### 7.2 Apply ActionType CRDs
+
+```bash
+oc apply -f deploy/action-types/ -n kubernaut-system
+```
+
+This creates ~34 ActionType CRs (e.g. `RollbackDeployment`, `CordonDrainNode`, `ExpandPersistentVolumeClaim`).
+
+### 7.3 Seed RemediationWorkflows
+
+```bash
+./scripts/seed-workflows.sh
+```
+
+Verify:
+
+```bash
+oc get remediationworkflows -n kubernaut-system
+```
+
+You should see ~28 workflows seeded (ansible and gitea-dependent workflows are skipped if those services are not present).
+
+### 7.4 Run a Demo Scenario
+
+```bash
+# Trigger a CrashLoopBackOff scenario
+./scenarios/crashloop/run.sh
+
+# Watch Kubernaut investigate and remediate
+oc get remediationrequests -n kubernaut-system -w
+
+# Clean up
+./scenarios/crashloop/cleanup.sh
 ```
 
 ---
 
-## Helm Chart — Development/Testing Only
+## Step 8: Verify the Installation {: #verify-installation }
+
+```bash
+# Operator
+oc get pods -n kubernaut-operator-system
+
+# Kubernaut CR status
+oc get kubernaut -n kubernaut-system
+
+# All pods should be Running (db-migrate will show Completed)
+oc get pods -n kubernaut-system
+
+# Check CR phase
+oc get kubernaut kubernaut -n kubernaut-system -o jsonpath='{.status.phase}'
+```
+
+Expected output: all pods `Running` (or `Completed` for db-migrate), CR phase `Running`.
+
+### Verify API Frontend with kagenti
+
+```bash
+# Check AF pod has sidecar containers (3/3 for kagenti 0.2.x)
+oc get pods -n kubernaut-system -l app=apifrontend
+
+# Check kagenti agent card sync
+oc get agentcard -n kubernaut-system
+```
+
+The `SYNCED` column should show `True` for the `apifrontend-deployment-card`.
+
+---
+
+## LLM Configuration Reference {: #llm-configuration-reference }
+
+Kubernaut has two components that consume LLM configuration:
+
+- **Kubernaut Agent (KA)** — the investigation/analysis engine. Supports 9 providers.
+- **API Frontend (AF)** — the MCP/A2A gateway. Supports 3 providers (subset of KA).
+
+The operator populates AF's LLM config from the same `spec.kubernautAgent.llm` CR fields. There is no separate AF LLM section in the CR.
+
+### Supported Providers
+
+| Provider value | Backend | KA | AF | Notes |
+|---|---|---|---|---|
+| `openai` | OpenAI API | Yes | No | Works with any OpenAI-compatible endpoint (vLLM, LiteLLM, etc.) |
+| `ollama` | Ollama | Yes | No | `endpoint` **required** (e.g. `http://ollama.svc:11434`) |
+| `azure` | Azure OpenAI | Yes | No | Requires `azureApiVersion`; `endpoint` = Azure resource URL |
+| `vertex` | Google Vertex AI (Gemini) | Yes | No | Gemini models via GCP; requires `vertexProject` |
+| `vertex_ai` | Anthropic Claude on Vertex AI | Yes | Yes | Claude models on GCP; requires `vertexProject`, `vertexLocation` |
+| `anthropic` | Anthropic API | Yes | Yes | Direct Anthropic API; API key required |
+| `gemini` | Google Gemini API | No | Yes | Gemini models via API key (not Vertex); AF only |
+| `bedrock` | AWS Bedrock | Yes | No | Uses AWS IAM/ADC; `bedrockRegion` optional |
+| `huggingface` | HuggingFace Inference | Yes | No | API token required |
+| `mistral` | Mistral API | Yes | No | API key required; `endpoint` optional |
+
+!!! note "`vertex` vs `vertex_ai`"
+    `vertex` = Gemini models on Vertex AI (LangChainGo); `vertex_ai` = Claude models on Vertex AI (Anthropic SDK). These are different code paths.
+
+### CR Fields (`spec.kubernautAgent.llm`)
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `provider` | string | Yes | — | Provider name from the table above |
+| `model` | string | Yes | — | Model name (e.g. `gpt-4o`, `claude-sonnet-4-6`, `llama3`) |
+| `credentialsSecretName` | string | Yes | — | Secret name containing API credentials |
+| `endpoint` | string | Depends | — | API endpoint URL. Required for `ollama`, `azure`, `mistral`. Optional for others. |
+| `temperature` | string | No | `"0.7"` | Sampling temperature (string to avoid CRD float issues) |
+| `maxRetries` | int | No | `3` | Maximum retry attempts for API calls |
+| `timeoutSeconds` | int | No | `120` | Timeout per API call in seconds |
+| `vertexProject` | string | Vertex/Vertex AI | — | GCP project ID |
+| `vertexLocation` | string | Vertex/Vertex AI | `us-central1` | GCP region |
+| `bedrockRegion` | string | Bedrock | — | AWS region |
+| `azureApiVersion` | string | Azure | — | Azure OpenAI API version (e.g. `2024-02-01`) |
+| `tlsCaFile` | string | No | — | Path to CA cert for TLS to LLM endpoint |
+| `oauth2` | object | No | disabled | OAuth2 client credentials auth (see below) |
+| `runtimeConfigMapName` | string | No | — | Name of a pre-existing ConfigMap for hot-reloadable runtime config |
+
+### Credential Secret Format
+
+| Provider | Expected Secret Key | Example |
+|---|---|---|
+| `openai` | `OPENAI_API_KEY` | API key string |
+| `anthropic` | `ANTHROPIC_API_KEY` | API key string |
+| `vertex_ai` / `vertex` | `GOOGLE_APPLICATION_CREDENTIALS` | GCP service account JSON. Falls back to Workload Identity / ADC if empty |
+| `azure` | `OPENAI_API_KEY` | Azure API key |
+| `ollama` | *(any key or empty)* | Usually not needed |
+| `bedrock` | *(empty)* | Uses AWS IAM; no secret key required |
+| `mistral` | `MISTRAL_API_KEY` | API key string |
+| `huggingface` | `HUGGINGFACEHUB_API_TOKEN` | HuggingFace token |
+
+### OAuth2 Configuration (`spec.kubernautAgent.llm.oauth2`)
+
+For LLM endpoints behind OAuth2 (client credentials grant):
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `enabled` | bool | No | Enable OAuth2 auth (default `false`) |
+| `tokenURL` | string | When enabled | Token endpoint URL |
+| `scopes` | []string | No | OAuth2 scopes |
+| `credentialsSecretRef` | string | When enabled | Secret name with keys `client-id` and `client-secret` |
+
+!!! note
+    OAuth2 is **not supported** for `vertex_ai` (uses GCP ADC internally).
+
+### AF LLM Limitations
+
+The AF supports only `vertex_ai`, `gemini`, and `anthropic`. If the KA is configured with a provider not supported by AF (e.g. `openai`, `ollama`), the AF's A2A endpoint returns `501 Not Implemented` for direct LLM-powered operations. MCP tool proxying to the KA still works regardless.
+
+---
+
+## Helm Chart — Development/Testing Only {: #helm-chart }
 
 !!! warning
-    The Helm chart is intended for development and testing only. For production disconnected deployments, use the [Operator (OLM)](#operator-olm-production) method above.
+    The Helm chart is intended for development and testing only. For production disconnected deployments, use the [Operator](#operator-olm) method above.
 
-The Helm-based airgap flow requires manually listing all images, mirroring them, and overriding image references via `values-airgap.yaml`. This section is retained for environments where OLM is not available.
+The Helm-based airgap flow requires manually listing all images, mirroring them, and overriding image references via `values-airgap.yaml`. This section is retained for environments where the operator is not available.
 
 ### Prerequisites (Helm)
 
@@ -320,37 +1390,7 @@ The Helm-based airgap flow requires manually listing all images, mirroring them,
 
 ### Step 1: Identify all images
 
-#### Kubernaut service images
-
-All published under `quay.io/kubernaut-ai/` with a tag matching the chart version:
-
-| Image | Description |
-|---|---|
-| `quay.io/kubernaut-ai/gateway` | Signal ingestion webhook |
-| `quay.io/kubernaut-ai/datastorage` | Audit trail and workflow catalog persistence |
-| `quay.io/kubernaut-ai/aianalysis` | Root cause analysis controller |
-| `quay.io/kubernaut-ai/signalprocessing` | Signal deduplication and enrichment |
-| `quay.io/kubernaut-ai/remediationorchestrator` | Remediation workflow orchestration |
-| `quay.io/kubernaut-ai/workflowexecution` | Job / Tekton execution engine |
-| `quay.io/kubernaut-ai/notification` | Notification delivery (Slack, Teams, PagerDuty) |
-| `quay.io/kubernaut-ai/effectivenessmonitor` | Post-remediation effectiveness verification |
-| `quay.io/kubernaut-ai/kubernautagent` | LLM integration service |
-| `quay.io/kubernaut-ai/authwebhook` | Admission controller for CRD authorization |
-| `quay.io/kubernaut-ai/apifrontend` | API Frontend service (new in v1.5) |
-| `quay.io/kubernaut-ai/db-migrate` | Database schema migration (pre-upgrade hook) |
-| `quay.io/kubernaut-ai/must-gather` | Diagnostic data collection for support |
-
-#### Infrastructure images
-
-| Image | Description |
-|---|---|
-| `registry.redhat.io/rhel10/postgresql-16` | PostgreSQL 16 (Red Hat RHEL10) |
-| `registry.redhat.io/rhel10/valkey-8` | Valkey 8 (Red Hat RHEL10) |
-| `registry.redhat.io/openshift4/ose-cli-rhel9:v4.17` | OCP CLI for TLS certificate hook Jobs |
-
-#### Automated image list
-
-Use the included script to extract the exact images from the chart templates:
+All published under `quay.io/kubernaut-ai/` with a tag matching the chart version. Use the included script to extract the exact images:
 
 ```bash
 ./hack/airgap/generate-image-list.sh \
@@ -360,58 +1400,13 @@ Use the included script to extract the exact images from the chart templates:
 
 ### Step 2: Mirror images
 
-Prepare the `ImageSetConfiguration`:
-
 ```bash
 cp hack/airgap/imageset-config.yaml.tmpl imageset-config.yaml
 sed -i 's/<VERSION>/{{ image_tag }}/g' imageset-config.yaml
-```
 
-The resulting file lists every image under `mirror.additionalImages`:
-
-```yaml
-kind: ImageSetConfiguration
-apiVersion: mirror.openshift.io/v1alpha2
-storageConfig:
-  local:
-    path: ./kubernaut-mirror
-mirror:
-  additionalImages:
-    - name: quay.io/kubernaut-ai/gateway:{{ image_tag }}
-    - name: quay.io/kubernaut-ai/datastorage:{{ image_tag }}
-    # ... all Kubernaut services ...
-    - name: quay.io/kubernaut-ai/db-migrate:{{ image_tag }}
-    - name: registry.redhat.io/rhel10/postgresql-16
-    - name: registry.redhat.io/rhel10/valkey-8
-    - name: registry.redhat.io/openshift4/ose-cli-rhel9:v4.17
-```
-
-Run the mirror:
-
-```bash
 oc mirror --config=imageset-config.yaml \
   docker://<mirror-registry>
 ```
-
-!!! tip "Alternative: skopeo"
-    For individual images (nested registry):
-
-    ```bash
-    skopeo copy \
-      docker://quay.io/kubernaut-ai/gateway:{{ image_tag }} \
-      docker://harbor.corp/kubernaut-ai/gateway:{{ image_tag }}
-    ```
-
-    `oc mirror` is preferred because it processes all images in one pass and preserves multi-arch manifests.
-
-!!! warning "OCP internal registry and multi-arch images"
-    The OCP integrated registry does not support multi-arch manifest pushes via `skopeo copy --all` (returns HTTP 500). When mirroring to the OCP internal registry with skopeo, use single-arch copies:
-
-    ```bash
-    skopeo copy --override-arch=amd64 --override-os=linux \
-      docker://quay.io/kubernaut-ai/gateway:{{ image_tag }} \
-      docker://<ocp-registry>/kubernaut-system/kubernaut-ai-gateway:{{ image_tag }}
-    ```
 
 ### Step 3: Configure the global pull secret
 
@@ -441,8 +1436,6 @@ kubectl create secret generic llm-credentials \
   -n kubernaut-system
 ```
 
-See the [secret provisioning](../getting-started/installation.md#2-provision-secrets) reference for the full secret schema.
-
 #### Edit the air-gap overlay
 
 Replace every `<mirror-registry>` placeholder in `values-airgap.yaml`:
@@ -452,56 +1445,7 @@ sed -i 's/<mirror-registry>/mirror.corp.example.com:5000/g' \
   charts/kubernaut/values-airgap.yaml
 ```
 
-The overlay overrides all image references:
-
-```yaml
-global:
-  image:
-    registry: <mirror-registry>
-    namespace: kubernaut-ai
-    separator: "/"   # use "-" for flat registries (quay.io, Docker Hub)
-
-postgresql:
-  image: <mirror-registry>/rhel10/postgresql-16
-
-valkey:
-  image: <mirror-registry>/rhel10/valkey-8
-
-hooks:
-  tlsCerts:
-    image: <mirror-registry>/openshift4/ose-cli-rhel9:v4.17
-```
-
-The `separator` field controls how the namespace is joined to the service name:
-
-| Separator | Result for gateway | Compatible registries |
-|---|---|---|
-| `/` (default) | `<mirror>/kubernaut-ai/gateway:tag` | Harbor, Artifactory, generic Docker v2 |
-| `-` | `<mirror>/kubernaut-ai-gateway:tag` | quay.io, Docker Hub, OCP internal |
-
 #### Install
-
-The two overlay files must be layered in this order:
-
-| Order | File | Purpose |
-|---|---|---|
-| 1 | `values-ocp.yaml` | Red Hat images, OCP monitoring endpoints |
-| 2 | `values-airgap.yaml` | Overrides all image refs to point at your mirror registry |
-
-!!! important "Layering order"
-    `values-airgap.yaml` **must** come after `values-ocp.yaml`. It overrides the `registry.redhat.io` image references with your mirror registry.
-
-Prepare your SDK config file with the local LLM endpoint (see [Kubernaut Agent SDK Config](../user-guide/configmap-kubernaut-agent.md)):
-
-```yaml
-# my-sdk-config.yaml
-llm:
-  provider: ollama
-  model: llama3
-  endpoint: http://ollama.internal.svc:11434
-```
-
-Install:
 
 ```bash
 helm install kubernaut charts/kubernaut/ \
@@ -511,65 +1455,127 @@ helm install kubernaut charts/kubernaut/ \
   --set-file kubernautAgent.sdkConfigContent=my-sdk-config.yaml
 ```
 
+!!! important "Layering order"
+    `values-airgap.yaml` **must** come after `values-ocp.yaml`. It overrides the `registry.redhat.io` image references with your mirror registry.
+
 ### Step 5: Verify
 
 ```bash
 kubectl get pods -n kubernaut-system
 ```
 
-All pods should reach `1/1 Running` within a few minutes. If any pod is stuck in `ImagePullBackOff`, see [Troubleshooting](#troubleshooting).
+All pods should reach `1/1 Running` within a few minutes.
 
 ---
 
 ## Troubleshooting
 
-### Image pull errors
-
-If any pod is stuck in `ImagePullBackOff` or `ErrImagePull`:
+### ImagePullBackOff
 
 ```bash
 oc describe pod <pod-name> -n kubernaut-system | grep -A5 "Events:"
+oc get pod <pod-name> -n kubernaut-system -o jsonpath='{.spec.containers[0].image}'
 ```
 
 Common causes:
 
-- Image not mirrored — re-run `oc-mirror`
-- Mirror credentials missing from global pull secret
-- IDMS not applied (operator path) or typo in `values-airgap.yaml` (Helm path)
+- Image not mirrored — re-run `oc mirror`
+- Mirror credentials not in global pull secret
+- IDMS not applied — run `oc apply -f oc-mirror-workspace/results-*/`
+- Verify IDMS: `oc get imagedigestmirrorset`
 
-Verify the actual image reference:
+### API Frontend CrashLoopBackOff with kagenti sidecar
+
+If the AF pod shows `CrashLoopBackOff` after the first 1-2 restarts, this is normal — the AF starts before envoy is ready, causing transient K8s API connection failures. It self-heals after 2-3 restarts.
+
+If it persists, check:
+
+- `oc logs -c envoy-proxy` for authbridge errors
+- `oc logs -c apifrontend` for application errors
+- SCC is correctly configured ([Step 5.2](#52-securitycontextconstraints))
+- kagenti ConfigMaps exist
+
+### 401 Unauthorized — "invalid token audience" {: #troubleshoot-401 }
+
+The API Frontend validates the JWT `aud` claim against `spec.apiFrontend.auth.audience`. A 401 with `"invalid token audience"` means the token's `aud` array does not contain the expected audience string.
+
+**Diagnosis:**
 
 ```bash
-oc get pod <pod-name> -n kubernaut-system \
-  -o jsonpath='{.spec.containers[0].image}'
+oc logs <af-pod> -c envoy-proxy | grep -E "authorized|rejected"
+oc logs <af-pod> -c apifrontend | grep "auth failed"
 ```
 
-### Verifying IDMS is active (operator path)
+**Common causes and fixes:**
+
+1. **CR audience does not match Keycloak realm URL.** Tokens issued by the `kagenti` client have the realm issuer URL in `aud` by default. Set the CR audience to the realm URL:
+
+    ```bash
+    oc patch kubernaut kubernaut -n kubernaut-system --type merge -p '{
+      "spec": {"apiFrontend": {"auth": {"audience": "https://<keycloak-host>/realms/kagenti"}}}
+    }'
+    ```
+
+2. **Missing audience mapper.** If you prefer a specific audience string, add an `oidc-audience-mapper` protocol mapper to the `kagenti` client.
+
+3. **Missing `groups` client scope.** Without it, the authwebhook's SAR cannot match OIDC groups to ClusterRoleBindings:
+
+    ```bash
+    echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq '.groups'
+    ```
+
+    If `groups` is null, add the `groups` client scope as a default scope to the Keycloak client.
+
+4. **AF pod not restarted after CR patch.** The AF reads config at startup. After patching the CR, delete the AF pod:
+
+    ```bash
+    oc delete pod -n kubernaut-system -l app=apifrontend
+    ```
+
+### 401 Unauthorized — Missing tool persona RBAC bindings
+
+If tool calls return 403/401 after token validates, add `roleBindings` to the CR:
+
+```yaml
+spec:
+  apiFrontend:
+    rbac:
+      roleBindings:
+      - role: sre
+        groups: ["platform-engineering"]
+      - role: ai-orchestrator
+        groups: ["platform-engineering"]
+```
+
+Verify CRBs are created:
+
+```bash
+oc get clusterrolebinding -l app.kubernetes.io/part-of=kubernaut | grep tool
+```
+
+### PostgreSQL data loss after pod restart (emptyDir)
+
+If Data Storage fails with `ERROR: relation "audit_events" does not exist` after a PostgreSQL pod restart, the database was using `emptyDir` and all data was lost.
+
+**Fix:** Provision PVCs as described in [Step 3.3](#step-33-provision-persistent-storage). After mounting the PVC, delete and re-create the Kubernaut CR to re-run migrations.
+
+### Migration Job Failure
+
+```bash
+oc logs job/kubernaut-db-migration -n kubernaut-system
+```
+
+Common causes:
+
+- **`configmap "kubernaut-migrations" not found`**: The operator creates this during reconciliation. Ensure the Kubernaut CR has been reconciled first.
+- **`secret "postgresql-secret" not found`**: Create the secret before the CR. Required keys: `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`.
+- **SSL errors**: Check `spec.postgresql.sslMode` matches the PostgreSQL server configuration.
+
+### Verifying IDMS is active
 
 ```bash
 oc get imagedigestmirrorset
-oc get imagedigestmirrorset kubernaut-mirror -o yaml
-```
-
-Verify CRI-O is applying the redirect:
-
-```bash
 oc debug node/<node-name> -- chroot /host crictl pull quay.io/kubernaut-ai/gateway@sha256:<digest> 2>&1
-```
-
-### Migration Job fails connecting to PostgreSQL
-
-If the db-migration Job logs show connection errors, check that your BYO PostgreSQL is reachable from the cluster and the secret credentials are correct:
-
-```bash
-oc logs job/db-migration -n kubernaut-system
-```
-
-### Verifying mirror registry contents
-
-```bash
-skopeo list-tags docker://<mirror-registry>/kubernaut-ai/gateway
-skopeo inspect docker://<mirror-registry>/kubernaut-ai/gateway:{{ image_tag }}
 ```
 
 ---
@@ -580,27 +1586,15 @@ skopeo inspect docker://<mirror-registry>/kubernaut-ai/gateway:{{ image_tag }}
 
 ```mermaid
 flowchart LR
-    A["Bastion host"] -->|"oc-mirror<br/>(catalog + relatedImages)"| B["Mirror registry"]
-    B -->|"IDMS + CatalogSource"| C["OCP cluster"]
-    C -->|"OperatorHub install<br/>+ Kubernaut CR"| D["Kubernaut running"]
+    A["Bastion host"] -->|"oc-mirror"| B["Mirror registry"]
+    B -->|"IDMS + CatalogSource/Manifest"| C["OCP cluster"]
+    C -->|"Install operator + Kubernaut CR"| D["Kubernaut running"]
 ```
 
-1. **Mirror** the operator catalog — `oc-mirror` discovers and mirrors all 17 images automatically
-2. **Apply** the generated IDMS and CatalogSource on the disconnected cluster
+1. **Mirror** all images (OLM catalog auto-discovery or manual ImageSetConfiguration)
+2. **Apply** the generated IDMS on the disconnected cluster
 3. **Configure** the global pull secret with mirror registry credentials
-4. **Install** the operator from OperatorHub and create the Kubernaut CR
-5. **Verify** pods are running and pulling from the mirror registry
-
-### Helm (Dev/Testing)
-
-```mermaid
-flowchart LR
-    A["Bastion host"] -->|"oc mirror<br/>(manual image list)"| B["Mirror registry"]
-    B -->|"global pull secret"| C["OCP cluster"]
-    C -->|"helm install<br/>values-airgap.yaml"| D["Kubernaut running"]
-```
-
-1. **Mirror** all images using a manually maintained `ImageSetConfiguration`
-2. **Configure** the global pull secret with mirror registry credentials
-3. **Install** the chart layering `values-ocp.yaml` + `values-airgap.yaml`
-4. **Verify** pods are running and pulling from the correct registry
+4. **Install** the operator (OLM or direct manifest) and provision prerequisites
+5. **Create** the Kubernaut CR with environment-specific values
+6. **Integrate** kagenti for A2A/SPIRE (if applicable)
+7. **Verify** pods are running and pulling from the mirror registry

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,9 +37,9 @@ theme:
     - toc.integrate
 
 extra:
-  chart_version: "1.5.0-rc2"
-  image_tag: "v1.5.0"
-  operator_image_tag: "1.5.0-rc2"
+  chart_version: "1.5.1"
+  image_tag: "v1.5.1"
+  operator_image_tag: "1.5.1"
   version:
     provider: mike
     default: latest


### PR DESCRIPTION
## Summary

Incorporates the validated air-gapped installation gist (operator v1.5.1) into the documentation and updates cross-cutting references across multiple pages.

- **Disconnected install overhaul** — Full rewrite of `disconnected-install.md` with both OLM and direct-manifest (non-OLM) installation paths, complete image digest inventory (17 images), PostgreSQL TLS configuration, BYO PostgreSQL/Valkey deployment manifests, Rego policy ConfigMaps, kagenti/SPIRE integration steps, Keycloak OIDC setup, OCP AlertManager configuration, demo workflow seeding, comprehensive LLM provider reference table (9 KA providers, 3 AF providers), and troubleshooting section.
- **Installation guide** — Added PostgreSQL TLS requirement note, LLM provider cross-reference, `roleBindings` configuration for tool RBAC, OCP AlertManager pointer, and demo seeding instructions.
- **Operator CR reference** — Added new API Frontend fields: `jwksURL`, `allowInsecureIssuers`, `APIFrontendSPIRESpec`, `APIFrontendRouteSpec`, and `toolCallsPerMinute` rate limit parameter.
- **Security & RBAC** — Added Keycloak OIDC configuration section: `groups` client scope with group-membership mapper, SPIFFE audience mapper, and stale token warning with diagnostic steps.
- **Version bump** — Updated `chart_version`, `image_tag`, and `operator_image_tag` to `1.5.1` in `mkdocs.yml` and `KUBERNAUT_RELEASE` in the deploy workflow.

## Test plan

- [x] `mkdocs build --strict` passes with no warnings
- [ ] Browse locally with `mkdocs serve` and verify:
  - [ ] Disconnected install guide renders correctly (OLM, direct manifest, Helm sections)
  - [ ] All internal cross-references resolve (PG TLS, LLM config, AlertManager, demo seeding)
  - [ ] Operator CR reference table renders new fields
  - [ ] Security & RBAC Keycloak section renders correctly
  - [ ] Version macros resolve to `v1.5.1` / `1.5.1` throughout


Made with [Cursor](https://cursor.com)