### PR TITLE
docs: add TARGET_RESOURCE_API_VERSION parameter and fix NAMESPACE optionality

### DIFF
--- a/docs/architecture/kubernaut-agent-investigation.md
+++ b/docs/architecture/kubernaut-agent-investigation.md
@@ -506,7 +506,7 @@ flowchart TD
 
 ### Outcome 1: Success (Workflow Selected)
 
-**Invocation 2** returns a `selected_workflow` with `workflow_id`, `confidence`, and `parameters` (through **`submit_result_with_workflow`**), after `mergePhase1Fallbacks` when needed. KA then injects the three canonical `TARGET_RESOURCE_*` parameters and constructs `remediationTarget` from the K8s-verified `root_owner` (resolved in **Invocation 1** via `get_namespaced_resource_context` or `get_cluster_resource_context`). This is the only outcome that proceeds to Rego evaluation.
+**Invocation 2** returns a `selected_workflow` with `workflow_id`, `confidence`, and `parameters` (through **`submit_result_with_workflow`**), after `mergePhase1Fallbacks` when needed. KA then injects the four canonical `TARGET_RESOURCE_*` parameters and constructs `remediationTarget` from the K8s-verified `root_owner` (resolved in **Invocation 1** via `get_namespaced_resource_context` or `get_cluster_resource_context`). This is the only outcome that proceeds to Rego evaluation.
 
 **Fields:** `needs_human_review=false`, `selected_workflow` present, `confidence >= 0.7`
 **Next:** AA transitions to `Analyzing` phase → Rego evaluation
@@ -544,7 +544,7 @@ The first invocation may identify a root cause, but the **workflow selection** s
 
 ### Outcome 5: RCA Incomplete
 
-KA could not determine the target resource identity because `root_owner` is missing from `session_state` -- either `get_namespaced_resource_context` / `get_cluster_resource_context` was never called during the investigation or it returned no owner chain. Without a verified target, KA cannot inject the canonical `TARGET_RESOURCE_*` parameters and the investigation is unsafe to proceed.
+KA could not determine the target resource identity because `root_owner` is missing from `session_state` -- either `get_namespaced_resource_context` / `get_cluster_resource_context` was never called during the investigation or it returned no owner chain. Without a verified target, KA cannot inject the four canonical `TARGET_RESOURCE_*` parameters and the investigation is unsafe to proceed.
 
 **Fields:** `needs_human_review=true`, `human_review_reason=rca_incomplete`
 **Next:** Routed to human review.

--- a/docs/architecture/workflow-execution.md
+++ b/docs/architecture/workflow-execution.md
@@ -256,7 +256,8 @@ The executor injects system variables and passes through all parameters from the
 | `TARGET_RESOURCE` | `wfe.Spec.TargetResource` (system-injected by WFE controller) |
 | `TARGET_RESOURCE_NAME` | `wfe.Spec.Parameters` (KA-injected from K8s root_owner) |
 | `TARGET_RESOURCE_KIND` | `wfe.Spec.Parameters` (KA-injected from K8s root_owner) |
-| `TARGET_RESOURCE_NAMESPACE` | `wfe.Spec.Parameters` (KA-injected from K8s root_owner) |
+| `TARGET_RESOURCE_NAMESPACE` | `wfe.Spec.Parameters` (KA-injected from K8s root_owner; empty for cluster-scoped) |
+| `TARGET_RESOURCE_API_VERSION` | `wfe.Spec.Parameters` (KA-injected; auto-resolved via ScopeResolver) |
 | Custom parameters | All remaining entries from `wfe.Spec.Parameters` (LLM-populated) |
 
 Custom parameters use `UPPER_SNAKE_CASE` names and are injected as environment variables (Jobs) or Tekton params (PipelineRuns).
@@ -267,7 +268,8 @@ Custom parameters use `UPPER_SNAKE_CASE` names and are injected as environment v
 |---|---|
 | `TARGET_RESOURCE_NAME` | `wfe.Spec.Parameters` (KA-injected from K8s root_owner) |
 | `TARGET_RESOURCE_KIND` | `wfe.Spec.Parameters` (KA-injected from K8s root_owner) |
-| `TARGET_RESOURCE_NAMESPACE` | `wfe.Spec.Parameters` (KA-injected from K8s root_owner) |
+| `TARGET_RESOURCE_NAMESPACE` | `wfe.Spec.Parameters` (KA-injected from K8s root_owner; empty for cluster-scoped) |
+| `TARGET_RESOURCE_API_VERSION` | `wfe.Spec.Parameters` (KA-injected; auto-resolved via ScopeResolver) |
 | `WFE_NAME` | `wfe.Name` (auto-injected) |
 | `WFE_NAMESPACE` | `wfe.Namespace` (auto-injected) |
 | `RR_NAME` | `wfe.Spec.RemediationRequestRef.Name` (auto-injected) |

