### PR TITLE
docs: fix stale pre-llmProfiles operator CR shape

### DIFF
--- a/docs/api-reference/operator-cr.md
+++ b/docs/api-reference/operator-cr.md
@@ -14,9 +14,8 @@ The `Kubernaut` custom resource (`kubernaut.ai/v1alpha1`) is the single deployme
 
     - `spec.aiAnalysis.policy.configMapName` — must reference a ConfigMap containing key `approval.rego`
     - `spec.signalProcessing.policy.configMapName` — must reference a ConfigMap containing key `policy.rego`
-    - `spec.kubernautAgent.llm.provider` — LLM provider name
-    - `spec.kubernautAgent.llm.model` — LLM model name
-    - `spec.kubernautAgent.llm.credentialsSecretName` — Secret with LLM API credentials
+    - `spec.kubernautAgent.llmProfileRef` — must reference a profile key defined in `spec.llmProfiles`
+    - For every profile in `spec.llmProfiles`: `.provider`, `.model`, and `.credentialsSecretName` — see [LLMProfileSpec](#llmprofilespec)
 
     Create these resources **before** applying the Kubernaut CR. See [Installation Prerequisites](../getting-started/installation.md#prerequisites).
 
@@ -26,6 +25,7 @@ The `Kubernaut` custom resource (`kubernaut.ai/v1alpha1`) is the single deployme
 |---|---|---|
 | `postgresql` | [PostgreSQLSpec](#postgresqlspec) | BYO PostgreSQL connection |
 | `valkey` | [ValkeySpec](#valkeyspec) | BYO Valkey/Redis connection |
+| `llmProfiles` | map[string][LLMProfileSpec](#llmprofilespec) | Named LLM provider profiles (at least 1 entry required), referenced by name from `kubernautAgent.llmProfileRef` and other components |
 | `kubernautAgent` | [KubernautAgentSpec](#kubernautagentspec) | LLM and agent configuration |
 
 ### Optional fields
@@ -81,7 +81,9 @@ The `Kubernaut` custom resource (`kubernaut.ai/v1alpha1`) is the single deployme
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `llm` | [LLMSpec](#llmspec) | **yes** | — | Primary LLM configuration |
+| `llmProfileRef` | string | **yes** | — | Name of a profile defined in `spec.llmProfiles`, used for KA's investigator LLM calls |
+| `runtimeConfigMapName` | string | no | — | BYO hot-reloadable ConfigMap name (key: `llm-runtime.yaml`) |
+| `phaseModels` | map[string]string | no | — | Per-phase LLM profile overrides (v1.5.1). Keys must be `rca`, `workflow_discovery`, or `validation` (CEL-validated); values are profile names in `spec.llmProfiles`. When absent, all phases use `llmProfileRef`'s profile. |
 | `interactive` | [InteractiveSpec](#interactivespec) | no | — | Interactive session configuration including JWT providers (v1.5.1) |
 | `maxTurns` | int | no | `40` | Max tool-call turns per investigation (min: 1) |
 | `session` | SessionSpec | no | — | Session TTL configuration |
@@ -93,7 +95,9 @@ The `Kubernaut` custom resource (`kubernaut.ai/v1alpha1`) is the single deployme
 | `logging` | LoggingSpec | no | — | Log level |
 | `resources` | ResourceRequirements | no | — | CPU/memory requests and limits |
 
-### LLMSpec
+### LLMProfileSpec {: #llmprofilespec }
+
+Profiles live in the top-level `spec.llmProfiles` map (keyed by an arbitrary user-chosen name, e.g. `"primary"`) and are referenced by name via `llmProfileRef` fields on `kubernautAgent`, `apiFrontend`, and `apiFrontend.severityTriage` — decoupling each component's LLM identity from a single shared config. At least one profile is required. (`kubernautAgent.alignmentCheck.llm` still uses its own pre-profile shape — see [AlignmentCheckSpec](#alignmentcheckspec) below.)
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
@@ -102,27 +106,32 @@ The `Kubernaut` custom resource (`kubernaut.ai/v1alpha1`) is the single deployme
 | `credentialsSecretName` | string | **yes** | — | Secret containing API key |
 | `endpoint` | string | no | — | Custom endpoint (required for `openai`, `ollama`, `azure`, `mistral`). For `openai`, the operator appends `/v1` and translates to `openai_compatible` for AF. |
 | `temperature` | string | no | — | LLM temperature |
-| `maxRetries` | int | no | — | Retry count per LLM call |
-| `timeoutSeconds` | int | no | — | Per-call timeout |
+| `maxRetries` | int | no | `3` | Retry count per LLM call |
+| `timeoutSeconds` | int | no | `120` | Per-call timeout |
 | `vertexProject` | string | no | — | Vertex AI project ID |
 | `vertexLocation` | string | no | — | Vertex AI location |
 | `bedrockRegion` | string | no | — | AWS Bedrock region |
 | `azureApiVersion` | string | no | — | Azure OpenAI API version |
 | `tlsCaFile` | string | no | — | Custom CA certificate file path |
+| `tlsCertFile` / `tlsKeyFile` | string | no | — | Client certificate/key paths for mTLS to the LLM endpoint (must be set together) |
+| `tlsClientSecretRef` | string | when mTLS configured | — | Secret containing `tls.crt`/`tls.key`, required when `tlsCertFile`/`tlsKeyFile` are set |
 | `oauth2` | OAuth2Spec | no | — | OAuth2 client credentials flow |
-| `runtimeConfigMapName` | string | no | — | BYO hot-reloadable ConfigMap name (key: `llm-runtime.yaml`) |
-| `phaseModels` | map[string][LLMPhaseOverrideSpec](#llmphaseoverridespec) | no | — | Per-phase LLM overrides (v1.5.1). Keys must be `rca`, `workflow_discovery`, or `validation` (CEL-validated). |
+| `reasoning` | LLMReasoningSpec | no | disabled | Model-aware reasoning/thinking-token configuration |
 
-### LLMPhaseOverrideSpec (v1.5.1) {: #llmphaseoverridespec }
+**Example:**
 
-| Field | Type | Description |
-|---|---|---|
-| `provider` | string | Override LLM provider for this phase |
-| `model` | string | Override model name |
-| `endpoint` | string | Override endpoint URL |
-| `apiKey` | string | Override API key |
+```yaml
+spec:
+  llmProfiles:
+    primary:
+      provider: openai
+      model: gpt-4o
+      credentialsSecretName: llm-credentials
+  kubernautAgent:
+    llmProfileRef: primary
+```
 
-See [Per-phase LLM routing](../user-guide/configmap-kubernaut-agent.md#per-phase-llm-routing-v151) for usage details and YAML examples.
+`phaseModels` values are plain profile names (strings), not inline override objects — each referenced profile may use its own provider/model/credentials independently of `llmProfileRef`'s profile. See [Per-phase LLM routing](../user-guide/configmap-kubernaut-agent.md#per-phase-llm-routing-v151) for usage details and YAML examples.
 
 ### InteractiveSpec (v1.5.1) {: #interactivespec }
 
@@ -217,6 +226,7 @@ See [Per-phase LLM routing](../user-guide/configmap-kubernaut-agent.md#per-phase
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `enabled` | *bool | no | `true` | Deploy the API Frontend. Set `false` to skip all AF resources |
+| `llmProfileRef` | string | no | — | Name of a profile in `spec.llmProfiles` for AF's own agent LLM connection. When empty, falls back to `kubernautAgent.llmProfileRef`'s resolved profile |
 | `auth` | [APIFrontendAuthSpec](#apifrontendauthspec) | no | — | OIDC authentication |
 | `rateLimit` | [APIFrontendRateLimitSpec](#apifrontendratelimitspec) | no | — | Request rate limiting |
 | `shutdown` | [APIFrontendShutdownSpec](#apifrontendshutdownspec) | no | — | Graceful shutdown |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -50,7 +50,7 @@ For complete installation instructions, see the [Kubernaut Operator Installation
     kagenti and the OIDC provider requirement are frequently conflated because kagenti's own Kind/OCP installers bundle a Keycloak instance (`scripts/kind/setup-kagenti.sh` deploys Keycloak as a **core** component), and several reference deployment guides reuse that bundled Keycloak as the OIDC provider for convenience. That makes kagenti a *practical* way to get a working OIDC provider quickly, but there is no code-level dependency: Console's `oauth2-proxy` sidecar and AF's JWT validation talk directly to whatever `issuerURL` you configure — they never call kagenti's API, its operator, or SPIRE. You can point `spec.apiFrontend.auth.issuerURL` / `spec.console.auth` at any OIDC provider without installing kagenti at all, as long as `spec.apiFrontend.spire.enabled` stays `false` (the default).
 
 !!! warning "CR validation"
-    The operator **rejects the Kubernaut CR** if any of the following fields are missing or reference non-existent resources: `spec.kubernautAgent.llm.provider`, `spec.kubernautAgent.llm.model`, `spec.kubernautAgent.llm.credentialsSecretName`, `spec.signalProcessing.policy.configMapName`, `spec.aiAnalysis.policy.configMapName`. Create these resources before applying the CR.
+    The operator **rejects the Kubernaut CR** if any of the following fields are missing or reference non-existent resources: `spec.kubernautAgent.llmProfileRef` (must name a key in `spec.llmProfiles`), each `spec.llmProfiles[<name>].provider`/`.model`/`.credentialsSecretName`, `spec.signalProcessing.policy.configMapName`, `spec.aiAnalysis.policy.configMapName`. Create these resources before applying the CR.
 
 **Operator image:** `quay.io/kubernaut-ai/kubernaut-operator:{{ operator_image_tag }}` (note: no `v` prefix, unlike component images which use `{{ image_tag }}`).
 
@@ -254,11 +254,13 @@ Both paths can be enabled simultaneously.
         host: valkey.kubernaut-system.svc.cluster.local
         port: 6379
         secretName: valkey-secret
-      kubernautAgent:
-        llm:
+      llmProfiles:
+        primary:
           provider: openai
           model: gpt-4o
           credentialsSecretName: llm-credentials
+      kubernautAgent:
+        llmProfileRef: primary
       signalProcessing:
         policy:
           configMapName: signalprocessing-policy
@@ -293,11 +295,13 @@ Both paths can be enabled simultaneously.
         host: valkey.kubernaut-system.svc.cluster.local
         port: 6379
         secretName: valkey-secret
-      kubernautAgent:
-        llm:
+      llmProfiles:
+        primary:
           provider: openai
           model: gpt-4o
           credentialsSecretName: llm-credentials
+      kubernautAgent:
+        llmProfileRef: primary
         interactive:
           enabled: true
           inactivityTimeout: 10m

--- a/docs/operations/disconnected-install.md
+++ b/docs/operations/disconnected-install.md
@@ -1302,7 +1302,7 @@ Kubernaut has two components that consume LLM configuration:
 - **Kubernaut Agent (KA)** — the investigation/analysis engine. Supports 9 providers.
 - **API Frontend (AF)** — the MCP/A2A gateway. Supports 4 providers (subset of KA).
 
-The operator populates AF's LLM config from the same `spec.kubernautAgent.llm` CR fields. There is no separate AF LLM section in the CR.
+By default, AF's LLM config resolves from the same profile as KA (`spec.kubernautAgent.llmProfileRef`). Set `spec.apiFrontend.llmProfileRef` to point AF at a different profile in `spec.llmProfiles` when it needs distinct credentials or a different provider than KA.
 
 ### Supported Providers
 
@@ -1322,7 +1322,7 @@ The operator populates AF's LLM config from the same `spec.kubernautAgent.llm` C
 !!! note "`vertex` vs `vertex_ai`"
     `vertex` = Gemini models on Vertex AI (LangChainGo); `vertex_ai` = Claude models on Vertex AI (Anthropic SDK). These are different code paths.
 
-### CR Fields (`spec.kubernautAgent.llm`)
+### CR Fields (`spec.llmProfiles[<name>]`, referenced by `spec.kubernautAgent.llmProfileRef`)
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
@@ -1339,7 +1339,8 @@ The operator populates AF's LLM config from the same `spec.kubernautAgent.llm` C
 | `azureApiVersion` | string | Azure | — | Azure OpenAI API version (e.g. `2024-02-01`) |
 | `tlsCaFile` | string | No | — | Path to CA cert for TLS to LLM endpoint |
 | `oauth2` | object | No | disabled | OAuth2 client credentials auth (see below) |
-| `runtimeConfigMapName` | string | No | — | Name of a pre-existing ConfigMap for hot-reloadable runtime config |
+
+`spec.kubernautAgent.runtimeConfigMapName` (a sibling of `llmProfileRef`, not a profile field) names a pre-existing ConfigMap for hot-reloadable runtime config.
 
 ### Credential Secret Format
 
@@ -1354,7 +1355,7 @@ The operator populates AF's LLM config from the same `spec.kubernautAgent.llm` C
 | `mistral` | `MISTRAL_API_KEY` | API key string |
 | `huggingface` | `HUGGINGFACEHUB_API_TOKEN` | HuggingFace token |
 
-### OAuth2 Configuration (`spec.kubernautAgent.llm.oauth2`)
+### OAuth2 Configuration (`spec.llmProfiles[<name>].oauth2`)
 
 For LLM endpoints behind OAuth2 (client credentials grant):
 

--- a/docs/user-guide/configmap-kubernaut-agent.md
+++ b/docs/user-guide/configmap-kubernaut-agent.md
@@ -165,7 +165,7 @@ integrations:
 ```
 
 !!! info "Operator: BYO runtime ConfigMap"
-    When deploying via the Kubernaut Operator, set `spec.kubernautAgent.llm.runtimeConfigMapName` to point to a ConfigMap you manage. The operator mounts it as the hot-reloadable config, so changes take effect without pod restart. The static ConfigMap is managed by the operator and should not be edited directly.
+    When deploying via the Kubernaut Operator, set `spec.kubernautAgent.runtimeConfigMapName` to point to a ConfigMap you manage. The operator mounts it as the hot-reloadable config, so changes take effect without pod restart. The static ConfigMap is managed by the operator and should not be edited directly.
 
 ### Per-phase LLM routing (v1.5.1) {: #per-phase-llm-routing-v151 }
 
@@ -202,9 +202,9 @@ The `phaseModels` map in the `kubernaut-agent-llm-runtime` ConfigMap allows conf
 
 **Configuration paths**:
 
-- **Operator CR**: `spec.kubernautAgent.llm.phaseModels` (map with CEL validation)
-- **Direct ConfigMap patch**: add `phaseModels:` key to the `kubernaut-agent-llm-runtime` ConfigMap
-- **Helm chart**: not yet exposed as a value key
+- **Operator CR**: `spec.kubernautAgent.phaseModels` — a map of phase name to a **profile name** defined in `spec.llmProfiles` (CEL-validated keys), not an inline override object. The operator resolves the named profile and renders it into the ConfigMap's override-object shape shown above.
+- **Direct ConfigMap patch**: add `phaseModels:` key to the `kubernaut-agent-llm-runtime` ConfigMap using the inline override-object shape directly
+- **Helm chart**: `kubernautAgent.phaseModels` — same profile-name-map shape as the operator CR, referencing `global.llmProfiles` (DD-PLATFORM-007)
 
 ??? example "phaseModels in kubernaut-agent-llm-runtime ConfigMap"
     ```yaml

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -69,7 +69,7 @@ Key differences from Helm:
 | NetworkPolicies | Enabled by default, per-service toggles | Disabled by default (`spec.networkPolicies.enabled`) |
 | Monitoring RBAC | Automatic when `kube-prometheus-stack` is installed | Controlled by `spec.monitoring.enabled` (default: `true`) |
 | Database | In-chart PostgreSQL option | BYO only — `spec.postgresql.host` + `spec.postgresql.secretName` |
-| KA runtime config | Direct ConfigMap editing | `spec.kubernautAgent.llm.runtimeConfigMapName` for BYO hot-reloadable config |
+| KA runtime config | Direct ConfigMap editing | `spec.kubernautAgent.runtimeConfigMapName` for BYO hot-reloadable config |
 | Image references | Standard Helm `image.repository`/`image.tag` | `RELATED_IMAGE_*` env vars for disconnected installs |
 | Agent RBAC extension | Manual ClusterRoleBinding creation | `spec.kubernautAgent.additionalClusterRoleBindings` (max 64) |
 

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -108,7 +108,7 @@ Configure different LLM models for each phase of the investigation pipeline via 
 
 Override fields per phase: `provider`, `endpoint`, `model`, `apiKey`, plus cloud-specific fields (`azureApiVersion`, `vertexProject`, `vertexLocation`, `bedrockRegion`). Non-empty fields override the base config; `temperature`, `maxRetries`, and `timeoutSeconds` are always inherited. Hot-reloadable via FileWatcher — no pod restart needed.
 
-**Configuration paths**: operator CR (`spec.kubernautAgent.llm.phaseModels`) or direct ConfigMap patch. The Helm chart does not yet expose `phaseModels` as a value key.
+**Configuration paths**: operator CR (`spec.kubernautAgent.phaseModels`, a map of phase to profile name) or direct ConfigMap patch (inline override object). The Helm chart now also exposes this as `kubernautAgent.phaseModels` (same profile-name-map shape).
 
 See [Kubernaut Agent Config: phaseModels](../user-guide/configmap-kubernaut-agent.md#per-phase-llm-routing-v151) for the full reference.
 
@@ -178,7 +178,7 @@ See [CRD Reference](../api-reference/crds.md) for the updated enum tables.
 The Kubernaut Operator CRD now includes:
 
 - **`JWTProviderSpec`** at `spec.kubernautAgent.interactive.jwtProviders[]` and `spec.apiFrontend.auth.jwtProviders[]` — `name`, `issuerURL`, `jwksURL`, `audiences`, `claimMappings` (`username`, `groups`)
-- **`phaseModels`** at `spec.kubernautAgent.llm.phaseModels` — per-phase LLM override map with CEL validation for keys (`rca`, `workflow_discovery`, `validation`)
+- **`phaseModels`** at `spec.kubernautAgent.phaseModels` — per-phase LLM profile override map with CEL validation for keys (`rca`, `workflow_discovery`, `validation`)
 - **`ConsoleSpec`** at `spec.console` — `enabled`, `auth.secretName`, `route.enabled`, `route.host`, `resources`
 
 See [Operator CR Reference](../api-reference/operator-cr.md) for the full schema.


### PR DESCRIPTION
## Summary

The Kubernaut Operator CRD replaced the flat `spec.kubernautAgent.llm.*` fields with a named-profile model (`spec.llmProfiles` + `llmProfileRef`), but several docs pages never caught up. Verified against the operator's current CRD (`api/v1alpha1/kubernaut_types.go` @ `main`) and its `ValidateKubernaut` webhook logic (`internal/resources/validation.go` @ `main`):

- `spec.kubernautAgent.llmProfileRef` is now the required field (references a key in `spec.llmProfiles`).
- Each entry in `spec.llmProfiles` requires `.provider`, `.model`, `.credentialsSecretName`.
- `spec.kubernautAgent.phaseModels` is now `map[string]string` (phase → profile name), not an inline override object.
- `spec.apiFrontend.llmProfileRef` is a separate, optional override (falls back to KA's profile).

As written, the installation guide's sample CRs (`spec.kubernautAgent.llm.provider/model/credentialsSecretName`) would be **rejected by the operator's own admission validation** if applied today.

## Changes

- `api-reference/operator-cr.md` — validation box, required-fields table, `KubernautAgentSpec` table, replaced the stale `LLMSpec`/`LLMPhaseOverrideSpec` sections with a `LLMProfileSpec` section (with a corrected example), added `apiFrontend.llmProfileRef`.
- `getting-started/installation.md` — validation box + both sample CRs (Gateway and API Frontend paths).
- `user-guide/configmap-kubernaut-agent.md` — `runtimeConfigMapName`/`phaseModels` operator-CR paths, and corrected a stale claim that Helm doesn't expose `phaseModels` (it now does, via `kubernautAgent.phaseModels`).
- `user-guide/configuration.md` — `runtimeConfigMapName` path in the Helm-vs-Operator comparison table.
- `operations/disconnected-install.md` — the "LLM Configuration Reference" section's CR field table, AF LLM config note, and OAuth2 heading.
- `whats-new/index.md` — `phaseModels` path + corrected Helm capability claim in two spots.

Verified with `mkdocs build --strict` (no new broken links/anchors).

## Out of scope (tracked separately)

A few remaining `kubernautAgent.llm.*` references are **Helm chart** `--set`/values-table usages (`getting-started/quickstart.md`, and two spots in `user-guide/configmap-kubernaut-agent.md`/`configuration.md`), not the operator CR. Helm now uses `global.llmProfiles` + `kubernautAgent.llmProfileRef` too, so these need a values-file example rewrite rather than a simple path substitution -- left as a follow-up so this PR stays focused on the operator CR shape that jordigilh/kubernaut-operator#236 flagged.

## Test plan

- [x] `mkdocs build --strict` succeeds with no new warnings/errors
- [x] Cross-checked every changed field path against the operator's current Go types and validation logic
- [ ] Docs site preview (CI) renders the new `LLMProfileSpec` section and example correctly

Closes jordigilh/kubernaut-operator#236

Made with [Cursor](https://cursor.com)