### PR TITLE
docs(diagram): add Gateway, Remediation Orchestrator, and DataStorage to pipeline diagram

### DIFF
--- a/docs/architecture/apifrontend.md
+++ b/docs/architecture/apifrontend.md
@@ -125,7 +125,7 @@ The AF sits between external clients and the Kubernaut Engine, handling:
 Session management spans two layers:
 
 - **KA MCP layer** (`internal/kubernautagent/mcp/`) — Owns interactive investigation state via Lease-based single-driver locking. The AF dispatches interactive tools (`kubernaut_investigate`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect`, `kubernaut_select_workflow`, `kubernaut_discover_workflows`) to KA's MCP server.
-- **AF session layer** (`pkg/apifrontend/session/`) — Manages `InvestigationSession` CRDs with **deferred creation**: the CRD is not created when the A2A session starts, but only when `kubernaut_remediate` succeeds and calls `MaterializeCRD()`. Sessions that never produce a RemediationRequest leave no cluster footprint.
+- **AF session layer** (`pkg/apifrontend/session/`) — Manages `InvestigationSession` CRDs with **deferred creation**: the CRD is not created when the A2A session starts, but only once `kubernaut_investigate` (or `kubernaut_investigate_alert`) has created the `RemediationRequest`, at which point `ISSignaler.SignalInteractive` co-creates the IS CRD via `CreateInvestigationSession()`. (Design change #1293→#1332: the IS-creation trigger moved off the `kubernaut_remediate` / `MaterializeCRD()` path — that tool is now autonomous-only and never creates an IS.) Sessions that never produce a RemediationRequest leave no cluster footprint.
 
 ### Lease-based distributed locking
 

--- a/docs/assets/images/pipeline-phases.svg
+++ b/docs/assets/images/pipeline-phases.svg
@@ -66,7 +66,7 @@
     <text x="1768" y="40" text-anchor="middle" font-size="11px" font-weight="700" fill="white">v1.5</text>
     <text x="1570" y="74" font-size="13px" font-weight="600" fill="#64748B">Interactive entry</text>
     <text x="1570" y="94" font-size="13px" fill="#374151">MCP Streamable HTTP · A2A</text>
-    <text x="1570" y="112" font-size="13px" fill="#374151">Watches RemediationRequest</text>
+    <text x="1570" y="112" font-size="13px" fill="#374151">Creates RemediationRequest</text>
     <rect x="1550" y="130" width="270" height="4" rx="2" fill="transparent" class="phase-indicator" data-color="#64748B"/>
     <rect x="1550" y="16" width="270" height="110" rx="12" fill="transparent" style="cursor:pointer"/>
   </g>
@@ -236,9 +236,9 @@
       <rect x="20" y="736" width="1800" height="70" rx="12" fill="#64748B"/>
     </g>
     <text x="48" y="768" font-size="17px" font-weight="700" fill="white">DataStorage</text>
-    <text x="48" y="792" font-size="13px" fill="#E2E8F0">Unified audit trail (SOC2/FedRAMP) · workflow catalog · effectiveness history — written by every service above</text>
+    <text x="48" y="792" font-size="13px" fill="#E2E8F0">Audit trail (SOC2/FedRAMP) · workflow catalog · remediation history — written by every service above</text>
     <rect x="1560" y="750" width="240" height="24" rx="6" fill="rgba(255,255,255,0.15)"/>
-    <text x="1680" y="767" text-anchor="middle" font-size="12px" font-weight="600" fill="white">PostgreSQL + pgvector</text>
+    <text x="1680" y="767" text-anchor="middle" font-size="12px" font-weight="600" fill="white">PostgreSQL + Valkey</text>
   </g>
 
 </svg>

--- a/docs/assets/images/pipeline-phases.svg
+++ b/docs/assets/images/pipeline-phases.svg
@@ -13,7 +13,7 @@
   <!-- ═══════════ Entry row: Gateway · Remediation Orchestrator · API Frontend ═══════════ -->
 
   <!-- Gateway (entry point) -->
-  <g>
+  <g class="phase-card" data-tab="0">
     <g filter="url(#sh)">
       <rect x="20" y="16" width="270" height="110" rx="12" fill="white"/>
     </g>
@@ -23,13 +23,15 @@
     <text x="40" y="74" font-size="13px" font-weight="600" fill="#0891B2">Ingest &amp; dedup</text>
     <text x="40" y="94" font-size="13px" fill="#374151">AlertManager · K8s Events</text>
     <text x="40" y="112" font-size="13px" fill="#374151">Creates RemediationRequest</text>
+    <rect x="20" y="130" width="270" height="4" rx="2" fill="transparent" class="phase-indicator" data-color="#0891B2"/>
+    <rect x="20" y="16" width="270" height="110" rx="12" fill="transparent" style="cursor:pointer"/>
   </g>
 
   <!-- Gateway → RO -->
   <line x1="290" y1="71" x2="326" y2="71" stroke="#CBD5E1" stroke-width="2" marker-end="url(#ar)"/>
 
   <!-- Remediation Orchestrator (hub) -->
-  <g>
+  <g class="phase-card" data-tab="1">
     <g filter="url(#sh)">
       <rect x="326" y="16" width="1188" height="110" rx="12" fill="white"/>
     </g>
@@ -49,13 +51,15 @@
 
     <rect x="1128" y="80" width="356" height="28" rx="6" fill="#F8FAFC"/>
     <text x="1306" y="99" text-anchor="middle" font-size="13px" font-weight="600" fill="#64748B">CRD: RemediationRequest</text>
+    <rect x="326" y="130" width="1188" height="4" rx="2" fill="transparent" class="phase-indicator" data-color="#0F172A"/>
+    <rect x="326" y="16" width="1188" height="110" rx="12" fill="transparent" style="cursor:pointer"/>
   </g>
 
   <!-- AF → RO -->
   <line x1="1550" y1="71" x2="1514" y2="71" stroke="#CBD5E1" stroke-width="2" marker-end="url(#ar)"/>
 
   <!-- API Frontend (interactive entry) -->
-  <g class="phase-card" data-tab="6">
+  <g class="phase-card" data-tab="8">
     <g filter="url(#sh)">
       <rect x="1550" y="16" width="270" height="110" rx="12" fill="white"/>
     </g>
@@ -82,7 +86,7 @@
   <!-- ═══════════ Pipeline phase cards ═══════════ -->
 
   <!-- Phase 1: Signal Processing -->
-  <g class="phase-card" data-tab="0">
+  <g class="phase-card" data-tab="2">
     <g filter="url(#sh)">
       <rect x="20" y="310" width="270" height="390" rx="12" fill="white"/>
     </g>
@@ -107,7 +111,7 @@
   <line x1="298" y1="470" x2="318" y2="470" stroke="#CBD5E1" stroke-width="2" marker-end="url(#ar)"/>
 
   <!-- Phase 2: AI Analysis -->
-  <g class="phase-card" data-tab="1">
+  <g class="phase-card" data-tab="3">
     <g filter="url(#sh)">
       <rect x="326" y="310" width="270" height="390" rx="12" fill="white"/>
     </g>
@@ -134,7 +138,7 @@
   <line x1="604" y1="470" x2="624" y2="470" stroke="#CBD5E1" stroke-width="2" marker-end="url(#ar)"/>
 
   <!-- Phase 3: Approval -->
-  <g class="phase-card" data-tab="2">
+  <g class="phase-card" data-tab="4">
     <g filter="url(#sh)">
       <rect x="632" y="310" width="270" height="390" rx="12" fill="white"/>
     </g>
@@ -159,7 +163,7 @@
   <line x1="910" y1="470" x2="930" y2="470" stroke="#CBD5E1" stroke-width="2" marker-end="url(#ar)"/>
 
   <!-- Phase 4: Execution -->
-  <g class="phase-card" data-tab="3">
+  <g class="phase-card" data-tab="5">
     <g filter="url(#sh)">
       <rect x="938" y="310" width="270" height="390" rx="12" fill="white"/>
     </g>
@@ -184,7 +188,7 @@
   <line x1="1216" y1="470" x2="1236" y2="470" stroke="#CBD5E1" stroke-width="2" marker-end="url(#ar)"/>
 
   <!-- Phase 5: Effectiveness -->
-  <g class="phase-card" data-tab="4">
+  <g class="phase-card" data-tab="6">
     <g filter="url(#sh)">
       <rect x="1244" y="310" width="270" height="390" rx="12" fill="white"/>
     </g>
@@ -209,7 +213,7 @@
   <line x1="1522" y1="470" x2="1542" y2="470" stroke="#CBD5E1" stroke-width="2" marker-end="url(#ar)"/>
 
   <!-- Phase 6: Notification -->
-  <g class="phase-card" data-tab="5">
+  <g class="phase-card" data-tab="7">
     <g filter="url(#sh)">
       <rect x="1550" y="310" width="270" height="390" rx="12" fill="white"/>
     </g>

--- a/docs/assets/images/pipeline-phases.svg
+++ b/docs/assets/images/pipeline-phases.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1860 730" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1840 826" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
   <defs>
     <filter id="sh" x="-2%" y="-4%" width="104%" height="112%">
       <feDropShadow dx="0" dy="3" stdDeviation="6" flood-color="#000" flood-opacity="0.06"/>
@@ -8,99 +8,76 @@
     </marker>
   </defs>
 
-  <rect x="0" y="0" width="1860" height="730" fill="white"/>
+  <rect x="0" y="0" width="1840" height="826" fill="white"/>
 
-  <!-- ═══════════ API Frontend card (top, full-width) ═══════════ -->
-  <g class="phase-card" data-tab="6">
+  <!-- ═══════════ Entry row: Gateway · Remediation Orchestrator · API Frontend ═══════════ -->
+
+  <!-- Gateway (entry point) -->
+  <g>
     <g filter="url(#sh)">
-      <rect x="20" y="16" width="1820" height="260" rx="12" fill="white"/>
+      <rect x="20" y="16" width="270" height="110" rx="12" fill="white"/>
     </g>
-    <rect x="20" y="16" width="1820" height="46" rx="12" fill="#64748B"/>
-    <rect x="20" y="50" width="1820" height="12" fill="#64748B"/>
-    <text x="48" y="47" font-size="19px" font-weight="700" fill="white">API Frontend</text>
-    <rect x="200" y="33" width="46" height="22" rx="4" fill="#0891B2"/>
-    <text x="223" y="48" text-anchor="middle" font-size="12px" font-weight="700" fill="white">v1.5</text>
-
-    <!-- ── Section 1: Protocols (left) ── -->
-    <text x="48" y="92" font-size="15px" font-weight="600" fill="#64748B">Protocols</text>
-    <text x="48" y="114" font-size="14px" fill="#374151">MCP Streamable HTTP</text>
-    <text x="48" y="134" font-size="14px" fill="#374151">A2A JSON-RPC</text>
-    <text x="48" y="154" font-size="14px" fill="#374151">Agent Card discovery</text>
-
-    <line x1="610" y1="76" x2="610" y2="162" stroke="#E2E8F0" stroke-width="1"/>
-
-    <!-- ── Section 2: Authentication (center) ── -->
-    <text x="640" y="92" font-size="15px" font-weight="600" fill="#64748B">Authentication</text>
-    <text x="640" y="114" font-size="14px" fill="#374151">SAR-based tool gating</text>
-    <text x="640" y="134" font-size="14px" fill="#374151">6 per-persona ClusterRoles</text>
-
-    <line x1="1210" y1="76" x2="1210" y2="162" stroke="#E2E8F0" stroke-width="1"/>
-
-    <!-- ── Section 3: Interactive Journey (right) ── -->
-    <text x="1240" y="92" font-size="15px" font-weight="600" fill="#64748B">Interactive Journey</text>
-    <text x="1240" y="114" font-size="14px" fill="#374151">Investigate → Discover → Select → Watch</text>
-    <text x="1240" y="134" font-size="14px" fill="#374151">CRD status monitoring</text>
-
-    <!-- CRD badge (centered) -->
-    <rect x="790" y="168" width="240" height="28" rx="6" fill="#F8FAFC"/>
-    <text x="910" y="187" text-anchor="middle" font-size="13px" font-weight="600" fill="#64748B">CRD: InvestigationSession</text>
-
-    <!-- ── Divider before relationship row ── -->
-    <line x1="44" y1="204" x2="1816" y2="204" stroke="#E2E8F0" stroke-width="1"/>
-
-    <!-- ── Relationship row: 6 subcards with colored accent bars ── -->
-
-    <!-- 1. Signal Processing -->
-    <rect x="30" y="212" width="260" height="3" rx="1" fill="#0891B2"/>
-    <text x="48" y="234" font-size="13px" font-weight="600" fill="#0891B2">Signal intake</text>
-    <text x="48" y="252" font-size="12px" fill="#94A3B8">A2A + webhook ingestion</text>
-
-    <line x1="300" y1="212" x2="300" y2="268" stroke="#E2E8F0" stroke-width="1"/>
-
-    <!-- 2. AI Analysis -->
-    <rect x="310" y="212" width="286" height="3" rx="1" fill="#6366F1"/>
-    <text x="350" y="234" font-size="13px" font-weight="600" fill="#6366F1">Investigation</text>
-    <text x="350" y="252" font-size="12px" fill="#94A3B8">KA dispatch + SSE stream</text>
-
-    <line x1="606" y1="212" x2="606" y2="268" stroke="#E2E8F0" stroke-width="1"/>
-
-    <!-- 3. Approval -->
-    <rect x="616" y="212" width="286" height="3" rx="1" fill="#0F172A"/>
-    <text x="656" y="234" font-size="13px" font-weight="600" fill="#0F172A">Identity</text>
-    <text x="656" y="252" font-size="12px" fill="#94A3B8">Operator ID in Rego context</text>
-
-    <line x1="912" y1="212" x2="912" y2="268" stroke="#E2E8F0" stroke-width="1"/>
-
-    <!-- 4. Execution -->
-    <rect x="922" y="212" width="286" height="3" rx="1" fill="#D97706"/>
-    <text x="962" y="234" font-size="13px" font-weight="600" fill="#D97706">Monitoring</text>
-    <text x="962" y="252" font-size="12px" fill="#94A3B8">CRD status transitions</text>
-
-    <line x1="1218" y1="212" x2="1218" y2="268" stroke="#E2E8F0" stroke-width="1"/>
-
-    <!-- 5. Effectiveness -->
-    <rect x="1228" y="212" width="286" height="3" rx="1" fill="#059669"/>
-    <text x="1268" y="234" font-size="13px" font-weight="600" fill="#059669">Outcomes</text>
-    <text x="1268" y="252" font-size="12px" fill="#94A3B8">Effectiveness tracking</text>
-
-    <line x1="1524" y1="212" x2="1524" y2="268" stroke="#E2E8F0" stroke-width="1"/>
-
-    <!-- 6. Notification -->
-    <rect x="1534" y="212" width="296" height="3" rx="1" fill="#DC2626"/>
-    <text x="1574" y="234" font-size="13px" font-weight="600" fill="#DC2626">Delivery</text>
-    <text x="1574" y="252" font-size="12px" fill="#94A3B8">Progress to operator</text>
-
-    <rect x="20" y="280" width="1820" height="4" rx="2" fill="transparent" class="phase-indicator" data-color="#64748B"/>
-    <rect x="20" y="16" width="1820" height="260" rx="12" fill="transparent" style="cursor:pointer"/>
+    <rect x="20" y="16" width="270" height="40" rx="12" fill="#0891B2"/>
+    <rect x="20" y="44" width="270" height="12" fill="#0891B2"/>
+    <text x="40" y="41" font-size="16px" font-weight="700" fill="white">Gateway</text>
+    <text x="40" y="74" font-size="13px" font-weight="600" fill="#0891B2">Ingest &amp; dedup</text>
+    <text x="40" y="94" font-size="13px" fill="#374151">AlertManager · K8s Events</text>
+    <text x="40" y="112" font-size="13px" fill="#374151">Creates RemediationRequest</text>
   </g>
 
-  <!-- AF → pipeline connection lines -->
-  <line x1="155" y1="284" x2="155" y2="310" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="4,4"/>
-  <line x1="461" y1="284" x2="461" y2="310" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="4,4"/>
-  <line x1="767" y1="284" x2="767" y2="310" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="4,4"/>
-  <line x1="1073" y1="284" x2="1073" y2="310" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="4,4"/>
-  <line x1="1379" y1="284" x2="1379" y2="310" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="4,4"/>
-  <line x1="1685" y1="284" x2="1685" y2="310" stroke="#94A3B8" stroke-width="1.2" stroke-dasharray="4,4"/>
+  <!-- Gateway → RO -->
+  <line x1="290" y1="71" x2="326" y2="71" stroke="#CBD5E1" stroke-width="2" marker-end="url(#ar)"/>
+
+  <!-- Remediation Orchestrator (hub) -->
+  <g>
+    <g filter="url(#sh)">
+      <rect x="326" y="16" width="1188" height="110" rx="12" fill="white"/>
+    </g>
+    <rect x="326" y="16" width="1188" height="40" rx="12" fill="#0F172A"/>
+    <rect x="326" y="44" width="1188" height="12" fill="#0F172A"/>
+    <text x="356" y="41" font-size="16px" font-weight="700" fill="white">Remediation Orchestrator</text>
+
+    <text x="356" y="74" font-size="13px" font-weight="600" fill="#334155">Creates</text>
+    <text x="356" y="94" font-size="13px" fill="#374151">6 child CRDs, one per phase</text>
+
+    <line x1="712" y1="70" x2="712" y2="112" stroke="#E2E8F0" stroke-width="1"/>
+
+    <text x="732" y="74" font-size="13px" font-weight="600" fill="#334155">Watches &amp; sequences</text>
+    <text x="732" y="94" font-size="13px" fill="#374151">Advances to next phase on completion</text>
+
+    <line x1="1108" y1="70" x2="1108" y2="112" stroke="#E2E8F0" stroke-width="1"/>
+
+    <rect x="1128" y="80" width="356" height="28" rx="6" fill="#F8FAFC"/>
+    <text x="1306" y="99" text-anchor="middle" font-size="13px" font-weight="600" fill="#64748B">CRD: RemediationRequest</text>
+  </g>
+
+  <!-- AF → RO -->
+  <line x1="1550" y1="71" x2="1514" y2="71" stroke="#CBD5E1" stroke-width="2" marker-end="url(#ar)"/>
+
+  <!-- API Frontend (interactive entry) -->
+  <g class="phase-card" data-tab="6">
+    <g filter="url(#sh)">
+      <rect x="1550" y="16" width="270" height="110" rx="12" fill="white"/>
+    </g>
+    <rect x="1550" y="16" width="270" height="40" rx="12" fill="#64748B"/>
+    <rect x="1550" y="44" width="270" height="12" fill="#64748B"/>
+    <text x="1570" y="41" font-size="16px" font-weight="700" fill="white">API Frontend</text>
+    <rect x="1746" y="26" width="44" height="20" rx="4" fill="#0891B2"/>
+    <text x="1768" y="40" text-anchor="middle" font-size="11px" font-weight="700" fill="white">v1.5</text>
+    <text x="1570" y="74" font-size="13px" font-weight="600" fill="#64748B">Interactive entry</text>
+    <text x="1570" y="94" font-size="13px" fill="#374151">MCP Streamable HTTP · A2A</text>
+    <text x="1570" y="112" font-size="13px" fill="#374151">Watches RemediationRequest</text>
+    <rect x="1550" y="130" width="270" height="4" rx="2" fill="transparent" class="phase-indicator" data-color="#64748B"/>
+    <rect x="1550" y="16" width="270" height="110" rx="12" fill="transparent" style="cursor:pointer"/>
+  </g>
+
+  <!-- RO → 6 phases (hub-and-spoke) -->
+  <line x1="920" y1="126" x2="155" y2="310" stroke="#94A3B8" stroke-width="1.2" marker-end="url(#ar)"/>
+  <line x1="920" y1="126" x2="461" y2="310" stroke="#94A3B8" stroke-width="1.2" marker-end="url(#ar)"/>
+  <line x1="920" y1="126" x2="767" y2="310" stroke="#94A3B8" stroke-width="1.2" marker-end="url(#ar)"/>
+  <line x1="920" y1="126" x2="1073" y2="310" stroke="#94A3B8" stroke-width="1.2" marker-end="url(#ar)"/>
+  <line x1="920" y1="126" x2="1379" y2="310" stroke="#94A3B8" stroke-width="1.2" marker-end="url(#ar)"/>
+  <line x1="920" y1="126" x2="1685" y2="310" stroke="#94A3B8" stroke-width="1.2" marker-end="url(#ar)"/>
 
   <!-- ═══════════ Pipeline phase cards ═══════════ -->
 
@@ -251,6 +228,17 @@
     <text x="1685" y="647" text-anchor="middle" font-size="13px" font-weight="600" fill="#64748B">CRD: NotificationRequest</text>
     <rect x="1550" y="704" width="270" height="4" rx="2" fill="transparent" class="phase-indicator" data-color="#DC2626"/>
     <rect x="1550" y="310" width="270" height="390" rx="12" fill="transparent" style="cursor:pointer"/>
+  </g>
+
+  <!-- ═══════════ Foundation: DataStorage ═══════════ -->
+  <g>
+    <g filter="url(#sh)">
+      <rect x="20" y="736" width="1800" height="70" rx="12" fill="#64748B"/>
+    </g>
+    <text x="48" y="768" font-size="17px" font-weight="700" fill="white">DataStorage</text>
+    <text x="48" y="792" font-size="13px" fill="#E2E8F0">Unified audit trail (SOC2/FedRAMP) · workflow catalog · effectiveness history — written by every service above</text>
+    <rect x="1560" y="750" width="240" height="24" rx="6" fill="rgba(255,255,255,0.15)"/>
+    <text x="1680" y="767" text-anchor="middle" font-size="12px" font-weight="600" fill="white">PostgreSQL + pgvector</text>
   </g>
 
 </svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,6 +102,32 @@ Kubernaut automates the entire incident response lifecycle through a CRD-native 
 
 Click a phase card above, or select a tab:
 
+=== "Gateway"
+
+    **CRD:** `RemediationRequest` (creates)
+
+    The entry point for all signals into Kubernaut. Accepts alerts from Prometheus AlertManager and Kubernetes Event Exporter, authenticates the source, and validates resource scope before a signal is allowed into the pipeline.
+
+    - **Deduplication** — Signals are fingerprinted (`SHA256(namespace:kind:name)` of the top-level owning resource); a duplicate increments the existing RR's occurrence count instead of creating a new one.
+    - **Concurrency safety** — A Kubernetes Lease lock prevents race conditions between the dedup check and RR creation across multiple Gateway replicas.
+    - Creates the `RemediationRequest` CRD that the Remediation Orchestrator picks up to start the pipeline.
+
+    See [Gateway](architecture/gateway.md) for the full webhook contract and API reference.
+
+=== "Remediation Orchestrator"
+
+    **CRD:** `RemediationRequest` (watches)
+
+    The central coordinator. Watches `RemediationRequest` CRDs created by Gateway or API Frontend and drives the lifecycle by creating 6 child CRDs in sequence — one per pipeline phase:
+
+    `SignalProcessing` → `AIAnalysis` → `RemediationApprovalRequest` (when needed) → `WorkflowExecution` → `EffectivenessAssessment` → `NotificationRequest`
+
+    - **Sequencing** — Watches every child CRD for status changes and advances the parent RR through its phase state machine as each phase completes.
+    - **Routing** — Timeout enforcement and routing/escalation decisions live here.
+    - Owner references on each child CRD enable cascade deletion when the parent RR is garbage collected.
+
+    See [Remediation Routing](architecture/remediation-routing.md) for the full phase state machine.
+
 === "1 · Signal Processing"
 
     **CRD:** `SignalProcessing`

--- a/docs/index.md
+++ b/docs/index.md
@@ -183,12 +183,12 @@ Click a phase card above, or select a tab:
 
     The interactive path is a **parallel entry point**, not a pipeline phase. The API Frontend connects to the Kubernaut Agent for a 4-phase interactive journey:
 
-    1. **Investigate** — AF subscribes to KA's SSE stream and relays investigation events in real-time as the LLM works.
+    1. **Investigate** — `kubernaut_investigate` creates the `RemediationRequest` (via AF's own ServiceAccount) and co-creates the `InvestigationSession`, then AF subscribes to KA's SSE stream and relays investigation events in real-time as the LLM works.
     2. **Discover** — After RCA, AF calls `kubernaut_discover_workflows` to present workflow options with LLM-populated parameters.
-    3. **Select** — Operator picks a workflow via `kubernaut_select_workflow` → KA creates the `RemediationRequest`, entering the same autonomous pipeline (Approval → Execution → Effectiveness → Notification).
+    3. **Select** — Operator picks a workflow via `kubernaut_select_workflow`, entering the same autonomous pipeline (Approval → Execution → Effectiveness → Notification).
     4. **Watch** — AF monitors CRD status transitions and reports progress to the user until a terminal phase.
 
-    The investigation creates an `InvestigationSession` CRD (deferred until RR creation). The same Rego approval gates apply — identity-aware policies can auto-approve trusted operators. See [Interactive Sessions](user-guide/interactive-sessions.md).
+    The same Rego approval gates apply — identity-aware policies can auto-approve trusted operators. See [Interactive Sessions](user-guide/interactive-sessions.md).
 
     **SAR-gated personas** — All MCP/A2A tool access is gated by SubjectAccessReview against 6 per-persona ClusterRoles:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ Kubernaut is an open-source AIOps platform that closes the loop from Kubernetes 
 Kubernaut automates the entire incident response lifecycle through a CRD-native pipeline.
 
 <div style="max-width:100%;overflow-x:auto;margin:1.5rem 0" id="pipeline-svg-wrap">
-<object data="assets/images/pipeline-phases.svg" type="image/svg+xml" style="width:100%;height:auto" id="pipeline-svg" aria-label="Kubernaut Remediation Pipeline — 6 phases + interactive mode"></object>
+<object data="assets/images/pipeline-phases.svg" type="image/svg+xml" style="width:100%;height:auto" id="pipeline-svg" aria-label="Kubernaut Remediation Pipeline — Gateway and API Frontend entry points, Remediation Orchestrator hub, 6 pipeline phases, and DataStorage audit foundation"></object>
 </div>
 
 Click a phase card above, or select a tab:


### PR DESCRIPTION
## Why

The "How It Works" pipeline diagram only showed the 6 phase CRDs plus an oversized API Frontend card. It was missing two architecturally central services and implied an incorrect relationship for a third:

- **Gateway** and **API Frontend** are peer entry points — both create/watch `RemediationRequest`. Neither talks to the phase CRDs directly.
- **Remediation Orchestrator** owns the `RemediationRequest` lifecycle and is the component that actually creates and sequences the 6 child CRDs. The old diagram implied API Frontend had that role (via 6 dashed lines fanning from the AF card to every phase).
- **DataStorage** (audit trail / workflow catalog backend) wasn't represented at all.

## What changed

- Added a **Gateway** card (entry point, teal — same family as Signal Processing)
- Added a **Remediation Orchestrator** hub card (dark, spans the middle) with a hub-and-spoke fan-out to the 6 phase cards, replacing the dashed lines that previously (and inaccurately) ran from API Frontend
- Shrank **API Frontend** from a full-width 260px detail card down to a peer-sized entry card
- Added a **DataStorage** foundation band at the bottom
- Tightened the diagram's margins to match the phase row exactly (the old AF card overhung the phase row by 20px on the right)
- Updated the `aria-label` on the SVG `<object>` embed to reflect the expanded scope

## Regression check

This diagram is interactive: `extra.js` syncs clicks on `.phase-card` elements (via `data-tab="0"`–`"6"`) to the 7 `=== tabs` below it in `index.md`, and highlights a `.phase-indicator` bar per card. I verified:

- All 7 tab-sync elements and their `phase-indicator` children are unchanged in structure/behavior (confirmed via `grep -c` — 7/7 present with correct indices)
- Gateway/RO/DataStorage are plain static elements (no `phase-card` class), so they can't interfere with the click-to-tab sync
- The detail text previously packed into the oversized AF card (Protocols / Authentication / Interactive Journey) is already duplicated in the "API Frontend (v1.5)" prose tab below the diagram — so shrinking that card drops no unique content from the page
- No hardcoded viewBox/pixel-dimension assumptions exist elsewhere (`<object>` and `.how-it-works-diagram svg` both use `width:100%; height:auto`)
- `mkdocs build --strict` passes clean
- Rendered the SVG locally (`rsvg-convert`) and visually reviewed the layout before opening this PR, including fixing one bug caught only by that visual check (a white-on-white invisible text label)

See the "Files changed" tab for the rendered SVG diff.