--- a/docs/user-guide/workflow-authoring.md
+++ b/docs/user-guide/workflow-authoring.md
@@ -245,7 +245,8 @@ Every workflow receives a set of standard `TARGET_RESOURCE_*` parameters that id
 |---|---|---|
 | `TARGET_RESOURCE_NAME` | string | Name of the root managing resource (e.g., `my-app`) |
 | `TARGET_RESOURCE_KIND` | string | Kind of the root managing resource (e.g., `Deployment`, `StatefulSet`, `Node`) |
-| `TARGET_RESOURCE_NAMESPACE` | string | Namespace of the root managing resource. **Omitted** for cluster-scoped resources (e.g., Nodes) |
+| `TARGET_RESOURCE_NAMESPACE` | string | Namespace of the root managing resource. **Empty string** for cluster-scoped resources (e.g., Nodes) |
+| `TARGET_RESOURCE_API_VERSION` | string | API version of the root managing resource (e.g., `apps/v1`, `v1`). Auto-resolved via ScopeResolver for unambiguous kinds |
 
 ### Declaring Standard Parameters in Workflow Schemas
 
@@ -263,13 +264,17 @@ parameters:
     description: "Kind of the root managing resource (auto-injected)"
   - name: TARGET_RESOURCE_NAMESPACE
     type: string
-    required: true
-    description: "Namespace of the root managing resource (auto-injected)"
+    required: false
+    description: "Namespace of the root managing resource (auto-injected; empty for cluster-scoped resources)"
+  - name: TARGET_RESOURCE_API_VERSION
+    type: string
+    required: false
+    description: "API version of the root managing resource (auto-injected when resolved)"
 ```
 
 ### Cluster-Scoped Resources
 
-For cluster-scoped resources (e.g., Nodes, PersistentVolumes), `TARGET_RESOURCE_NAMESPACE` is **not injected** to prevent parameter validation failures. Workflows that handle both namespaced and cluster-scoped resources should declare `TARGET_RESOURCE_NAMESPACE` as **optional** (`required: false`).
+For cluster-scoped resources (e.g., Nodes, PersistentVolumes), `TARGET_RESOURCE_NAMESPACE` is injected as an **empty string**. Workflows that handle both namespaced and cluster-scoped resources should declare `TARGET_RESOURCE_NAMESPACE` as **optional** (`required: false`) and check for an empty value. `TARGET_RESOURCE_API_VERSION` is auto-resolved via the ScopeResolver for unambiguous kinds (e.g., `Deployment` → `apps/v1`) and is only injected when successfully resolved.
 
 See the [worked example below](#step-4-create-the-workflows) for a complete workflow schema that declares these parameters.
 
@@ -354,8 +359,12 @@ spec:
       description: "Kind of the root managing resource (KA-injected)"
     - name: TARGET_RESOURCE_NAMESPACE
       type: string
-      required: true
-      description: "Namespace of the root managing resource (KA-injected)"
+      required: false
+      description: "Namespace of the root managing resource (KA-injected; empty for cluster-scoped)"
+    - name: TARGET_RESOURCE_API_VERSION
+      type: string
+      required: false
+      description: "API version of the root managing resource (KA-injected)"
     - name: TARGET_DEPLOYMENT
       type: string
       required: true
@@ -400,8 +409,12 @@ spec:
       description: "Kind of the root managing resource (KA-injected)"
     - name: TARGET_RESOURCE_NAMESPACE
       type: string
-      required: true
-      description: "Namespace of the root managing resource (KA-injected)"
+      required: false
+      description: "Namespace of the root managing resource (KA-injected; empty for cluster-scoped)"
+    - name: TARGET_RESOURCE_API_VERSION
+      type: string
+      required: false
+      description: "API version of the root managing resource (KA-injected)"
     - name: TARGET_DEPLOYMENT
       type: string
       required: true

--- a/docs/user-guide/workflows.md
+++ b/docs/user-guide/workflows.md
@@ -117,8 +117,12 @@ spec:
       description: "Kind of the root managing resource (KA-injected)"
     - name: TARGET_RESOURCE_NAMESPACE
       type: string
-      required: true
-      description: "Namespace of the root managing resource (KA-injected)"
+      required: false
+      description: "Namespace of the root managing resource (KA-injected; empty for cluster-scoped)"
+    - name: TARGET_RESOURCE_API_VERSION
+      type: string
+      required: false
+      description: "API version of the root managing resource (KA-injected)"
     - name: TARGET_DEPLOYMENT
       type: string
       required: true
@@ -344,8 +348,12 @@ spec:
       description: "Kind of the root managing resource (KA-injected)"
     - name: TARGET_RESOURCE_NAMESPACE
       type: string
-      required: true
-      description: "Namespace of the root managing resource (KA-injected)"
+      required: false
+      description: "Namespace of the root managing resource (KA-injected; empty for cluster-scoped)"
+    - name: TARGET_RESOURCE_API_VERSION
+      type: string
+      required: false
+      description: "API version of the root managing resource (KA-injected)"
 
   dependencies:
     secrets:
@@ -559,7 +567,8 @@ Every workflow schema **must** declare these three parameters as `required: true
 |---|---|
 | `TARGET_RESOURCE_NAME` | Name of the root managing resource |
 | `TARGET_RESOURCE_KIND` | Kind of the root managing resource (e.g., `Deployment`) |
