### PR TITLE
docs: v1.5.1 release documentation

### DIFF
--- a/docs/api-reference/apifrontend-api.md
+++ b/docs/api-reference/apifrontend-api.md
@@ -66,7 +66,7 @@ Returns `501` when MCP is disabled in the AF configuration.
 }
 ```
 
-The AF runs its own MCP server with **21 `kubernaut_*` MCP tools** exposed on the MCP bridge (see [MCP Tool Reference](mcp-tools.md) for the full list). Each tool dispatches to its backend: K8s API (CRD operations), KA MCP (workflow selection/discovery and interactive session lifecycle), DataStorage (analytics), or local (presentation). Five additional internal tools (`kubectl_get`, `kubectl_list`, `kubectl_list_events`, `kubernaut_check_existing_remediation`, `kubernaut_remediate`) are used only inside the A2A agent loop and are not exposed on the MCP bridge.
+The AF runs its own MCP server with **23 `kubernaut_*` MCP tools** exposed on the MCP bridge (see [MCP Tool Reference](mcp-tools.md) for the full list). Each tool dispatches to its backend: K8s API (CRD operations), KA MCP (workflow selection/discovery and interactive session lifecycle), DataStorage (analytics), or local (presentation). Five additional internal tools (`kubectl_get`, `kubectl_list`, `kubectl_list_events`, `kubernaut_check_existing_remediation`, `kubernaut_remediate`) are used only inside the A2A agent loop and are not exposed on the MCP bridge.
 
 ### A2A JSON-RPC 2.0
 
@@ -77,13 +77,14 @@ POST /                  # root alias — same handler
 
 Agent-to-Agent protocol endpoint accepting JSON-RPC 2.0 messages. Supported methods include `message/send`. Requires Bearer JWT authentication. `POST /` is an alias for `POST /a2a/invoke`, providing A2A spec conformance for clients that expect the root path.
 
-The A2A agent uses **21 SAR-gated `kubernaut_*` MCP tools** exposed on the MCP bridge, plus 5 internal tools, organized in six domains:
+The A2A agent uses **23 SAR-gated `kubernaut_*` MCP tools** exposed on the MCP bridge, plus 5 internal tools, organized in seven domains:
 
 | Domain | Tools | Backend |
 |---|---|---|
 | **CRD operations** | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_approve`, `kubernaut_cancel_remediation`, `kubernaut_watch`, `kubernaut_list_approval_requests`, `kubernaut_get_approval_request`, `kubernaut_await_session` | K8s API (AF SA) |
-| **Investigation & session lifecycle** | `kubernaut_investigate`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect` | KA MCP |
+| **Investigation & session lifecycle** | `kubernaut_investigate`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_complete_no_action`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect` | KA MCP |
 | **Workflow** | `kubernaut_discover_workflows`, `kubernaut_select_workflow` | KA MCP |
+| **Alerts** | `kubernaut_list_alerts` (conditional on Prometheus) | Prometheus |
 | **Data & history** | `kubernaut_list_workflows`, `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail` | DataStorage REST |
 | **Presentation** | `kubernaut_present_decision` | Local |
 
@@ -105,6 +106,62 @@ The AF's A2A agent also uses **5 internal tools** that are SAR-gated but not exp
 All internal tools use the AF ServiceAccount ([unified SA model](../architecture/security-rbac.md#unified-sa-model)) and are SAR-gated on the A2A path via `newRBACGuard()`.
 
 When `severityTriage.enabled: true` and a Prometheus URL is configured, 3 additional alert tools are registered: `list_alerts`, `get_alert_details`, `kubernaut_investigate_alert`. See [MCP Tool Reference — Alert tools](mcp-tools.md#alert-tools).
+
+### Status SSE (v1.5.1) {: #status-sse-v151 }
+
+```
+POST /a2a/status
+```
+
+Real-time remediation status streaming endpoint (DD-AF-008). Clients subscribe to phase transitions for a specific RemediationRequest via a JSON-RPC 2.0 request body.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "status/subscribe",
+  "params": { "rr_id": "rr-abc-123" }
+}
+```
+
+**Response:** `Content-Type: text/event-stream` with `Cache-Control: no-cache`, `Connection: keep-alive`, `X-Accel-Buffering: no`.
+
+**SSE event types:**
+
+| Event | Purpose | Payload |
+|---|---|---|
+| `status/update` | Emitted on subscribe (current state) and on each RR phase transition | `rr_id`, `phase`, `timestamp`, `final` (bool), `metadata` (optional) |
+| `status/closing` | Emitted 5 seconds before token expiry | `reason` (e.g. `token_expiry`), `reconnect` (bool, always `true`) |
+
+**Wire format example:**
+
+```
+event: status/update
+data: {"jsonrpc":"2.0","method":"status/update","params":{"rr_id":"rr-abc-123","phase":"Verifying","timestamp":"2026-06-18T15:10:00Z","final":false}}
+
+: heartbeat (every 15s)
+
+event: status/closing
+data: {"jsonrpc":"2.0","method":"status/closing","params":{"reason":"token_expiry","reconnect":true}}
+```
+
+**Authentication:** Same OIDC bearer token chain as `/mcp` and `/a2a/invoke`. No per-resource SAR — all authenticated users can subscribe.
+
+**Keepalive:** `": "` comment line every 15 seconds to keep TCP alive.
+
+**Auto-reconnect:** The handler automatically reconnects the underlying `controller-runtime` watch if the watch channel closes (server-side timeout). Clients should reconnect with a fresh token when they receive `status/closing` with `reconnect: true`.
+
+**Error codes:**
+
+| Code | Meaning |
+|---|---|
+| `-32600` | Invalid request (bad JSON / unparseable body) |
+| `-32601` | Method not found (method is not `status/subscribe`) |
+| `-32602` | Invalid params (`rr_id` is empty) |
+| `-32001` | RR not found in the cluster |
+| `-32002` | Access denied (reserved) |
 
 ### A2A Streaming Events {: #a2a-streaming-events }
 

