### PR TITLE
docs: migrate to 4-level severity model (critical > high > warning > info)

### DIFF
--- a/docs/api-reference/crds.md
+++ b/docs/api-reference/crds.md
@@ -1009,7 +1009,7 @@ _Appears in:_
 | ---| ---| ---|
 | `remediationRequestRef`| _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#objectreference-v1-core)_| Reference to parent RemediationRequest (if applicable)<br />Used for audit correlation and lineage tracking <br />Optional: NotificationRequest can be standalone (e.g., system-generated alerts)|
 | `type`| _[NotificationType](#notificationtype)_| Type of notification (escalation, simple, status-update)|
-| `priority`| _[NotificationPriority](#notificationpriority)_| Priority of notification (critical, high, medium, low)|
+| `priority`| _[NotificationPriority](#notificationpriority)_| Priority of notification (critical, high, warning, info)|
 | `subject`| _string_| Subject line for notification|
 | `body`| _string_| Notification body content|
 | `severity`| _string_| Severity from the originating signal (used for routing)<br /> promoted from mutable label to immutable spec field|
@@ -1755,7 +1755,7 @@ _Appears in:_
 | Field| Type| Description|
 | ---| ---| ---|
 | `summary`| _string_| Brief summary of root cause|
-| `severity`| _string_| Severity determined by RCA <br /> Aligned with KA/workflow catalog (critical, high, medium, low, unknown)|
+| `severity`| _string_| Severity determined by RCA <br /> Aligned with KA/workflow catalog (critical, high, warning, info, unknown)|
 | `signalType`| _string_| Signal type determined by RCA (may differ from input)|
 | `contributingFactors`| _string array_| Contributing factors|
 | `remediationTarget`| _[RemediationTarget](#remediationtarget)_| RemediationTarget identifies the actual resource the LLM determined should be remediated.<br /> The LLM may identify a higher-level resource (e.g., Deployment) rather than<br />the Pod that generated the signal. The WFE creator should prefer this over the RR's<br />TargetResource when available to ensure the correct resource is patched.|
@@ -1797,7 +1797,7 @@ _Appears in:_
 | Field| Type| Description|
 | ---| ---| ---|
 | `fingerprint`| _string_| Signal fingerprint for correlation|
-| `severity`| _string_| Signal severity: critical, high, medium, low, unknown (normalized by SignalProcessing Rego - )|
+| `severity`| _string_| Signal severity: critical, high, warning, info, unknown (normalized by SignalProcessing Rego - )|
 | `signalName`| _string_| Signal name (e.g., OOMKilled, CrashLoopBackOff)<br />Normalized by SignalProcessing: proactive names mapped to base names|
 | `signalMode`| _string_| SignalMode indicates whether this is a reactive or proactive signal.<br /> Proactive Signal Mode Prompt Strategy<br />Copied from SignalProcessing status by RemediationOrchestrator.<br />Used by Kubernaut Agent to switch investigation prompt (RCA vs. predict & prevent).|
 | `environment`| _string_| Environment classification<br />Examples: "production", "staging", "development", "qa-eu", "canary"|
@@ -1915,7 +1915,7 @@ _Appears in:_
 | `environmentClassification`| _[EnvironmentClassification](#environmentclassification)_| Categorization results|
 | `priorityAssignment`| _[PriorityAssignment](#priorityassignment)_||
 | `businessClassification`| _BusinessClassification_||
-| `severity`| _string_| Severity determination <br />Normalized severity determined by Rego policy: "critical", "high", "medium", "low", or "unknown"<br />Aligned with KA/workflow catalog severity levels for consistency across platform<br />Enables downstream services (AIAnalysis, RemediationOrchestrator, Notification)<br />to interpret alert urgency without understanding external severity schemes.|
+| `severity`| _string_| Severity determination <br />Normalized severity determined by Rego policy: "critical", "high", "warning", "info", or "unknown"<br />Aligned with KA/workflow catalog severity levels for consistency across platform<br />Enables downstream services (AIAnalysis, RemediationOrchestrator, Notification)<br />to interpret alert urgency without understanding external severity schemes.|
 | `policyHash`| _string_| PolicyHash is the SHA256 hash of the Rego policy used for severity determination<br />Provides audit trail and policy version tracking for compliance requirements<br />Expected format: 64-character hexadecimal string (SHA256 hash)|
 | `signalMode`| _string_| SignalMode indicates whether this is a reactive or proactive signal.<br /> Proactive Signal Mode Classification<br /> Proactive Signal Mode Classification and Prompt Strategy<br />Set during the Classifying phase alongside severity, environment, and priority.<br />All signals MUST be classified — "reactive" is the default for unmapped types.|
 | `signalName`| _string_| SignalName is the normalized signal name after proactive-to-base mapping.<br /> Signal Name Normalization<br />For proactive signals (e.g., "PredictedOOMKill"), this is the base name (e.g., "OOMKilled").<br />For reactive signals, this matches Spec.Signal.Name unchanged.<br />This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, KA).|

--- a/docs/api-reference/mcp-tools.md
+++ b/docs/api-reference/mcp-tools.md
@@ -581,7 +581,7 @@ Backend: **Prometheus** (AF ServiceAccount) — queries the configured Prometheu
 - **`kubernaut_list_alerts`** — Query firing Prometheus alerts with optional filters
 
     - `namespace` (`string`) — Filter by namespace
-    - `severity` (`string`) — Filter by severity (`critical`, `high`, `medium`, `low`, `info`, `warning`)
+    - `severity` (`string`) — Filter by severity (`critical`, `high`, `warning`, `info`)
     - `state` (`string`) — Filter by alert state (`firing`, `pending`)
 
     Returns a `ListAlertsResult` with `alerts[]` (sorted by severity descending, then `active_at` ascending FIFO), `count`, `total_count`, `truncated`, and `prioritized` (index-based priority metadata). Sensitive label keys (`password`, `token`, `secret`, `key`, `credential`, `bearer`) are stripped. URLs and IPs in label/annotation values are redacted (FedRAMP SI-10). If the serialized response exceeds the max tool output size, alerts are trimmed from the tail (lowest priority) and `truncated` is set to `true`.
@@ -757,7 +757,7 @@ These tools are only available when the AF has a Prometheus connection configure
 
 | Tool | Purpose |
 |------|---------|
-| `list_alerts` | Query Prometheus alerts with optional filters. Params: `namespace`, `severity` (critical/high/medium/low/info/warning), `state` (firing/pending). Returns redacted `AlertSummary` array. |
+| `list_alerts` | Query Prometheus alerts with optional filters. Params: `namespace`, `severity` (critical/high/warning/info), `state` (firing/pending). Returns redacted `AlertSummary` array. |
 | `get_alert_details` | Get details of a specific alert. Params: `alert_name` (required), `namespace` (optional). Returns matching `AlertSummary` array. |
 | `kubernaut_investigate_alert` | Alert-first RR creation with scope validation. Params: `alert_name`, `api_version`, `kind`, `name` (all required), `namespace` (optional for cluster-scoped). Validates alert exists in Prometheus and checks namespace/cluster scope via RESTMapper before creating the RR (#1372). |
 

--- a/docs/architecture/data-persistence.md
+++ b/docs/architecture/data-persistence.md
@@ -630,7 +630,7 @@ Per-resource action summary joining `resource_references`, `action_histories`, a
 
 ### incident_summary_view
 
-Incident counts grouped by signal severity (ordered critical → low).
+Incident counts grouped by signal severity (ordered critical → info).
 
 ### oscillation_detection_summary
 

--- a/docs/architecture/signal-processing.md
+++ b/docs/architecture/signal-processing.md
@@ -141,7 +141,7 @@ The classification phase evaluates four classifiers in sequence. A failure in se
 - **Query**: `data.signalprocessing.severity`
 - **Input**: `{namespace: {name, labels}, signal: {severity, type, source, labels}, workload: {kind, name, labels}}`
 - **Output**: Normalized severity string
-- **Values**: `critical`, `high`, `medium`, `low`, `unknown`
+- **Values**: `critical`, `high`, `warning`, `info`, `unknown`
 - **Fatal on failure**: A severity policy error transitions the CRD to `Failed` with `RegoEvaluationError`
 
 ### 4. Signal Mode Classifier (YAML)

--- a/docs/architecture/workflow-selection.md
+++ b/docs/architecture/workflow-selection.md
@@ -77,7 +77,7 @@ Every workflow declares four mandatory labels. DataStorage applies these as hard
 
 | Label | Type | Values | SQL Pattern |
 |---|---|---|---|
-| `severity` | `string[]` | `critical`, `high`, `medium`, `low`, `"*"` | `labels->'severity' ? $val OR labels->'severity' ? '*'` |
+| `severity` | `string[]` | `critical`, `high`, `warning`, `info`, `"*"` | `labels->'severity' ? $val OR labels->'severity' ? '*'` |
 | `component` | `string[]` | `pod`, `deployment`, `node`, `"*"` | Array containment (case-insensitive match to resource kind), consistent with `severity` / `environment` JSONB patterns |
 | `environment` | `string[]` | `production`, `staging`, `development`, `test`, `"*"` | `labels->'environment' ? $val OR labels->'environment' ? '*'` |
 | `priority` | `string` | `P0`, `P1`, `P2`, `P3`, `"*"` | Scalar match with `"*"` wildcard |

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,7 +108,7 @@ Click a phase card above, or select a tab:
 
     AlertManager webhooks, Kubernetes Events, and A2A/Interactive sessions (v1.5) are ingested, enriched with Kubernetes context (owner chain, namespace labels, workload metadata), and classified by OPA/Rego policies across multiple dimensions:
 
-    - **Severity** — normalized to a standard scale (critical, high, medium, low).
+    - **Severity** — normalized to a standard scale (critical, high, warning, info).
     - **Environment** — inferred from namespace labels (production, staging, development).
     - **Priority** — P0–P3 based on policy evaluation.
     - **Signal mode** — reactive (active incident) or proactive (predicted issue).

--- a/docs/operations/disconnected-install.md
+++ b/docs/operations/disconnected-install.md
@@ -553,10 +553,10 @@ data:
     default severity := "unknown"
     severity := "critical" if { lower(input.signal.severity) == "critical" }
     severity := "high"     if { lower(input.signal.severity) == "high" }
-    severity := "medium"   if { lower(input.signal.severity) == "medium" }
-    severity := "medium"   if { lower(input.signal.severity) == "warning" }
-    severity := "low"      if { lower(input.signal.severity) == "low" }
-    severity := "low"      if { lower(input.signal.severity) == "info" }
+    severity := "warning"  if { lower(input.signal.severity) == "warning" }
+    severity := "warning"  if { lower(input.signal.severity) == "medium" }
+    severity := "info"     if { lower(input.signal.severity) == "info" }
+    severity := "info"     if { lower(input.signal.severity) == "low" }
 
     # Priority Assignment
     default priority := {"priority": "P3", "policy_name": "default"}

--- a/docs/use-cases/llm-judgment-approval-gate.md
+++ b/docs/use-cases/llm-judgment-approval-gate.md
@@ -57,7 +57,7 @@ actionability: NotActionable
 selectedWorkflow: null
 warnings: []
 rootCauseAnalysis:
-  severity: low
+  severity: info
   summary: >
     Orphaned PVCs from completed batch jobs detected in demo-orphaned-pvc namespace.
     Five PVCs remain after their associated batch jobs completed. The data-processor
@@ -86,7 +86,7 @@ The LLM correctly characterized the situation as low-priority housekeeping:
 > 'batch-run=completed' and are not mounted by any running pods. The data-processor
 > deployment is healthy and unaffected."
 
-- **Severity:** `low`
+- **Severity:** `info`
 - **Contributing factors:** "Completed batch jobs without automatic PVC cleanup",
   "Missing storage lifecycle management"
 
@@ -128,7 +128,7 @@ think this actually warrants automated action."*
     "rationale": "The workflow specifically targets orphaned PVCs from completed batch jobs..."
   },
   "rootCauseAnalysis": {
-    "severity": "low",
+    "severity": "info",
     "summary": "Five orphaned PVCs from completed batch jobs consuming 500Mi...",
     "contributingFactors": [
       "Completed batch jobs without automatic PVC cleanup",
@@ -165,7 +165,7 @@ remediation if they choose to proceed.
 
 **3. Human-in-the-loop approval** — The Rego policy catches the LLM's warning via the
 `has_warnings` rule and requires manual approval. The operator receives the full context:
-the LLM's RCA (low severity), the matched workflow (CleanupPVC), and the warning (no
+the LLM's RCA (info severity), the matched workflow (CleanupPVC), and the warning (no
 remediation warranted). They can make an informed decision: clean up now, or leave it for
 the next maintenance window.
 
@@ -304,7 +304,7 @@ Production environment requires manual review. A `RemediationApprovalRequest` is
 
 ### 5. Operator reviews and rejects
 
-The operator sees the low severity, the 0.9-confidence workflow match, and the "no
+The operator sees the info severity, the 0.9-confidence workflow match, and the "no
 remediation warranted" warning. They reject the cleanup:
 
 ```bash

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -37,7 +37,7 @@ Created after a RemediationRequest is accepted. The Signal Processing controller
 - **Environment classification** — Inferred from namespace labels or Rego policies (production, staging, development, test)
 - **Priority assignment** — P0–P3 based on Rego policy evaluation or severity-based fallback
 - **Business classification** — Business unit, service owner, criticality level, and SLA requirement (when labels are present)
-- **Severity normalization** — Maps raw alert severity to a standard scale (critical, high, medium, low, unknown) via Rego policies with a configurable fallback matrix
+- **Severity normalization** — Maps raw alert severity to a standard scale (critical, high, warning, info, unknown) via Rego policies with a configurable fallback matrix
 - **Signal mode** — Reactive (something broke) or proactive (something is predicted to break)
 - **Signal name normalization** — Normalizes the signal name for downstream matching while preserving the original for audit
 

--- a/docs/user-guide/configmap-notification.md
+++ b/docs/user-guide/configmap-notification.md
@@ -94,8 +94,8 @@ receivers:
 | Key | Source | Example Values |
 |---|---|---|
 | `type` | Notification type | `Escalation`, `Simple`, `StatusUpdate`, `Approval`, `ManualReview`, `Completion` |
-| `severity` | Signal severity | `critical`, `high`, `medium`, `low` |
-| `priority` | Notification priority | `Critical`, `High`, `Medium`, `Low` |
+| `severity` | Signal severity | `critical`, `high`, `warning`, `info` |
+| `priority` | Notification priority | `Critical`, `High`, `Warning`, `Info` |
 | `phase` | Remediation phase | `signal-processing`, `ai-analysis`, `executing` |
 | `environment` | Namespace environment | `production`, `staging`, `development` |
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -32,7 +32,7 @@ kubectl label namespace my-app kubernaut.ai/managed=true
 | `kubernaut.ai/environment` | `production`, `staging`, `development`, `qa`, `test` | SP `policy.rego` (environment rules), AA approval | Environment classification and approval gates |
 | `kubernaut.ai/business-unit` | Any string | SP `policy.rego` (custom labels rules) | Business unit classification (LLM context only) |
 | `kubernaut.ai/service-owner` | Any string | SP `policy.rego` (custom labels rules) | Service owner team |
-| `kubernaut.ai/criticality` | `critical`, `high`, `medium`, `low` | SP `policy.rego` (custom labels rules) | Business criticality |
+| `kubernaut.ai/criticality` | `critical`, `high`, `warning`, `info` | SP `policy.rego` (custom labels rules) | Business criticality |
 | `kubernaut.ai/sla-tier` | `platinum`, `gold`, `silver`, `bronze` | SP `policy.rego` (custom labels rules) | SLA tier |
 
 ### Custom Labels

--- a/docs/user-guide/notifications.md
+++ b/docs/user-guide/notifications.md
@@ -66,8 +66,8 @@ Routes match on notification attributes:
 | Match Key | Source | Example Values |
 |---|---|---|
 | `type` | Notification type | `Escalation`, `Simple`, `StatusUpdate`, `Approval`, `ManualReview`, `Completion` |
-| `severity` | Signal severity | `critical`, `high`, `medium`, `low` |
-| `priority` | Notification priority | `Critical`, `High`, `Medium`, `Low` |
+| `severity` | Signal severity | `critical`, `high`, `warning`, `info` |
+| `priority` | Notification priority | `Critical`, `High`, `Warning`, `Info` |
 | `phase` | Remediation phase | `signal-processing`, `ai-analysis`, `executing` |
 | `environment` | Namespace environment | `production`, `staging`, `development` |
 | `review-source` | Why review was triggered | `WorkflowResolutionFailed`, `ExhaustedRetries` |

--- a/docs/user-guide/policies.md
+++ b/docs/user-guide/policies.md
@@ -32,16 +32,16 @@ Normalizes the raw alert severity to one of Kubernaut's standard values.
 
 **Rule name:** `severity`
 
-**Output:** string -- one of `critical`, `high`, `medium`, `low`, `unknown`
+**Output:** string -- one of `critical`, `high`, `warning`, `info`, `unknown`
 
 **Default mapping:**
 
 | Input (case-insensitive) | Output |
 |---|---|
 | `critical`, `sev1`, `p0`, `p1`, `error` | `critical` |
-| `high`, `sev2`, `p2`, `warning` | `high` |
-| `medium`, `sev3` | `medium` |
-| `low`, `p3` | `low` |
+| `high`, `sev2`, `p2` | `high` |
+| `warning`, `medium`, `sev3` | `warning` |
+| `info`, `low`, `p3` | `info` |
 | Anything else | `unknown` |
 
 **Input:** `input.signal.severity` (the raw severity string from the alert source)

--- a/docs/user-guide/rego-reference.md
+++ b/docs/user-guide/rego-reference.md
@@ -37,7 +37,7 @@ All SP rules receive the same `PolicyInput` struct:
 
 **Rego query:** `data.signalprocessing.severity`
 
-**Expected output:** A string -- one of `critical`, `high`, `medium`, `low`, `unknown`
+**Expected output:** A string -- one of `critical`, `high`, `warning`, `info`, `unknown`
 
 #### Example: PagerDuty P0--P4 Mapping
 
@@ -50,8 +50,8 @@ severity_map := {
     "p0": "critical",
     "p1": "critical",
     "p2": "high",
-    "p3": "medium",
-    "p4": "low",
+    "p3": "warning",
+    "p4": "info",
 }
 
 severity := severity_map[lower(input.signal.severity)] if {
@@ -78,7 +78,7 @@ severity := "critical" if {
 # Prometheus alerts use standard severity labels
 severity := input.signal.severity if {
     input.signal.source == "prometheus"
-    input.signal.severity in {"critical", "high", "medium", "low"}
+    input.signal.severity in {"critical", "high", "warning", "info"}
 }
 
 default severity := "unknown"
@@ -162,7 +162,7 @@ import rego.v1
 # Severity dimension (cross-references the severity rule)
 severity_score := 3 if { severity == "critical" }
 severity_score := 2 if { severity == "high" }
-severity_score := 1 if { severity == "medium" }
+severity_score := 1 if { severity == "warning" }
 default severity_score := 0
 
 # Environment dimension (cross-references the environment rule)
@@ -295,7 +295,7 @@ The approval policy runs after the investigation pipeline returns a successful w
 | Field | Type | Description |
 |---|---|---|
 | `input.signal_type` | `string` | Signal name that triggered the analysis (e.g., `OOMKilled`, `CrashLoopBackOff`) |
-| `input.severity` | `string` | Normalized severity from SP (`critical`, `high`, `medium`, `low`) |
+| `input.severity` | `string` | Normalized severity from SP (`critical`, `high`, `warning`, `info`) |
 | `input.environment` | `string` | Environment classification from SP (`production`, `staging`, etc.) |
 | `input.business_priority` | `string` | Priority assigned by SP (`P0`--`P3`) |
 
@@ -342,7 +342,7 @@ These are infrastructure characteristics detected by the LLM during root cause a
 | `input.custom_labels` | `map[string][]string` | Operator-defined labels from the custom labels policy |
 | `input.business_classification.business_unit` | `string` | Business unit from the business policy |
 | `input.business_classification.service_owner` | `string` | Service owner team |
-| `input.business_classification.criticality` | `string` | Criticality level (`critical`, `high`, `medium`, `low`) |
+| `input.business_classification.criticality` | `string` | Criticality level (`critical`, `high`, `warning`, `info`) |
 | `input.business_classification.sla_requirement` | `string` | SLA tier (e.g., `platinum`, `gold`, `silver`, `bronze`) |
 
 ### Example: Default Policy (Environment-Gated)

--- a/docs/user-guide/signals.md
+++ b/docs/user-guide/signals.md
@@ -155,7 +155,7 @@ After the Gateway creates a `RemediationRequest`, the Orchestrator creates a `Si
 
 Rego policies evaluate the enriched signal to determine:
 
-- **Severity** — `critical`, `high`, `medium`, `low`, or `unknown`
+- **Severity** — `critical`, `high`, `warning`, `info`, or `unknown`
 - **Priority** — Business impact and urgency
 - **Environment** — Production, staging, development
 - **Signal mode** — Reactive or proactive

--- a/docs/user-guide/workflows.md
+++ b/docs/user-guide/workflows.md
@@ -93,7 +93,7 @@ spec:
   actionType: RestartDeployment
 
   labels:
-    severity: [critical, high, medium]
+    severity: [critical, high, warning]
     environment: [production, staging, development, "*"]
     component: [deployment]
     priority: "*"
@@ -316,7 +316,7 @@ spec:
   actionType: FixConfiguration
 
   labels:
-    severity: [high, medium]
+    severity: [high, warning]
     environment: [production, staging]
     component: [deployment]
     priority: "*"
@@ -393,7 +393,7 @@ Mandatory labels control when a workflow is eligible during discovery:
 
 | Label | Type | Required | Description |
 |---|---|---|---|
-| `severity` | string[] | Yes | Severity levels: `critical`, `high`, `medium`, `low` (array, `minItems: 1`) |
+| `severity` | string[] | Yes | Severity levels: `critical`, `high`, `warning`, `info` (array, `minItems: 1`) |
 | `environment` | string[] | Yes | Environments: `production`, `staging`, `development`, `test`, or `"*"` (array, `minItems: 1`) |
 | `component` | string[] | Yes | Resource kind(s): `pod`, `deployment`, `node`, or `"*"` (array, `minItems: 1`) |
 | `priority` | string | Yes | Priority: `P0`, `P1`, `P2`, `P3`, or `"*"` (single value) |
@@ -635,7 +635,7 @@ spec:
     whenToUse: "When config drift is detected and the correct state is in a Git repository"
   actionType: FixConfiguration
   labels:
-    severity: [high, medium]
+    severity: [high, warning]
     environment: [production, staging]
     component: [deployment]
     priority: "*"


### PR DESCRIPTION
## Summary

Migrates all documentation references from the 5-level severity model (`critical > high > medium > low > info`) to the 4-level model (`critical > high > warning > info`), aligning with ADR-066 (kubernaut#1417).

- **`medium` → `warning`** and **`low` → `info`** across 16 files
- Backward-compatible input mappings retained in Rego examples: incoming `medium` maps to `warning`, incoming `low` maps to `info`
- `confidenceLevel` ("low" / "medium" / "high") left unchanged — it tracks confidence scores, not severity
- No duplicate values introduced after migration

### Files changed by group

1. **Core severity model** — `policies.md`, `rego-reference.md`, `signal-processing.md`
2. **CRD & API references** — `crds.md`, `mcp-tools.md`, `workflow-selection.md`, `data-persistence.md`
3. **User guide** — `configuration.md`, `concepts.md`, `signals.md`, `workflows.md`, `notifications.md`, `configmap-notification.md`
4. **Operations & examples** — `disconnected-install.md`, `llm-judgment-approval-gate.md`
5. **Homepage** — `index.md`

## Test plan

- [ ] Verify no remaining `medium` or `low` as severity **output** values (backward-compat **input** mappings are expected)
- [ ] Verify no duplicate `warning` or `info` values in any enum list
- [ ] Build site with `mkdocs build --strict` and confirm no new warnings
- [ ] Cross-reference with kubernaut#1417 migration phases

Ref: kubernaut#1417 (ADR-066)


Made with [Cursor](https://cursor.com)