-| `TARGET_RESOURCE_NAMESPACE` | Namespace of the root managing resource |
+| `TARGET_RESOURCE_NAMESPACE` | Namespace of the root managing resource (empty for cluster-scoped) |
+| `TARGET_RESOURCE_API_VERSION` | API version of the root managing resource (e.g., `apps/v1`) |
 
 These are **KA-injected** -- Kubernaut Agent derives them from the K8s-verified `root_owner` (resolved via the Pod → ReplicaSet → Deployment owner chain) and injects them into `selected_workflow.parameters` before the AIAnalysis completes. The LLM never sees or populates these fields (they are stripped from the schema before the LLM receives it).
 
@@ -596,7 +605,7 @@ execution:
 
 The Workflow Execution controller creates a Job with:
 
-- **Environment variables** -- All parameters (including the three canonical `TARGET_RESOURCE_*` params) injected as env vars, plus the system-injected `TARGET_RESOURCE`
+- **Environment variables** -- All parameters (including the four canonical `TARGET_RESOURCE_*` params) injected as env vars, plus the system-injected `TARGET_RESOURCE`
 - **Dependency mounts** -- Secrets at `/run/kubernaut/secrets/<name>`, ConfigMaps at `/run/kubernaut/configmaps/<name>`
 - **ServiceAccount** -- Per-workflow SA from `execution.serviceAccountName` (recommended). Falls back to the execution namespace default SA if omitted.
 
@@ -613,7 +622,7 @@ execution:
 The bundle must contain a Tekton Pipeline named `workflow`. The controller creates a PipelineRun with:
 
 - **Tekton bundle resolver** -- The bundle is referenced via `resolver: bundles` with the digest-pinned image
-- **Parameters** -- All parameters (including the three canonical `TARGET_RESOURCE_*` params) injected as Tekton params, plus the system-injected `TARGET_RESOURCE`
+- **Parameters** -- All parameters (including the four canonical `TARGET_RESOURCE_*` params) injected as Tekton params, plus the system-injected `TARGET_RESOURCE`
 - **Dependency workspaces** -- Secrets as `secret-<name>` workspace bindings, ConfigMaps as `configmap-<name>` workspace bindings
 
 Tekton provides step ordering, retries, and artifact passing between steps.
@@ -658,8 +667,12 @@ spec:
       description: "Kind of the root managing resource (KA-injected)"
     - name: TARGET_RESOURCE_NAMESPACE
       type: string
-      required: true
-      description: "Namespace of the root managing resource (KA-injected)"
+      required: false
+      description: "Namespace of the root managing resource (KA-injected; empty for cluster-scoped)"
+    - name: TARGET_RESOURCE_API_VERSION
+      type: string
+      required: false
+      description: "API version of the root managing resource (KA-injected)"
 ```
 
 The `engineConfig` fields for Ansible:


### PR DESCRIPTION
## Summary

- Adds the missing `TARGET_RESOURCE_API_VERSION` parameter to all workflow schema declarations, variable tables, and summary references across 4 files
- Fixes `TARGET_RESOURCE_NAMESPACE` from `required: true` to `required: false` — the code always injects it but sets it to an empty string for cluster-scoped resources (Nodes, PersistentVolumes)
- Updates narrative references from "three canonical" to "four canonical" `TARGET_RESOURCE_*` parameters
- Corrects the cluster-scoped resources note: namespace is injected as an empty string, not omitted

### Files changed

| File | Changes |
|---|---|
| `workflow-authoring.md` | Table, schema example, 2 worked examples, cluster-scoped note |
| `workflows.md` | 3 parameter blocks, summary table, 2 narrative references |
| `workflow-execution.md` | 2 variable tables (Job + Ansible paths) |
| `kubernaut-agent-investigation.md` | 2 narrative references |

## Test plan

- [ ] Verify all `TARGET_RESOURCE_*` parameter blocks include all 4 params
- [ ] Verify no remaining "three canonical" references
- [ ] Cross-reference with `internal/kubernautagent/parser/validator.go` `kaManagedParams` map


Made with [Cursor](https://cursor.com)