--- a/docs/api-reference/crds.md
+++ b/docs/api-reference/crds.md
@@ -30,7 +30,7 @@ _Appears in:_
 - [AIAnalysisStatus](#aianalysisstatus)
 
 _Validation:_
-- Enum: [AnalysisCompleted WorkflowResolutionFailed WorkflowNotNeeded NoWorkflowSelected RegoEvaluationError TransientError APIError]
+- Enum: [AnalysisCompleted WorkflowResolutionFailed WorkflowNotNeeded NoWorkflowSelected RegoEvaluationError TransientError APIError InteractiveCancelled ParentCancelled]
 
 | Value| Description|
 | ---| ---|
@@ -41,6 +41,8 @@ _Validation:_
 | `RegoEvaluationError`||
 | `TransientError`||
 | `APIError`||
+| `InteractiveCancelled`| Interactive session was cancelled by the operator (v1.5.1)|
+| `ParentCancelled`| Parent RemediationRequest entered a terminal phase, cascading cancellation to this AIAnalysis (v1.5.1)|
 
 
 ### AIAnalysisSpec
@@ -82,7 +84,7 @@ _Appears in:_
 | `phase`| _string_| Phase tracking (no "Approving" or "Recommending" phase - simplified 4-phase flow)|
 | `message`| _string_||
 | `reason`| _[AIAnalysisReason](#aianalysisreason)_| Reason provides the umbrella failure or completion category.|
-| `subReason`| _string_| SubReason provides specific failure cause within the Reason category<br /> Maps to needs_human_review triggers from KA<br /> Added InvestigationInconclusive, ProblemResolved for new investigation outcomes|
+| `subReason`| _string_| SubReason provides specific failure cause within the Reason category<br /> Maps to needs_human_review triggers from KA<br /> Added InvestigationInconclusive, ProblemResolved for new investigation outcomes<br /> v1.5.1: `OperatorEscalation` added for escalation via `kubernaut_complete_no_action`|
 | `startedAt`| _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#time-v1-meta)_| Timestamps|
 | `completedAt`| _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#time-v1-meta)_||
 | `rootCause`| _string_| Identified root cause|
@@ -93,7 +95,7 @@ _Appears in:_
 | `approvalReason`| _string_| Reason why approval is required (when ApprovalRequired=true)|
 | `approvalContext`| _[ApprovalContext](#approvalcontext)_| Rich context for approval notification|
 | `needsHumanReview`| _boolean_| Set by Kubernaut Agent when AI cannot produce reliable result<br />True if human review required (KA decision: RCA incomplete/unreliable)<br /> Triggers NotificationRequest creation in RO<br />BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.|
-| `humanReviewReason`| _string_| Reason why human review needed (when NeedsHumanReview=true)<br /> Maps to KA's human_review_reason enum values<br /> alignment_check_failed added for shadow agent alignment verdicts|
+| `humanReviewReason`| _string_| Reason why human review needed (when NeedsHumanReview=true)<br /> Maps to KA's human_review_reason enum values<br /> alignment_check_failed added for shadow agent alignment verdicts<br /> v1.5.1: `operator_escalation` added for escalation via `kubernaut_complete_no_action`|
 | `alignmentVerdict`| _[AlignmentVerdictStatus](#alignmentverdictstatus)_| Shadow agent alignment verdict from KA (#1076).<br />When CircuitBreakerActivated=true, the investigation was terminated early<br />and LLM results (RootCauseAnalysis, SelectedWorkflow) may be incomplete<br />or compromised. Users should treat shadow findings as the primary content.|
 | `actionability`| _string_| #388: LLM's assessment of whether the alert warrants action.<br />Empty when not yet assessed (pre-investigation or error paths).<br />"Actionable" when the LLM determines the alert warrants action (default for all processed alerts).<br />"NotActionable" when the LLM determines the alert is benign (e.g., orphaned PVCs).|
 | `investigationId`| _string_| KA investigation ID for correlation|

--- a/docs/api-reference/mcp-tools.md
+++ b/docs/api-reference/mcp-tools.md
@@ -1,13 +1,13 @@
 # MCP Tool Reference
 
-The API Frontend exposes **21 `kubernaut_*` MCP tools** on its Streamable HTTP endpoint (`POST /mcp`).
+The API Frontend exposes **23 `kubernaut_*` MCP tools** on its Streamable HTTP endpoint (`POST /mcp`).
 Each tool is SAR-gated via [per-persona ClusterRoles](../architecture/security-rbac.md#per-persona-clusterroles), rate-limited, and audit-logged.
 
 All tools return JSON in MCP `CallToolResult` text content. Default timeout is 30 s (configurable per tool).
 RBAC is fail-closed — SAR errors deny the call.
 
 !!! info "Conditional tool surface (#1366)"
-    When [`interactive.enabled`](../user-guide/configuration.md) is `false`, **10 session-dependent tools** are hidden from MCP `tools/list` and the A2A agent, leaving **11 stateless tools** (CRD operations + data/history). Hidden tools: `kubernaut_investigate`, `kubernaut_discover_workflows`, `kubernaut_select_workflow`, `kubernaut_present_decision`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect`, `kubernaut_await_session`.
+    When [`interactive.enabled`](../user-guide/configuration.md) is `false`, **11 session-dependent tools** are hidden from MCP `tools/list` and the A2A agent, leaving **12 stateless tools** (CRD operations + data/history); 13 with `kubernaut_list_alerts` if Prometheus is configured. Hidden tools: `kubernaut_investigate`, `kubernaut_discover_workflows`, `kubernaut_select_workflow`, `kubernaut_present_decision`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_complete_no_action`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect`, `kubernaut_await_session`.
 
 !!! tip "Building skills on Kubernaut tools"
     When authoring MCP skills or prompts that call these tools, use the **"When to use"** guidance below each tool to select the right one.
@@ -204,7 +204,10 @@ Backend: **K8s API** (AF ServiceAccount) — operates on `kubernaut.ai/v1alpha1/
     - `reason` (`string`) — Decision rationale (stored as `status.decisionMessage`)
     - `workflow_override` (`string`) — Override workflow (stored as `status.workflowOverride.workflowName`)
 
-    **When to use:** Final step in the approval flow after reviewing the RAR with `kubernaut_get_approval_request`. Always provide a `reason` for audit trail traceability.
+    !!! warning "MCP bridge only (DD-AF-006, v1.5.1)"
+        `kubernaut_approve` is **structurally absent** from the A2A agent's `buildToolList()` as of v1.5.1. It remains on the MCP bridge for the Kubernaut Console's Approve/Reject buttons. This prevents an LLM from autonomously approving RARs via prompt injection, preserving the human consent gate. Defense-in-depth: (1) tool absent from agent, (2) explicit prompt instruction, (3) SAR RBAC on MCP, (4) audit trail.
+
+    **When to use:** Final step in the approval flow after reviewing the RAR with `kubernaut_get_approval_request`. Always provide a `reason` for audit trail traceability. Must be called via the MCP bridge (Console or direct MCP client) — not available to the A2A agent.
 
     ??? example "Response"
         ```json
@@ -335,6 +338,27 @@ All interactive tools share a common response shape:
     - `message` (`string`) — Optional message
 
     **When to use:** Resume a session after a network disconnect or client restart. Check status with `kubernaut_status` first.
+
+    **Personas:** SRE, AI Orchestrator
+
+---
+
+- **`kubernaut_complete_no_action`** — Complete an investigation with no remediation action {: #complete-no-action }
+
+    Backend: **KA MCP**
+
+    - `rr_id` (`string`) **(required)** — Remediation request ID
+    - `escalation_reason` (`string`) — If provided, the investigation is escalated to operator review instead of dismissed
+
+    Two behavior paths based on `escalation_reason`:
+
+    - **Absent** — dismiss: `IsActionable=false`, `HumanReviewNeeded=false`, status set to `completed_no_action`
+    - **Present** — escalate: `HumanReviewNeeded=true`, `HumanReviewReason=operator_escalation`, status set to `escalated`. The Remediation Orchestrator creates a `ManualReviewRequired` and sends a `NotificationRequest` to the `ops-escalation-channel`.
+
+    !!! note "MCP bridge only"
+        This tool is available on the MCP bridge but is **not** registered in the A2A agent's `buildToolList()` (DD-AF-007). The Console uses it for its dismiss and escalation buttons.
+
+    **When to use:** End an investigation when no automated remediation is appropriate — either dismiss (alert self-resolved or false positive) or escalate (requires human expertise beyond Kubernaut's scope).
 
     **Personas:** SRE, AI Orchestrator
 
@@ -547,6 +571,73 @@ Backend: **DataStorage** — queries the Kubernaut DataStorage service.
 
 ---
 
+## Alerts {: #alerts }
+
+Backend: **Prometheus** (AF ServiceAccount) — queries the configured Prometheus endpoint.
+
+!!! info "Conditional registration"
+    Alert tools are only registered when `severityTriage.enabled: true` and a Prometheus URL is configured via `severityTriage.prometheusURL`. When Prometheus is not configured, these tools do not appear in `tools/list`.
+
+- **`kubernaut_list_alerts`** — Query firing Prometheus alerts with optional filters
+
+    - `namespace` (`string`) — Filter by namespace
+    - `severity` (`string`) — Filter by severity (`critical`, `high`, `medium`, `low`, `info`, `warning`)
+    - `state` (`string`) — Filter by alert state (`firing`, `pending`)
+
+    Returns a `ListAlertsResult` with `alerts[]` (sorted by severity descending, then `active_at` ascending FIFO), `count`, `total_count`, `truncated`, and `prioritized` (index-based priority metadata). Sensitive label keys (`password`, `token`, `secret`, `key`, `credential`, `bearer`) are stripped. URLs and IPs in label/annotation values are redacted (FedRAMP SI-10). If the serialized response exceeds the max tool output size, alerts are trimmed from the tail (lowest priority) and `truncated` is set to `true`.
+
+    **When to use:** Discover active alerts before starting an investigation. Use severity and namespace filters to narrow results.
+
+    ??? example "Response"
+        ```json
+        {
+          "alerts": [
+            {
+              "labels": {
+                "alertname": "KubePodCrashLooping",
+                "namespace": "production",
+                "severity": "critical",
+                "pod": "api-server-xyz",
+                "container": "api"
+              },
+              "annotations": {
+                "summary": "Pod production/api-server-xyz is crash looping",
+                "runbook_url": "[URL_REDACTED]"
+              },
+              "state": "firing",
+              "active_at": "2026-06-18T14:30:00Z"
+            },
+            {
+              "labels": {
+                "alertname": "KubeDeploymentReplicasMismatch",
+                "namespace": "production",
+                "severity": "warning",
+                "deployment": "api-server"
+              },
+              "annotations": {
+                "summary": "Deployment production/api-server has 0/2 replicas ready"
+              },
+              "state": "firing",
+              "active_at": "2026-06-18T14:31:00Z"
+            }
+          ],
+          "count": 2,
+          "total_count": 2,
+          "truncated": false,
+          "prioritized": {
+            "selected_index": 0,
+            "tied_indices": [],
+            "also_active_start": 1
+          }
+        }
+        ```
+
+        **`prioritized` fields**: `selected_index` is the highest-severity, longest-firing alert. `tied_indices` lists other alerts at the same severity. `also_active_start` is the array index where lower-severity alerts begin.
+
+    **Personas:** SRE
+
+---
+
 ## Common UX Flows
 
 ### Approval flow
@@ -603,8 +694,9 @@ kubernaut_list_remediations()
 | Backend | Tools |
 |---------|-------|
 | **K8s API** (AF SA) | `list_remediations`, `get_remediation`, `cancel_remediation`, `watch`, `approve`, `list_approval_requests`, `get_approval_request`, `await_session` |
-| **KA MCP** | `investigate`, `message`, `complete`, `cancel`, `status`, `reconnect`, `discover_workflows`, `select_workflow` |
+| **KA MCP** | `investigate`, `message`, `complete`, `complete_no_action`, `cancel`, `status`, `reconnect`, `discover_workflows`, `select_workflow` |
 | **DataStorage** | `list_workflows`, `get_remediation_history`, `get_effectiveness`, `get_audit_trail` |
+| **Prometheus** | `list_alerts` (conditional on `severityTriage.enabled`) |
 | **Local** | `present_decision` |
 
 ---
@@ -631,11 +723,12 @@ All tool names below are prefixed with `kubernaut_`.
 | `cancel` | :material-check: | :material-check: | | | | |
 | `status` | :material-check: | :material-check: | | | | |
 | `reconnect` | :material-check: | :material-check: | | | | |
-| `takeover` | :material-check: | :material-check: | | | | |
+| `complete_no_action` | :material-check: | :material-check: | | | | |
 | `discover_workflows` | :material-check: | :material-check: | | | | |
 | `select_workflow` | :material-check: | :material-check: | | | | |
 | `present_decision` | :material-check: | :material-check: | | | | |
 | `list_workflows` | :material-check: | | | :material-check: | :material-check: | |
+| `list_alerts` | :material-check: | | | | | |
 | `get_remediation_history` | :material-check: | | | | :material-check: | |
 | `get_effectiveness` | :material-check: | | | :material-check: | :material-check: | |
 | `get_audit_trail` | :material-check: | | | | :material-check: | |

--- a/docs/api-reference/operator-cr.md
+++ b/docs/api-reference/operator-cr.md
@@ -45,6 +45,7 @@ The `Kubernaut` custom resource (`kubernaut.ai/v1alpha1`) is the single deployme
 | `apiFrontend` | [APIFrontendSpec](#apifrontendspec) | enabled | MCP/A2A gateway, OIDC auth, SAR-based tool authorization (v1.5+) |
 | `authWebhook` | AuthWebhookSpec | — | Logging, resources |
 | `dataStorage` | [DataStorageSpec](#datastoragespec) | — | Endpoint propagation delay, retention, logging, resources |
+| `console` | [ConsoleSpec](#consolespec) | disabled | Kubernaut Console deployment (v1.5.1) |
 | `networkPolicies` | [NetworkPoliciesSpec](#networkpoliciesspec) | disabled | Kubernetes NetworkPolicy creation |
 
 ---
@@ -81,6 +82,7 @@ The `Kubernaut` custom resource (`kubernaut.ai/v1alpha1`) is the single deployme
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `llm` | [LLMSpec](#llmspec) | **yes** | — | Primary LLM configuration |
+| `interactive` | [InteractiveSpec](#interactivespec) | no | — | Interactive session configuration including JWT providers (v1.5.1) |
 | `maxTurns` | int | no | `40` | Max tool-call turns per investigation (min: 1) |
 | `session` | SessionSpec | no | — | Session TTL configuration |
 | `audit` | AuditSpec | no | enabled | Audit event logging |
@@ -109,6 +111,25 @@ The `Kubernaut` custom resource (`kubernaut.ai/v1alpha1`) is the single deployme
 | `tlsCaFile` | string | no | — | Custom CA certificate file path |
 | `oauth2` | OAuth2Spec | no | — | OAuth2 client credentials flow |
 | `runtimeConfigMapName` | string | no | — | BYO hot-reloadable ConfigMap name (key: `llm-runtime.yaml`) |
+| `phaseModels` | map[string][LLMPhaseOverrideSpec](#llmphaseoverridespec) | no | — | Per-phase LLM overrides (v1.5.1). Keys must be `rca`, `workflow_discovery`, or `validation` (CEL-validated). |
+
+### LLMPhaseOverrideSpec (v1.5.1) {: #llmphaseoverridespec }
+
+| Field | Type | Description |
+|---|---|---|
+| `provider` | string | Override LLM provider for this phase |
+| `model` | string | Override model name |
+| `endpoint` | string | Override endpoint URL |
+| `apiKey` | string | Override API key |
+
+See [Per-phase LLM routing](../user-guide/configmap-kubernaut-agent.md#per-phase-llm-routing-v151) for usage details and YAML examples.
+
+### InteractiveSpec (v1.5.1) {: #interactivespec }
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `false` | Enable interactive MCP sessions |
+| `jwtProviders` | [][JWTProviderSpec](#jwtproviderspec) | — | Trusted JWT issuers for interactive session authentication |
 
 ### AlignmentCheckSpec
 
@@ -217,12 +238,27 @@ The `Kubernaut` custom resource (`kubernaut.ai/v1alpha1`) is the single deployme
 | `jwtProviders` | [][JWTProviderSpec](#jwtproviderspec) | — | One or more OIDC JWT providers |
 | `allowInsecureJWKS` | bool | `false` | Permit HTTP JWKS URLs for dev/test. **Must be `false` in production.** |
 
-### JWTProviderSpec {: #jwtproviderspec }
+### JWTProviderSpec (v1.5.1) {: #jwtproviderspec }
+
+Used at `spec.kubernautAgent.interactive.jwtProviders[]` and `spec.apiFrontend.auth.jwtProviders[]`.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | **yes** | Human-readable provider name (1--63 chars, must be unique) |
+| `issuerURL` | string | **yes** | OIDC issuer URL -- must match the `iss` claim in tokens |
+| `jwksURL` | string | no | JWKS endpoint URL (max 2048 chars). Falls back to `issuerURL` for OIDC discovery if omitted. Must use HTTPS unless `allowInsecureJWKS` is true. |
+| `audiences` | []string | **yes** | Expected JWT audience claims (min 1 entry). Tokens without a matching `aud` are rejected. |
+| `claimMappings` | [ClaimMappingsSpec](#claimmappingsspec) | no | Custom claim-to-identity field mappings |
+
+### ClaimMappingsSpec {: #claimmappingsspec }
 
 | Field | Type | Description |
 |---|---|---|
-| `name` | string | Human-readable provider name (1–63 chars) |
-| `jwksURL` | string | JWKS endpoint URL. Must use HTTPS unless `allowInsecureJWKS` is true |
+| `username` | string | JWT claim name to extract as username (e.g., `preferred_username`, `email`) |
+| `groups` | string | JWT claim name to extract group membership (e.g., `groups`, `realm_access.roles`). Supports dot-notation for nested claims. |
+
+!!! note "No `uid` field"
+    `ClaimMappingsSpec` supports `username` and `groups` only. There is no `uid` field in the operator CRD.
 
 ### APIFrontendRBACSpec {: #apifrontendrbacspec }
 
@@ -294,6 +330,18 @@ spec:
 | `retention` | RetentionSpec | — | Periodic purge of expired audit events (FedRAMP AU-11) |
 | `logging` | LoggingSpec | — | Log level |
 | `resources` | ResourceRequirements | — | CPU/memory requests and limits |
+
+### ConsoleSpec (v1.5.1) {: #consolespec }
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `enabled` | *bool | no | `false` | Opt-in Kubernaut Console deployment |
+| `auth.secretName` | string | when enabled | — | Pre-existing Secret with keys: `client-id`, `client-secret`, `cookie-secret` for OAuth2 Proxy |
+| `route.enabled` | *bool | no | `true` | Create an OCP Route for the Console |
+| `route.host` | string | no | auto-derived | Custom route hostname. When empty, derived from namespace. |
+| `resources` | ResourceRequirements | no | — | CPU/memory requests and limits for the Console container |
+
+The Console OIDC issuer URL is derived from `spec.apiFrontend.auth.jwtProviders[0].issuerURL`, falling back to `spec.apiFrontend.auth.issuerURL`.
 
 ### NetworkPoliciesSpec
 

--- a/docs/api-reference/operator-cr.md
+++ b/docs/api-reference/operator-cr.md
@@ -269,21 +269,20 @@ Used at `spec.kubernautAgent.interactive.jwtProviders[]` and `spec.apiFrontend.a
 
 ### ToolRoleBinding {: #toolrolebinding }
 
+Exactly one of `role` or `clusterRoleName` must be set. Entries with both or neither are rejected by CR validation.
+
 | Field | Type | Description |
 |---|---|---|
-| `role` | string | Persona name. One of: `sre`, `ai-orchestrator`, `cicd`, `observability`, `l3-audit`, `remediation-approver` |
+| `role` | string | Built-in persona name. One of: `sre`, `ai-orchestrator`, `cicd`, `observability`, `l3-audit`, `remediation-approver`. Mutually exclusive with `clusterRoleName`. |
+| `clusterRoleName` | string | Reference to a **user-managed** ClusterRole for custom tool authorization. The operator creates only the ClusterRoleBinding; the ClusterRole must be pre-created by the user with rules granting verb `use` on resource `tools` in apiGroup `kubernaut.ai`. Mutually exclusive with `role`. |
 | `groups` | []string | OIDC group names to bind to this role (min 1) |
 
-**Example:**
+**Example (built-in personas only):**
 
 ```yaml
 spec:
   apiFrontend:
-    auth:
-      issuerURL: https://dex.kubernaut.svc.cluster.local:5556/dex
-      audience: kubernaut-apifrontend
     rbac:
-      sarCacheTTL: 30s
       roleBindings:
         - role: sre
           groups: ["sre-team", "platform-eng"]
@@ -292,6 +291,25 @@ spec:
         - role: remediation-approver
           groups: ["change-mgmt"]
 ```
+
+**Example (mixed — built-in + custom ClusterRoles):**
+
+```yaml
+spec:
+  apiFrontend:
+    rbac:
+      roleBindings:
+        # Built-in persona: operator manages the ClusterRole
+        - role: sre
+          groups: ["senior-sres"]
+        # User-managed ClusterRole: operator creates only the CRB
+        - clusterRoleName: kubernaut-restricted-investigator
+          groups: ["junior-sres"]
+        - clusterRoleName: kubernaut-readonly-audit
+          groups: ["compliance-team"]
+```
+
+See [Custom ClusterRoles](../architecture/security-rbac.md#custom-clusterroles) for how to create user-managed ClusterRoles with fine-grained tool subsets.
 
 ### APIFrontendRateLimitSpec {: #apifrontendratelimitspec }
 

--- a/docs/architecture/apifrontend.md
+++ b/docs/architecture/apifrontend.md
@@ -11,7 +11,7 @@ The AF sits between external clients and the Kubernaut Engine, handling:
 - **Protocol translation** — MCP tool calls and A2A tasks are translated into internal Kubernaut API calls
 - **Authentication** — OIDC/OAuth2 via JWKS validation with JWT claim extraction
 - **Authorization** — Kubernetes-native SAR-based tool authorization (PR #1222); fail-closed with TTL cache
-- **MCP bridge** — Dispatches 21 `kubernaut_*` MCP tools to their backends (K8s API, KA MCP, DataStorage) with per-tool routing. When `interactive.enabled: false` (#1366), 10 session-dependent tools are hidden, leaving 11 stateless tools for CRD and data operations only.
+- **MCP bridge** — Dispatches 23 `kubernaut_*` MCP tools to their backends (K8s API, KA MCP, DataStorage, Prometheus) with per-tool routing. When `interactive.enabled: false` (#1366), 11 session-dependent tools are hidden, leaving 12 stateless tools for CRD and data operations only (13 with `kubernaut_list_alerts` if Prometheus is configured).
 - **Streaming** — Relays Server-Sent Events from KA's SSE endpoint to MCP clients
 
 ## Agentic Architecture

--- a/docs/architecture/kubernaut-agent-investigation.md
+++ b/docs/architecture/kubernaut-agent-investigation.md
@@ -48,6 +48,9 @@ The Helm chart supports three tiers for providing the SDK config -- see [Configu
 
 In **v1.3** the pipeline uses **two distinct LLM invocations** (new v1.3 architecture, superseding the v1.1 three-phase, single-session design). The sessions do not share model chat memory. The first performs RCA with full tool access; the second performs workflow selection from structured inputs only, then Kubernaut Agent merges results.
 
+!!! info "Per-phase model routing (v1.5.1)"
+    Each invocation can use a **different LLM model** via the `phaseModels` map in the `kubernaut-agent-llm-runtime` ConfigMap. The `EffectivePhaseConfig()` function resolves the model for each phase at runtime — non-empty override fields win, empty fields inherit from the base config. Phase keys: `rca` (Invocation 1), `workflow_discovery` (Invocation 2), `validation` (post-selection). See [Per-phase LLM routing](../user-guide/configmap-kubernaut-agent.md#per-phase-llm-routing-v151).
+
 ```mermaid
 flowchart LR
     I1["Invocation 1: RCA"] -->|structured context| I2["Invocation 2: Workflow selection"]

--- a/docs/architecture/remediation-routing.md
+++ b/docs/architecture/remediation-routing.md
@@ -322,6 +322,7 @@ When a RR reaches a terminal phase:
 
 1. **NotificationRequest** -- Created for `Completed`, `Failed`, and `TimedOut` outcomes. For `Failed`, `transitionToFailed` creates an Escalation NR (`nr-escalation-<rr-name>`) unless a ManualReview or Escalation NR already exists (double-NR guard)
 2. **Duplicate notification** -- If `DuplicateCount > 0`, a bulk notification (`nr-bulk-<rr-name>`) is created for tracked duplicates
+3. **Cascade terminal (v1.5.1)** -- All child resources (AIAnalysis, SignalProcessing, WorkflowExecution) are patched to `PhaseFailed` with message `"Parent RR entered terminal phase: {phase}"`. This ensures children do not continue processing after the parent has terminated. The cascade is idempotent and non-fatal -- patch failures are logged but do not prevent the parent from reaching its terminal state.
 3. **Consecutive failure update** -- `ConsecutiveFailureCount` and `NextAllowedExecution` are updated for backoff calculation
 
 ## Escalation Paths

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -300,6 +300,7 @@ In enforce mode, a positive detection triggers `context.WithCancelCause(ErrCircu
 Shadow agent results are propagated through the system:
 
 - **`alignment_verdict`** field on the Kubernaut Agent `IncidentResponse` (OpenAPI) and `AIAnalysisStatus` (CRD) carrying the verdict (`result`, `circuit_breaker_activated`, `summary`, `findings`)
+- **`aiagent.alignment.verdict` audit event** — emitted by `InvestigatorWrapper.emitVerdictEvent()` after every investigation. Payload includes `result` (`aligned`/`suspicious`), `circuit_breaker_activated`, `summary`, `flagged`/`total` counts, `findings[]`, and optional `grounding_review` (v1.5.1)
 - **NotificationRequest `ReviewContext`** includes `alignmentVerdict` and `circuitBreakerActivated` fields for routing rule support
 - **Manual review notifications** render shadow agent findings prominently when `alignment_check_failed` SubReason escalates to `NotificationPriorityCritical`
 
@@ -394,8 +395,8 @@ The Helm chart ships 6 per-persona ClusterRoles via a data-driven template (`api
 
 | ClusterRole | Persona | MCP Tools | Tool List |
 |---|---|---|---|
-| `kubernaut-tool-sre` | Full investigation + remediation | 19 | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_approve`, `kubernaut_cancel_remediation`, `kubernaut_watch`, `kubernaut_await_session`, `kubernaut_investigate`, `kubernaut_discover_workflows`, `kubernaut_select_workflow`, `kubernaut_present_decision`, `kubernaut_list_workflows`, `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect` |
-| `kubernaut-tool-ai-orchestrator` | Automated agent orchestration (no approval) | 13 | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch`, `kubernaut_await_session`, `kubernaut_investigate`, `kubernaut_discover_workflows`, `kubernaut_select_workflow`, `kubernaut_present_decision`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect` |
+| `kubernaut-tool-sre` | Full investigation + remediation | 21 | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_approve`, `kubernaut_cancel_remediation`, `kubernaut_watch`, `kubernaut_await_session`, `kubernaut_investigate`, `kubernaut_discover_workflows`, `kubernaut_select_workflow`, `kubernaut_present_decision`, `kubernaut_list_workflows`, `kubernaut_list_alerts`, `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_complete_no_action`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect` |
+| `kubernaut-tool-ai-orchestrator` | Automated agent orchestration (no approval) | 15 | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch`, `kubernaut_await_session`, `kubernaut_investigate`, `kubernaut_discover_workflows`, `kubernaut_select_workflow`, `kubernaut_present_decision`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_complete_no_action`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect` |
 | `kubernaut-tool-cicd` | CI/CD pipeline integration | 4 | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch`, `kubernaut_await_session` |
 | `kubernaut-tool-observability` | Read-only observability | 6 | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_watch`, `kubernaut_await_session`, `kubernaut_get_effectiveness`, `kubernaut_list_workflows` |
 | `kubernaut-tool-l3-audit` | Compliance and auditing | 6 | `kubernaut_list_remediations`, `kubernaut_get_remediation`, `kubernaut_list_workflows`, `kubernaut_get_remediation_history`, `kubernaut_get_effectiveness`, `kubernaut_get_audit_trail` |
@@ -457,6 +458,21 @@ All AF Kubernetes API calls use the **AF pod's own ServiceAccount** — there is
 | SEC-02 | K8s audit logs attribute actions to AF SA, not the end user | Application audit trail carries user identity; correlate via `actor_ip` |
 | SEC-04 | AF SA privilege aggregation | ClusterRole is explicit and minimal; reviewed per release |
 | SEC-09 | Persona misconfiguration could over-grant | Helm values are the source of truth; `kubernaut-tool-*` roles are data-driven |
+
+### Approval Consent Guard (DD-AF-006, v1.5.1) {: #approval-consent-guard }
+
+`kubernaut_approve` is **structurally absent** from the A2A agent's `buildToolList()` as of v1.5.1. It remains registered on the MCP bridge for the Kubernaut Console's Approve/Reject buttons and direct MCP client access.
+
+**Rationale**: An LLM with access to `kubernaut_approve` could autonomously approve RARs via prompt injection, bypassing the human consent gate that RARs exist to enforce.
+
+**Defense-in-depth layers**:
+
+1. Tool absent from `buildToolList()` -- structurally impossible for the A2A agent to call
+2. Explicit prompt instruction telling the agent the tool is unavailable
+3. SAR RBAC on the MCP bridge path
+4. Audit trail attributing every approval to the human user
+
+Similarly, `kubernaut_complete_no_action` is MCP-only (DD-AF-007) -- it is not available to the A2A agent.
 
 ### Trusted Intermediary Delegation (#1287) {: #trusted-intermediary }
 

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -405,6 +405,114 @@ The Helm chart ships 6 per-persona ClusterRoles via a data-driven template (`api
 !!! info "Internal tools"
     The AF also uses 5 internal tools (`kubectl_get`, `kubectl_list`, `kubectl_list_events`, `kubernaut_check_existing_remediation`, `kubernaut_remediate`) that run under the AF pod's own ServiceAccount. These are **not** exposed via MCP/A2A, are **not** SAR-gated, and are not included in persona tool counts.
 
+### Custom ClusterRoles {: #custom-clusterroles }
+
+For organizations that need tool subsets not covered by the 6 built-in personas — for example, separation of duties where SREs can investigate but not approve — the operator supports **user-managed ClusterRoles** via the `clusterRoleName` field on `ToolRoleBinding`.
+
+**How it works:**
+
+1. You create a ClusterRole with `verb: use` on `resource: tools` in `apiGroup: kubernaut.ai`, listing the desired tool names as `resourceNames`
+2. In the Kubernaut CR, add a `roleBindings` entry with `clusterRoleName` (instead of `role`) pointing to your ClusterRole
+3. The operator creates only the ClusterRoleBinding — it does **not** create or modify your ClusterRole
+
+**Validation:** `role` and `clusterRoleName` are mutually exclusive. Entries with both or neither set are rejected by CR validation.
+
+??? example "Custom ClusterRole: restricted investigator (investigate + read, no approval)"
+    ```yaml
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: kubernaut-restricted-investigator
+    rules:
+      - apiGroups: ["kubernaut.ai"]
+        resources: ["tools"]
+        verbs: ["use"]
+        resourceNames:
+          - kubernaut_list_remediations
+          - kubernaut_get_remediation
+          - kubernaut_watch
+          - kubernaut_investigate
+          - kubernaut_message
+          - kubernaut_complete
+          - kubernaut_cancel
+          - kubernaut_status
+          - kubernaut_reconnect
+    ```
+
+??? example "Custom ClusterRole: readonly audit (history + effectiveness only)"
+    ```yaml
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: kubernaut-readonly-audit
+    rules:
+      - apiGroups: ["kubernaut.ai"]
+        resources: ["tools"]
+        verbs: ["use"]
+        resourceNames:
+          - kubernaut_list_remediations
+          - kubernaut_get_remediation
+          - kubernaut_get_remediation_history
+          - kubernaut_get_effectiveness
+          - kubernaut_get_audit_trail
+    ```
+
+??? example "Mixed CR configuration (built-in + custom)"
+    ```yaml
+    spec:
+      apiFrontend:
+        rbac:
+          roleBindings:
+            - role: sre
+              groups: ["senior-sres"]
+            - clusterRoleName: kubernaut-restricted-investigator
+              groups: ["junior-sres"]
+            - clusterRoleName: kubernaut-readonly-audit
+              groups: ["compliance-team"]
+    ```
+
+#### Available tool `resourceNames`
+
+The following tool names can be used in `resourceNames` when authoring custom ClusterRoles. The SAR check matches against these exact strings.
+
+**MCP bridge tools (23)** — available to external MCP clients and the Kubernaut Console:
+
+| `resourceName` | Description |
+|---|---|
+| `kubernaut_list_remediations` | List active and recent remediations |
+| `kubernaut_get_remediation` | Get details of a specific remediation |
+| `kubernaut_cancel_remediation` | Cancel an active remediation |
+| `kubernaut_watch` | Stream live status updates for a remediation |
+| `kubernaut_list_approval_requests` | List approval requests |
+| `kubernaut_get_approval_request` | Get full details of an approval request |
+| `kubernaut_approve` | Approve or reject a pending approval request |
+| `kubernaut_await_session` | Wait for an investigation session to become ready |
+| `kubernaut_investigate` | Start or join an investigation |
+| `kubernaut_message` | Send a message to an active investigation session |
+| `kubernaut_complete` | Complete an investigation session |
+| `kubernaut_complete_no_action` | Complete with no remediation (dismiss or escalate) |
+| `kubernaut_cancel` | Cancel an active investigation session |
+| `kubernaut_status` | Get the current status of an investigation session |
+| `kubernaut_reconnect` | Reconnect to a disconnected session |
+| `kubernaut_discover_workflows` | Discover available workflows for a remediation |
+| `kubernaut_select_workflow` | Select a workflow for execution |
+| `kubernaut_present_decision` | Present investigation results for a decision |
+| `kubernaut_list_workflows` | List available workflows from the catalog |
+| `kubernaut_list_alerts` | Query firing Prometheus alerts (conditional) |
+| `kubernaut_get_remediation_history` | Query historical remediations |
+| `kubernaut_get_effectiveness` | Get effectiveness scores for workflows |
+| `kubernaut_get_audit_trail` | Retrieve the audit trail for a remediation |
+
+**A2A agent internal tools (5)** — used inside the A2A agent loop, SAR-gated on the A2A path:
+
+| `resourceName` | Description |
+|---|---|
+| `kubectl_get` | Get any namespaced K8s resource (Secret `.data` redacted) |
+| `kubectl_list` | List namespaced K8s resources (Secret `.data` redacted) |
+| `kubectl_list_events` | List K8s events with reason/object filters |
+| `kubernaut_check_existing_remediation` | Check for duplicate RemediationRequest |
+| `kubernaut_remediate` | Create a new RemediationRequest CRD |
+
 ### Binding example
 
 ```yaml

--- a/docs/user-guide/configmap-kubernaut-agent.md
+++ b/docs/user-guide/configmap-kubernaut-agent.md
@@ -167,6 +167,63 @@ integrations:
 !!! info "Operator: BYO runtime ConfigMap"
     When deploying via the Kubernaut Operator, set `spec.kubernautAgent.llm.runtimeConfigMapName` to point to a ConfigMap you manage. The operator mounts it as the hot-reloadable config, so changes take effect without pod restart. The static ConfigMap is managed by the operator and should not be edited directly.
 
+### Per-phase LLM routing (v1.5.1) {: #per-phase-llm-routing-v151 }
+
+The `phaseModels` map in the `kubernaut-agent-llm-runtime` ConfigMap allows configuring different LLM models for each phase of the investigation pipeline. This is useful for routing expensive reasoning models to RCA while using faster/cheaper models for workflow selection or validation.
+
+**Valid phase keys** (CEL-validated when using the operator CR):
+
+| Phase key | Description |
+|---|---|
+| `rca` | Root-cause analysis loop (K8s + Prometheus tools) |
+| `workflow_discovery` | Workflow selection and discovery |
+| `validation` | Post-selection validation |
+
+**Override fields** (all optional; non-empty fields override the base LLM config):
+
+| Field | Description |
+|---|---|
+| `provider` | Override LLM provider |
+| `model` | Override model name |
+| `endpoint` | Override endpoint URL |
+| `apiKey` | Override API key |
+| `azureApiVersion` | Azure API version override |
+| `vertexProject` | GCP project override |
+| `vertexLocation` | GCP region override |
+| `bedrockRegion` | AWS Bedrock region override |
+
+`temperature`, `maxRetries`, and `timeoutSeconds` are always inherited from the base `LLMRuntimeConfig` and cannot be overridden per phase.
+
+**Merge behavior**: `EffectivePhaseConfig()` copies the base config, then overlays non-empty override fields. If `phaseModels` is empty or the phase has no entry, the base config is used unchanged.
+
+**Validation**: unknown phase keys are rejected at startup. An override where all fields are empty is rejected.
+
+**Hot-reloadable**: yes — changes to the `kubernaut-agent-llm-runtime` ConfigMap take effect via FileWatcher without pod restart.
+
+**Configuration paths**:
+
+- **Operator CR**: `spec.kubernautAgent.llm.phaseModels` (map with CEL validation)
+- **Direct ConfigMap patch**: add `phaseModels:` key to the `kubernaut-agent-llm-runtime` ConfigMap
+- **Helm chart**: not yet exposed as a value key
+
+??? example "phaseModels in kubernaut-agent-llm-runtime ConfigMap"
+    ```yaml
+    model: gpt-4o
+    endpoint: http://llm-gateway:8080/v1
+    temperature: 0.7
+    maxRetries: 3
+    timeoutSeconds: 120
+    phaseModels:
+      rca:
+        provider: anthropic
+        endpoint: http://anthropic-api
+        model: claude-sonnet-4-6
+      workflow_discovery:
+        model: claude-haiku-3
+      validation:
+        model: gpt-4o-mini
+    ```
+
 ## Supported Providers
 
 | Config `ai.llm.provider` | Backend | Implementation |

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -227,11 +227,65 @@ The API Frontend service provides the REST API surface for external integrations
 | `apifrontend.config.server.healthPort` | Health check port | `8081` |
 | `apifrontend.config.session.disconnectTTL` | TTL before disconnected sessions are cleaned up | `10m` |
 | `apifrontend.config.session.retentionTTL` | How long completed sessions are retained | `720h` |
-| `apifrontend.config.interactive.enabled` | Enable interactive session MCP tools. When `false`, 10 session-dependent tools are hidden from MCP enumeration and the A2A agent tool list, leaving 11 stateless CRD/data tools (#1366). | `true` |
+| `apifrontend.config.interactive.enabled` | Enable interactive session MCP tools. When `false`, 11 session-dependent tools are hidden from MCP enumeration and the A2A agent tool list, leaving 12 stateless CRD/data tools; 13 with `kubernaut_list_alerts` if Prometheus is configured (#1366). | `true` |
 | `apifrontend.config.severityTriage.enabled` | Enable severity triage. Required for alert tools (`list_alerts`, `get_alert_details`, `kubernaut_investigate_alert`). | `false` |
 | `apifrontend.config.severityTriage.prometheusURL` | Prometheus API URL for alert queries. Required when `severityTriage.enabled: true`. | `""` |
 | `apifrontend.config.severityTriage.cacheTTLSeconds` | Severity triage cache TTL | `30` |
 | `apifrontend.config.severityTriage.llmConfidence` | LLM confidence threshold for severity triage | `0.7` |
+
+#### Severity Triage (v1.5.1) {: #severity-triage-v151 }
+
+The severity triage pipeline can use a **dedicated LLM** for LLM-based severity classification, separate from the A2A agent's LLM. This is configured via the `severityTriage.llm` block in the `apifrontend-config` ConfigMap — it is **not** exposed as a Helm value.
+
+The Helm chart exposes only `cacheTTLSeconds` and `llmConfidence` (see table above). All other severity triage fields require a ConfigMap overlay or direct patch.
+
+When deploying via the **Kubernaut Operator**, severity triage is auto-derived from `spec.monitoring.enabled` — there is no CRD field for `severityTriage`.
+
+**ConfigMap fields** (in addition to the Helm-managed values above):
+
+| ConfigMap key | Type | Description |
+|---|---|---|
+| `severityTriage.enabled` | bool | Enable severity triage pipeline |
+| `severityTriage.prometheusURL` | string | Prometheus API URL (required when enabled) |
+| `severityTriage.prometheusTlsCaFile` | string | CA cert for Prometheus TLS |
+| `severityTriage.prometheusBearerTokenFile` | string | Bearer token file for Prometheus auth |
+| `severityTriage.maxQueriesPerCall` | int | Max Prometheus queries per triage call (default 10) |
+| `severityTriage.maxRulesEvaluated` | int | Max rules evaluated per triage (default 100) |
+| `severityTriage.llm.provider` | string | LLM provider: `vertex_ai`, `gemini`, `anthropic` |
+| `severityTriage.llm.model` | string | Model name |
+| `severityTriage.llm.endpoint` | string | Custom endpoint URL |
+| `severityTriage.llm.apiKeyFile` | string | Path to API key file |
+| `severityTriage.llm.timeoutSeconds` | int | HTTP timeout (default 120) |
+| `severityTriage.llm.tlsCaFile` | string | Custom CA for LLM endpoint |
+| `severityTriage.llm.tlsCertFile` | string | Client cert for mTLS |
+| `severityTriage.llm.tlsKeyFile` | string | Client key for mTLS |
+| `severityTriage.llm.oauth2.enabled` | bool | Enable OAuth2 client credentials |
+| `severityTriage.llm.oauth2.tokenURL` | string | OAuth2 token endpoint |
+| `severityTriage.llm.oauth2.scopes` | []string | OAuth2 scopes |
+| `severityTriage.llm.oauth2.credentialsDir` | string | Directory with `client-id`/`client-secret` |
+| `severityTriage.llm.circuitBreaker.enabled` | bool | Enable circuit breaker |
+| `severityTriage.llm.circuitBreaker.failureThreshold` | int | Failures before opening (default 5) |
+| `severityTriage.llm.circuitBreaker.timeout` | string | Open-state duration (default 30s) |
+| `severityTriage.llm.customHeaders` | []object | Custom headers (name/value or name/filePath) |
+
+??? example "ConfigMap overlay with dedicated severity triage LLM"
+    ```yaml
+    severityTriage:
+      enabled: true
+      prometheusURL: "https://prometheus.monitoring:9090"
+      prometheusTlsCaFile: /etc/apifrontend/tls-ca/ca.crt
+      prometheusBearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      cacheTTLSeconds: 30
+      maxQueriesPerCall: 10
+      maxRulesEvaluated: 100
+      llmConfidence: 0.7
+      llm:
+        provider: gemini
+        model: gemini-2.0-flash
+        apiKeyFile: /etc/apifrontend/llm-key/key
+        timeoutSeconds: 120
+    ```
+
 | `apifrontend.resources.requests.memory` | Memory request | `64Mi` |
 | `apifrontend.resources.requests.cpu` | CPU request | `50m` |
 | `apifrontend.resources.limits.memory` | Memory limit | `256Mi` |
@@ -241,6 +295,126 @@ The API Frontend service provides the REST API surface for external integrations
 | `apifrontend.config.auth.jwtProviders[].claimMappings.username` | CEL expression to extract username from JWT claims (e.g., `claims.email`). Falls back to `preferred_username` / `sub` when empty (#1392). | `""` |
 | `apifrontend.config.auth.jwtProviders[].claimMappings.groups` | CEL expression to extract groups from JWT claims (e.g., `claims.roles`). Falls back to `groups` claim when empty (#1392). | `""` |
 | `apifrontend.config.rbac.sarCacheTTL` | SAR result cache TTL | `30s` |
+
+#### JWT Providers (v1.5.1) {: #jwt-providers-v151 }
+
+Both the Kubernaut Agent and API Frontend support **multiple JWT providers** via a `jwtProviders[]` array. The two services use intentionally different schemas.
+
+**Kubernaut Agent** (`kubernautAgent.interactive.jwtProviders[]`):
+
+| Parameter | Description | Default |
+|---|---|---|
+| `kubernautAgent.interactive.jwtProviders[].name` | Human-readable provider name (max 63 chars) | — |
+| `kubernautAgent.interactive.jwtProviders[].issuer` | JWT issuer URL (must match `iss` claim, max 2048 chars) | — |
+| `kubernautAgent.interactive.jwtProviders[].jwksURL` | JWKS endpoint URL (**required**, max 2048 chars, must be http/https) | — |
+| `kubernautAgent.interactive.jwtProviders[].audience` | Expected audience claim (singular string) | — |
+| `kubernautAgent.interactive.jwtProviders[].claimMappings.username` | Claim name for username extraction | `preferred_username` |
+| `kubernautAgent.interactive.jwtProviders[].claimMappings.groups` | Claim name for group extraction (supports dot-notation) | `groups` |
+
+Duplicate `issuer` URLs across providers are rejected at startup.
+
+**API Frontend** (`apifrontend.config.auth.jwtProviders[]`):
+
+| Parameter | Description | Default |
+|---|---|---|
+| `apifrontend.config.auth.jwtProviders[].name` | Provider name (optional but must be unique if set) | — |
+| `apifrontend.config.auth.jwtProviders[].issuerURL` | OIDC issuer URL (**required**, must be https unless `allowInsecureIssuers`) | — |
+| `apifrontend.config.auth.jwtProviders[].jwksURL` | JWKS endpoint (optional, falls back to `issuerURL` for OIDC discovery) | — |
+| `apifrontend.config.auth.jwtProviders[].audiences` | Expected audience claims (**required**, non-empty string array) | — |
+| `apifrontend.config.auth.jwtProviders[].claimMappings.username` | CEL expression or claim path for username | — |
+| `apifrontend.config.auth.jwtProviders[].claimMappings.groups` | CEL expression or claim path for groups | — |
+
+Legacy single-provider fields (`apifrontend.config.auth.issuerURL` + `apifrontend.config.auth.audience`) remain supported for backward compatibility.
+
+!!! warning "Schema differences"
+    KA uses `issuer` / `audience` (singular), AF uses `issuerURL` / `audiences` (plural array). KA requires `jwksURL`, AF makes it optional. AF supports CEL expressions in claim mappings, KA uses simple claim names.
+
+??? example "Dual-provider configuration (Keycloak + SPIRE)"
+    ```yaml
+    # Kubernaut Agent (interactive sessions)
+    kubernautAgent:
+      interactive:
+        enabled: true
+        jwtProviders:
+          - name: keycloak
+            issuer: "https://keycloak.example.com/realms/kubernaut"
+            jwksURL: "https://keycloak.example.com/realms/kubernaut/protocol/openid-connect/certs"
+            audience: "kubernaut-agent"
+            claimMappings:
+              username: "preferred_username"
+              groups: "groups"
+
+    # API Frontend
+    apifrontend:
+      config:
+        auth:
+          jwtProviders:
+            - name: keycloak
+              issuerURL: "https://keycloak.example.com/realms/kagenti"
+              jwksURL: "http://keycloak-service.keycloak:8080/realms/kagenti/protocol/openid-connect/certs"
+              audiences: ["kubernaut-apifrontend"]
+              claimMappings:
+                username: "preferred_username"
+                groups: "groups"
+            - name: spire
+              issuerURL: "https://oidc-discovery-provider.example.com"
+              jwksURL: "https://spire-spiffe-oidc-discovery-provider.zero-trust-workload-identity-manager.svc:443/keys"
+              audiences: ["spiffe://trust-domain/ns/kubernaut-system/sa/apifrontend"]
+    ```
+
+#### SPIRE JWT-SVID Integration (v1.5.1) {: #spire-integration-v151 }
+
+SPIRE integration enables workload identity for A2A communication between Kubernaut and agents on other platforms (RHDH, ACM) that authenticate via SPIRE JWT-SVIDs. The integration requires [kagenti](https://github.com/kagenti/kagenti) (the SPIRE operator) and involves two layers: the **operator** registering the SPIFFE identity, and the **AF** validating SPIRE-issued JWTs.
+
+**Prerequisites:**
+
+- kagenti installed with a `SPIREClusterConfig` defining the trust domain
+- SPIRE OIDC Discovery Provider deployed (exposes JWKS at `/.well-known/openid-configuration` and `/keys`)
+- The trust domain must match across SPIRE server, ClusterSPIFFEID, and JWT `iss` claim
+
+**Operator setup** (`spec.apiFrontend.spire`):
+
+When `spire.enabled: true`, the operator:
+
+1. Labels the namespace with `kagenti-enabled=true`
+2. Creates a `ClusterSPIFFEID` resource registering a SPIFFE identity for the AF ServiceAccount: `spiffe://{trustDomain}/ns/{namespace}/sa/apifrontend`
+3. kagenti's webhook injects the authbridge sidecar into the AF pod
+
+| CR field | Description |
+|---|---|
+| `spec.apiFrontend.spire.enabled` | Enable SPIRE integration |
+| `spec.apiFrontend.spire.className` | SPIRE class name from kagenti's `SPIREClusterConfig` (e.g., `zero-trust-workload-identity-manager-spire`) |
+| `spec.apiFrontend.spire.trustDomain` | Override trust domain (default: uses SPIRE's `{{ .TrustDomain }}` template variable) |
+
+**AF JWT validation:**
+
+Add SPIRE as a second JWT provider in `apiFrontend.config.auth.jwtProviders[]`. The AF validates SPIRE JWT-SVIDs using the OIDC Discovery Provider's JWKS endpoint:
+
+```yaml
+apifrontend:
+  config:
+    auth:
+      jwtProviders:
+        - name: keycloak
+          issuerURL: "https://keycloak.example.com/realms/kagenti"
+          audiences: ["kubernaut-apifrontend"]
+        - name: spire
+          issuerURL: "https://oidc-discovery-provider.example.com"
+          jwksURL: "https://spire-spiffe-oidc-discovery-provider.zero-trust-workload-identity-manager.svc:443/keys"
+          audiences: ["spiffe://apps.example.com/ns/kubernaut-system/sa/apifrontend"]
+```
+
+**kagenti auto-detection:**
+
+When kagenti's authbridge sidecar is active, the operator auto-detects the OIDC issuer URL and JWKS URL from kagenti's `authbridge-config` ConfigMap. Explicit CR values take precedence over auto-detected values (`CM-6`). When auto-detection is active, `auth.issuerURL` is not required in the CR (`IA-2`).
+
+**SPIFFE ID convention:**
+
+```
+spiffe://{trustDomain}/ns/{namespace}/sa/{serviceAccountName}
+```
+
+This follows kagenti's standard `/ns/{namespace}/sa/{serviceaccount}` path convention (FedRAMP SC-8, IA-5).
 
 #### AF LLM Configuration (v1.5+)
 

--- a/docs/user-guide/interactive-sessions.md
+++ b/docs/user-guide/interactive-sessions.md
@@ -90,7 +90,16 @@ All four tools share the same input schema:
 }
 ```
 
-`kubernaut_complete` closes the investigation with an RCA summary. If no workflow is needed, it is the equivalent of the KA's `kubernaut_complete_no_action` tool.
+`kubernaut_complete` closes the investigation with an RCA summary. If no workflow is needed, use `kubernaut_complete_no_action` instead.
+
+### `kubernaut_complete_no_action` (v1.5.1)
+
+Closes the investigation without selecting a workflow. Two behavior paths:
+
+- **Dismiss** (no `escalation_reason`): the investigation completes with `IsActionable=false`. The RR transitions to `completed_no_action`.
+- **Escalate** (with `escalation_reason`): sets `HumanReviewNeeded=true` and `HumanReviewReason=operator_escalation`. The Remediation Orchestrator creates a `ManualReviewRequired` and sends a notification to the `ops-escalation-channel`.
+
+This tool is available on the **MCP bridge only** (DD-AF-007) -- it is not registered in the A2A agent's tool list. The Kubernaut Console uses it for its dismiss and escalation buttons.
 
 ### `kubernaut_discover_workflows`
 

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -6,6 +6,190 @@ Review the changes below to understand what differs from the version you are cur
 
 ---
 
+## v1.5.1
+
+### Kubernaut Console
+
+Kubernaut v1.5.1 introduces the **Kubernaut Console**, a web UI for interactive investigation and remediation. Operators can chat with the Kubernaut Agent in real time, view live RCA progress, approve remediation actions, and inspect audit trails from a single pane of glass.
+
+Key capabilities:
+
+- **A2A chat interface** — interactive investigation via `POST /a2a/invoke` with real-time SSE streaming of agent reasoning, tool calls, and investigation events
+- **Thinking panel** — live visualization of the agent's reasoning with collapsible sections for `reasoning`, `tool_call`, and `investigation` events
+- **RCA cards** — structured root cause analysis display with causal chain, confidence score, severity, and tool call count
+- **Workflow selection** — recommended remediation workflows with countdown confirmation and alignment verdicts
+- **Approval gate** — approve or decline `RemediationApprovalRequest` via `kubernaut_approve` on the MCP bridge
+- **Escalation input** — inline escalation with reason capture via `kubernaut_complete_no_action` with `escalation_reason`
+- **Verification timer** — live stabilization window countdown tracking `stabilization_elapsed`, `spec_hash_computed`, `alert_check`, and `health_check` steps
+- **Phase indicator** — real-time lifecycle banner (Investigating, Decision, Remediation, Verifying, Complete) with elapsed timer
+- **Real-time status streaming** — separate SSE subscription to `POST /a2a/status` for RR phase changes with automatic reconnection
+
+The Console deploys as a single pod with two containers: an **oauth2-proxy** sidecar (OIDC authentication, port 4180) and an **nginx** container serving the SPA and proxying API calls to the API Frontend (port 8080). On OpenShift, a TLS-terminated Route is created automatically.
+
+#### Deployment
+
+**Prerequisites**: Kubernetes 1.28+ or OpenShift 4.14+, Kubernaut API Frontend deployed, OIDC provider (Keycloak, Dex).
+
+```bash
+# 1. Create the OIDC secret
+kubectl create secret generic kubernaut-console-oidc \
+  --namespace kubernaut-system \
+  --from-literal=client-id=kubernaut-console \
+  --from-literal=client-secret=<YOUR_CLIENT_SECRET> \
+  --from-literal=cookie-secret=$(openssl rand -base64 32)
+
+# 2. Install the chart
+helm install kubernaut-console ./chart \
+  --namespace kubernaut-system \
+  --set auth.issuerUrl=https://your-keycloak/realms/kubernaut \
+  --set auth.clientId=kubernaut-console \
+  --set apiFrontend.url=http://apifrontend-service.kubernaut-system.svc:8443
+```
+
+When deploying via the **Kubernaut Operator**, use `spec.console` instead (see [ConsoleSpec](../api-reference/operator-cr.md#consolespec)).
+
+#### Helm values
+
+| Value | Default | Description |
+|---|---|---|
+| `image.repository` | `ghcr.io/jordigilh/kubernaut-console` | Container image |
+| `image.tag` | `latest` | Image version (pin by digest for production) |
+| `apiFrontend.url` | `http://apifrontend.kubernaut-system.svc:8443` | API Frontend service URL |
+| `auth.provider` | `oidc` | OAuth2 Proxy provider |
+| `auth.issuerUrl` | — | OIDC issuer URL |
+| `auth.clientId` | `kubernaut-console` | OIDC client ID |
+| `auth.existingSecret` | `kubernaut-console-oidc` | Secret with keys: `client-id`, `client-secret`, `cookie-secret` |
+| `auth.skipTlsVerify` | `true` | Skip TLS for dev (must be `false` in production) |
+| `auth.redirectUrl` | — | OAuth2 callback URL |
+| `service.type` | `ClusterIP` | Service type |
+| `service.port` | `4180` | Service port (OAuth2 Proxy) |
+| `route.enabled` | `true` | Create OpenShift Route |
+| `route.host` | auto-derived | Custom route hostname |
+| `route.tls.termination` | `edge` | TLS termination mode |
+
+#### Nginx proxy routes
+
+| Location | Target | Timeout | Notes |
+|---|---|---|---|
+| `/a2a/` | API Frontend | 3600s | SSE streaming, buffering disabled |
+| `/mcp` | API Frontend | 30s | JSON-RPC tool calls |
+| `/.well-known/` | API Frontend | default | Agent card discovery |
+| `/healthz` | local 200 | — | Liveness/readiness probe |
+| `/` | static files | — | SPA fallback to `index.html` |
+
+#### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| 502 on `/a2a/` | AF not reachable | Check AF service DNS and port |
+| OIDC redirect loop | Incorrect redirect URI | Verify Keycloak/Dex client config matches `auth.redirectUrl` |
+| SSE disconnects | Proxy timeout too low | Ensure 3600s timeouts on SSE route |
+| Stale UI after deploy | Image pull policy `IfNotPresent` | Use `Always` or pin by digest |
+
+See the [Kubernaut Console repository](https://github.com/jordigilh/kubernaut-console) for full architecture, Kind demo deployment, and development setup.
+
+### Interactive GitOps remediation demo
+
+A video demonstrating **GitOps drift remediation in interactive mode** has been added to the [Kubernaut README](https://github.com/jordigilh/kubernaut). The demo shows the full journey: a bad commit breaks a ConfigMap in a GitOps-managed production namespace, Kubernaut traces the pod crash to the ConfigMap root cause, selects `git revert` over `kubectl rollback` because the environment is GitOps-managed, pauses for human approval (production namespace), and executes the fix via ArgoCD sync.
+
+<div align="center">
+  <video src="https://github.com/user-attachments/assets/b95290db-412b-4d6d-81b8-f766ef4657e2" controls width="100%"></video>
+</div>
+
+### Per-phase LLM routing (`phaseModels`)
+
+Configure different LLM models for each phase of the investigation pipeline via the `phaseModels` map in the `kubernaut-agent-llm-runtime` ConfigMap:
+
+| Phase key | Description |
+|---|---|
+| `rca` | Root-cause analysis loop (K8s + Prometheus tools) |
+| `workflow_discovery` | Workflow selection and discovery |
+| `validation` | Post-selection validation |
+
+Override fields per phase: `provider`, `endpoint`, `model`, `apiKey`, plus cloud-specific fields (`azureApiVersion`, `vertexProject`, `vertexLocation`, `bedrockRegion`). Non-empty fields override the base config; `temperature`, `maxRetries`, and `timeoutSeconds` are always inherited. Hot-reloadable via FileWatcher — no pod restart needed.
+
+**Configuration paths**: operator CR (`spec.kubernautAgent.llm.phaseModels`) or direct ConfigMap patch. The Helm chart does not yet expose `phaseModels` as a value key.
+
+See [Kubernaut Agent Config: phaseModels](../user-guide/configmap-kubernaut-agent.md#per-phase-llm-routing-v151) for the full reference.
+
+### Severity triage LLM configuration
+
+The severity triage pipeline can now use a **dedicated LLM** instead of sharing the agent's LLM. Configure via a ConfigMap overlay under `severityTriage.llm` — supports `provider` (vertex_ai, gemini, anthropic), `model`, `endpoint`, `apiKeyFile`, `timeoutSeconds`, `oauth2`, `circuitBreaker`, and `customHeaders`.
+
+The Helm chart exposes only two severity triage values: `cacheTTLSeconds` (default 30) and `llmConfidence` (default 0.7). The full `LLMConfig` block requires a ConfigMap overlay. The operator auto-derives severity triage enablement from `spec.monitoring.enabled`.
+
+See [Configuration: Severity Triage](../user-guide/configuration.md#severity-triage-v151) for the full reference.
+
+### Multi-provider JWT authentication
+
+Both the Kubernaut Agent and API Frontend now support **multiple JWT providers** via a `jwtProviders[]` array, enabling dual-provider configurations (e.g., Keycloak + SPIRE). The two services use intentionally different schemas:
+
+| Field | Kubernaut Agent | API Frontend |
+|---|---|---|
+| Issuer | `issuer` (string) | `issuerURL` (string) |
+| Audience | `audience` (singular string) | `audiences` (string array) |
+| JWKS URL | `jwksURL` (required) | `jwksURL` (optional, falls back to issuerURL) |
+| Claim mappings | Simple claim names, dot-notation | CEL expressions or claim paths |
+
+`ClaimMappingsSpec` supports `username` and `groups` fields. Legacy single-provider fields (`issuerURL` + `audience`) remain supported for backward compatibility.
+
+See [Configuration: JWT Providers](../user-guide/configuration.md#jwt-providers-v151) for the full reference.
+
+### MCP tool surface: 21 to 23
+
+Two tools join the public MCP bridge:
+
+| Tool | Condition | Purpose |
+|---|---|---|
+| `kubernaut_list_alerts` | Registered when `severityTriage.enabled: true` and Prometheus is configured | Query firing alerts with `namespace`, `severity`, `state` filters |
+| `kubernaut_complete_no_action` | Always registered | Complete an investigation with no remediation — dismiss or escalate to operator |
+
+When `interactive.enabled: false`, **11 session-dependent tools** are hidden (up from 10), leaving **12 stateless tools** on MCP (13 with `list_alerts` if Prometheus is configured).
+
+See [MCP Tool Reference](../api-reference/mcp-tools.md) for the updated tool list.
+
+### Breaking: `kubernaut_approve` removed from A2A agent (DD-AF-006)
+
+`kubernaut_approve` is **structurally absent** from the A2A agent's `buildToolList()`. It remains available on the MCP bridge for the Kubernaut Console's Approve/Reject buttons. This prevents an LLM from autonomously approving RemediationApprovalRequests via prompt injection, preserving the human consent gate that RARs exist to enforce.
+
+Defense-in-depth: (1) tool absent from `buildToolList()`, (2) explicit prompt instruction, (3) SAR RBAC on the MCP path, (4) audit trail attributing every approval to the human user.
+
+### `POST /a2a/status` SSE endpoint (DD-AF-008)
+
+New endpoint for real-time remediation status streaming. Clients subscribe to phase transitions for a specific RemediationRequest.
+
+- **Request**: JSON-RPC 2.0 body with method `status/subscribe` and `params.rr_id`
+- **Events**: `status/update` (phase, timestamp, final, metadata) and `status/closing` (reason, reconnect)
+- **Heartbeat**: 15-second keepalive
+- **Auth**: same OIDC chain as `/mcp` and `/a2a/invoke`
+
+See [API Frontend API: Status SSE](../api-reference/apifrontend-api.md#status-sse-v151) for the full reference.
+
+### CRD changes
+
+- **`HumanReviewReason`** enum: added `operator_escalation` — triggered by `kubernaut_complete_no_action` with `escalation_reason`
+- **`SubReason`** enum: added `OperatorEscalation`
+- **AIAnalysis reasons**: added `InteractiveCancelled` and `ParentCancelled`
+
+See [CRD Reference](../api-reference/crds.md) for the updated enum tables.
+
+### Operator CR updates
+
+The Kubernaut Operator CRD now includes:
+
+- **`JWTProviderSpec`** at `spec.kubernautAgent.interactive.jwtProviders[]` and `spec.apiFrontend.auth.jwtProviders[]` — `name`, `issuerURL`, `jwksURL`, `audiences`, `claimMappings` (`username`, `groups`)
+- **`phaseModels`** at `spec.kubernautAgent.llm.phaseModels` — per-phase LLM override map with CEL validation for keys (`rca`, `workflow_discovery`, `validation`)
+- **`ConsoleSpec`** at `spec.console` — `enabled`, `auth.secretName`, `route.enabled`, `route.host`, `resources`
+
+See [Operator CR Reference](../api-reference/operator-cr.md) for the full schema.
+
+### Platform hardening
+
+- **Cascade terminal phase** — When a RemediationRequest enters a terminal phase, all child resources (AIAnalysis, SignalProcessing, WorkflowExecution) are patched to `PhaseFailed`. Idempotent, non-fatal.
+- **`alignment_verdict` audit event** — Emitted after every investigation with structured payload: `result` (aligned/suspicious), `circuit_breaker_activated`, `summary`, `findings[]`, and optional `grounding_review`
+
+---
+
 ## v1.5
 
 ### API Frontend — new service
@@ -16,7 +200,7 @@ Kubernaut v1.5 introduces the **API Frontend** (AF), the 11th microservice. It a
 - **A2A support** — Agent-to-Agent protocol with agent card discovery at `/.well-known/agent-card.json`
 - **SSE streaming** — Real-time investigation output streamed token-by-token via Server-Sent Events
 - **SAR authorization** — Kubernetes-native SubjectAccessReview tool authorization with 6 per-persona ClusterRoles, fail-closed, and TTL-cached results
-- **MCP bridge** — Dispatches 21 `kubernaut_*` MCP tools to their backends (K8s API, KA MCP, DataStorage) with per-tool RBAC, rate limiting, and audit. Not a transparent proxy — each tool has its own handler and routing
+- **MCP bridge** — Dispatches 23 `kubernaut_*` MCP tools to their backends (K8s API, KA MCP, DataStorage) with per-tool RBAC, rate limiting, and audit. Not a transparent proxy — each tool has its own handler and routing
 
 See [API Frontend Architecture](../architecture/apifrontend.md) for the full design, and [Configuration: API Frontend](../user-guide/configuration.md#api-frontend-v15) for Helm values.
 
@@ -24,7 +208,7 @@ See [API Frontend Architecture](../architecture/apifrontend.md) for the full des
 
 Operators and AI agents can now connect to Kubernaut via MCP for **interactive investigation and remediation**. This is the flagship v1.5 feature, replacing the autonomous-only pipeline with an operator-in-the-loop model when desired.
 
-The API Frontend exposes **21 `kubernaut_*` MCP tools** on its MCP endpoint (`POST /mcp`), organized by domain:
+The API Frontend exposes **23 `kubernaut_*` MCP tools** on its MCP endpoint (`POST /mcp`), organized by domain:
 
 | Domain | Tools |
 |---|---|
@@ -83,7 +267,7 @@ The 4 narrow AF triage tools (`af_get_pods`, `af_get_workloads`, `af_list_events
 
 `af_resolve_owner` is removed — KA independently resolves the owner chain during RCA. The new tools use `RESTMapper` for dynamic kind-to-GVR resolution. Secret `.data` fields are redacted before returning to the LLM.
 
-All internal tools (`kubectl_*`, `kubernaut_check_existing_remediation`, `kubernaut_remediate`) run inside the AF's A2A agent loop and are not exposed on the MCP bridge. They are still SAR-gated via `newRBACGuard()` and included in per-persona ClusterRoles. The external MCP surface consists of **21 `kubernaut_*` MCP tools** spanning CRD operations, investigation, interactive session lifecycle, analytics, and presentation.
+All internal tools (`kubectl_*`, `kubernaut_check_existing_remediation`, `kubernaut_remediate`) run inside the AF's A2A agent loop and are not exposed on the MCP bridge. They are still SAR-gated via `newRBACGuard()` and included in per-persona ClusterRoles. The external MCP surface consists of **23 `kubernaut_*` MCP tools** spanning CRD operations, investigation, interactive session lifecycle, alerts, analytics, and presentation.
 
 ### Session takeover security (SEC-TAKEOVER-001)
 

--- a/docs/whats-next/index.md
+++ b/docs/whats-next/index.md
@@ -6,9 +6,38 @@ hide:
 
 # What's Next
 
-The features below are planned for future Kubernaut releases. For features that shipped in v1.5 (Interactive MCP Sessions, API Frontend, SAR-based tool authorization, severity triage pipeline), see [What's New: v1.5](../whats-new/index.md#v15).
+The features below are planned for future Kubernaut releases. For features that shipped in v1.5, see [What's New: v1.5](../whats-new/index.md#v15). For features that shipped in v1.5.1 (Kubernaut Console, per-phase LLM routing, multi-provider JWT, severity triage LLM, SSE status endpoint), see [What's New: v1.5.1](../whats-new/index.md#v151).
 
-## v1.5.x — Custom Agent Injection & ITSM (upcoming)
+## v1.6 — Fleet Remediation & ITSM (next)
+
+### Fleet Operations
+
+Hub-and-spoke deployment using [ACM/OCM](https://open-cluster-management.io/) (Open Cluster Management) — policy-driven remediation across fleet-scale Kubernetes environments, 7 steps from alert to remediation, zero remote footprint ([#54](https://github.com/jordigilh/kubernaut/issues/54)).
+
+<div style="max-width:100%;overflow-x:auto;margin:1rem 0">
+<img src="../assets/images/fleet-operations.svg" alt="Fleet Operations — Hub-and-spoke remediation flow" style="width:100%">
+</div>
+
+#### Remediation flow
+
+1. Remote Prometheus forwards metrics to Thanos on hub
+2. Alertmanager fires alert → Kubernaut Engine triggers pipeline
+3. KE obtains JWT from Keycloak for MCP investigation
+4. KE calls MCP on target remote cluster for RCA investigation
+5. KE obtains JWT from Keycloak for remediation execution
+6. KE dispatches remediation playbook to AWX
+7. AWX executes fix on target remote cluster via ephemeral SA
+
+!!! tip "Zero persistent credentials"
+    Remediation uses ephemeral ServiceAccounts with OCM-managed lifecycle — no long-lived secrets stored on remote clusters.
+
+### ServiceNow Incident Triage
+
+Consume ServiceNow incidents as signals through the API Frontend, enabling Kubernaut to investigate and remediate ITSM tickets alongside Kubernetes alerts ([#1338](https://github.com/jordigilh/kubernaut/issues/1338)).
+
+---
+
+## Future
 
 ### Custom Agent Injection
 
@@ -38,67 +67,10 @@ Recipe runs via Kubernaut Agent endpoint at effectiveness assessment time.
 
 **Example: `verify-business-slo`** — Calls an SLO/Business Metrics MCP to check p95 latency, error rate, and order throughput against SLO budget. Returns a structured pass/fail verdict with business impact data, replacing the default Kubernetes health check with SRE-defined assessment SOPs.
 
-### ServiceNow Incident Triage
-
-Consume ServiceNow incidents as signals through the API Frontend, enabling Kubernaut to investigate and remediate ITSM tickets alongside Kubernetes alerts ([#1338](https://github.com/jordigilh/kubernaut/issues/1338)).
-
 ---
 
-## v1.6 — Fleet Management (next)
-
-### Fleet Operations
-
-Hub-and-spoke deployment using [ACM/OCM](https://open-cluster-management.io/) (Open Cluster Management) — policy-driven remediation across fleet-scale Kubernetes environments, 7 steps from alert to remediation, zero remote footprint.
-
-<div style="max-width:100%;overflow-x:auto;margin:1rem 0">
-<img src="../assets/images/fleet-operations.svg" alt="Fleet Operations — Hub-and-spoke remediation flow" style="width:100%">
-</div>
-
-#### Remediation flow
-
-1. Remote Prometheus forwards metrics to Thanos on hub
-2. Alertmanager fires alert → Kubernaut Engine triggers pipeline
-3. KE obtains JWT from Keycloak for MCP investigation
-4. KE calls MCP on target remote cluster for RCA investigation
-5. KE obtains JWT from Keycloak for remediation execution
-6. KE dispatches remediation playbook to AWX
-7. AWX executes fix on target remote cluster via ephemeral SA
-
-!!! tip "Zero persistent credentials"
-    Remediation uses ephemeral ServiceAccounts with OCM-managed lifecycle — no long-lived secrets stored on remote clusters.
-
-### Kubernaut Console
-
-Web UI for interactive investigation, remediation monitoring, and workflow management.
-
-!!! example "Conceptual mockups"
-    The following mockups show the planned Kubernaut Console experience. Designs are subject to change.
-
-#### Fleet Overview
-
-Natural language query bar for intent-driven navigation. KPI cards (active investigations, resolved, critical alerts, avg resolution time), cluster health grid, and a filtered alerts table — all driven by the operator's query.
-
-<div style="max-width:100%;overflow-x:auto;margin:1rem 0">
-<img src="../assets/images/backstage-console-fleet.svg" alt="Kubernaut Console — Fleet Overview" style="width:100%">
-</div>
-
-#### Investigation View
-
-Chat-style investigation transcript showing the Kubernaut Agent's live reasoning, tool calls, and root cause analysis. Operators can follow the AI's investigation in real time and intervene when needed.
-
-<div style="max-width:100%;overflow-x:auto;margin:1rem 0">
-<img src="../assets/images/backstage-investigation.svg" alt="Kubernaut Console — Investigation View" style="width:100%">
-</div>
-
-#### Workflow Catalog
-
-Searchable workflow catalog with natural language filtering, KPI metrics, and a table showing workflow status, action types, match count, and effectiveness scores.
-
-<div style="max-width:100%;overflow-x:auto;margin:1rem 0">
-<img src="../assets/images/backstage-workflows.svg" alt="Kubernaut Console — Workflow Catalog" style="width:100%">
-</div>
-
----
+!!! success "Shipped in v1.5.1"
+    **Kubernaut Console** — Web UI for interactive investigation and remediation. See [What's New: v1.5.1](../whats-new/index.md#v151).
 
 !!! info "Subject to change"
     Features listed here are planned but may change. See the [Kubernaut milestones](https://github.com/jordigilh/kubernaut/milestones) for the latest status. For the full roadmap including Collective Intelligence and Operational Expansion (cost, security, non-K8s), see [ROADMAP.md](https://github.com/jordigilh/kubernaut/blob/main/docs/roadmap/ROADMAP.md).


### PR DESCRIPTION
## Summary

- Add comprehensive v1.5.1 release notes to What's New covering Console (with deployment guide, Helm values, troubleshooting), interactive GitOps demo video, per-phase LLM routing, severity triage LLM, multi-provider JWT auth, MCP tool surface 21→23, DD-AF-006 consent guard, POST /a2a/status SSE, CRD enum changes, operator CR updates, and platform hardening
- Update MCP tool reference with `kubernaut_complete_no_action` (escalation routing) and `kubernaut_list_alerts` (conditional on Prometheus), full response examples, persona access matrix, and backend routing summary
- Document `POST /a2a/status` SSE endpoint (DD-AF-008) with JSON-RPC request format, event types, wire format example, keepalive, auto-reconnect, and error codes
- Add severity triage LLM ConfigMap overlay reference (22 fields), per-phase LLM routing guide (`rca`/`workflow_discovery`/`validation`), dual JWT provider schemas (KA vs AF), and SPIRE JWT-SVID integration guide
- Expand operator CR with `JWTProviderSpec` (5 fields), `ClaimMappingsSpec`, `LLMPhaseOverrideSpec`, `InteractiveSpec`, `ConsoleSpec`, and `phaseModels` on `LLMSpec`
- Update CRD enums: `InteractiveCancelled`, `ParentCancelled` on `AIAnalysisReason`; `OperatorEscalation` on `subReason`; `operator_escalation` on `humanReviewReason`
- Update behavioral docs: per-phase model routing in investigation pipeline, cascade terminal phase in remediation routing, `kubernaut_complete_no_action` in interactive sessions, DD-AF-006 approval consent guard and `alignment_verdict` audit event in security-rbac
- Align What's Next roadmap: Console shipped, ServiceNow to v1.6, Custom Agent Injection to Future

Closes #177, #178, #179

### Files changed (13)

| Group | Files |
|---|---|
| Release notes & roadmap | `whats-new/index.md`, `whats-next/index.md` |
| API reference | `mcp-tools.md`, `apifrontend-api.md`, `apifrontend.md`, `crds.md`, `operator-cr.md` |
| Configuration guides | `configuration.md`, `configmap-kubernaut-agent.md` |
| Behavioral docs | `kubernaut-agent-investigation.md`, `remediation-routing.md`, `interactive-sessions.md`, `security-rbac.md` |

### Follow-up issues

- #180 — Dedicated Console user guide page
- #181 — DD-AUTH-MCP-001 v1.6 qualifier removal (kubernaut repo)
- #182 — FedRAMP control impact notes
- #183 — Console Helm values reference
- #184 — v1.5 stale MCP tool count

## Test plan

- [ ] `mkdocs serve` renders all 13 modified pages without errors
- [ ] All internal cross-references (`#severity-triage-v151`, `#jwt-providers-v151`, `#per-phase-llm-routing-v151`, `#status-sse-v151`, `#complete-no-action`, `#consolespec`, `#jwtproviderspec`, `#claimmappingsspec`, `#llmphaseoverridespec`, `#interactivespec`, `#approval-consent-guard`, `#spire-integration-v151`) resolve correctly
- [ ] Video embed in What's New renders the GitHub-hosted mp4
- [ ] Collapsible examples (`??? example`) expand correctly in MkDocs Material
- [ ] Admonitions (`!!! warning`, `!!! info`, `!!! note`, `!!! success`) render with correct styling


Made with [Cursor](https://cursor.com)