### PR TITLE
docs: close v1.5.0→v1.5.6 documentation gaps

### DIFF
--- a/docs/api-reference/operator-cr.md
+++ b/docs/api-reference/operator-cr.md
@@ -264,6 +264,14 @@ Used at `spec.kubernautAgent.interactive.jwtProviders[]` and `spec.apiFrontend.a
 |---|---|---|---|
 | `sarCacheTTL` | string | `30s` | Cache duration for SAR results (Go duration format) |
 | `roleBindings` | [][ToolRoleBinding](#toolrolebinding) | — | Maps persona-based tool roles to OIDC groups |
+| `consoleAccessGroups` | []string | auto-derived (see below) | OIDC groups granted the coarse-grained `kubernaut.ai/console` "use" gate (v1.5.6, kubernaut#1919). Checked in addition to the per-tool `kubernaut.ai/tools` grant on every `/mcp` and `/a2a/invoke` call. |
+
+!!! info "`consoleAccessGroups` default differs from the Helm chart (kubernaut-operator#289)"
+    When **unset** (`nil`, the field has no `omitempty` — an explicit `[]` is a distinct, meaningful value from "unset"), the operator defaults `consoleAccessGroups` to the deduplicated union of every group already present in `roleBindings` above — **not** the Helm chart's static list of the 6 built-in persona names. This makes the Operator path upgrade-safe by construction: any group with an existing per-tool binding automatically keeps console access, with no risk of the tool-call lockout described in [Security & RBAC: Console-access authorization gate](../architecture/security-rbac.md#console-access-gate).
+
+    - Omit the field to keep this auto-derived default.
+    - Set an explicit non-empty list for independent, narrower control.
+    - Set an explicit empty list (`consoleAccessGroups: []`) to deny console access to everyone via this gate.
 
 ### ToolRoleBinding {: #toolrolebinding }
 

--- a/docs/architecture/security-rbac.md
+++ b/docs/architecture/security-rbac.md
@@ -405,6 +405,59 @@ The Helm chart ships 6 per-persona ClusterRoles via a data-driven template (`api
 !!! info "Internal tools"
     The AF also uses 5 internal tools (`kubectl_get`, `kubectl_list`, `kubectl_list_events`, `kubernaut_check_existing_remediation`, `kubernaut_remediate`) that run under the AF pod's own ServiceAccount. These are **not** exposed via MCP/A2A, are **not** SAR-gated, and are not included in persona tool counts.
 
+### Console-access authorization gate (v1.5.6) {: #console-access-gate }
+
+v1.5.6 adds a second, **coarse-grained** SAR check in front of the per-tool checks above (#1919, #1941, AC-3/AC-6/AU-12). Every tool-invocation request on `POST /mcp` and `POST /a2a/invoke` must now pass **both**:
+
+1. `can <user> use console in apiGroup kubernaut.ai?` — the new coarse-grained gate, checked once per request
+2. `can <user> use tools/<tool-name> in apiGroup kubernaut.ai?` — the existing per-tool check described above
+
+Both are independent SAR calls (different `resource` values, same `apiGroup: kubernaut.ai`, `verb: use`) with independently cached results — a group can hold one without the other. The gate is **fail-closed**: an SAR API error is treated the same as denial.
+
+**Advisory pre-flight endpoint** — `GET /a2a/access` lets a UI client check the console gate before opening a session, without the roundtrip cost of a real tool call:
+
+| Response | Meaning |
+|---|---|
+| `200 OK` (empty body) | Authenticated user holds the console-access grant |
+| `401 Unauthorized` (RFC 7807) | No authenticated identity on the request |
+| `403 Forbidden` (RFC 7807) | Authenticated but not granted (or the SAR call itself errored); emits an `EventAuthAccessDenied` audit event with `endpoint: "console"` |
+
+This endpoint is **advisory only** — it is not itself a security boundary. The actual enforcement is the per-request SAR check on every `/mcp` and `/a2a/invoke` call, identical to the per-tool gate.
+
+#### Helm: `consoleAccessGroups`
+
+The chart's `apifrontend.config.rbac.consoleAccessGroups` value controls which OIDC groups pass the console gate. It **defaults to all 6 built-in persona names** (`sre`, `ai-orchestrator`, `cicd`, `observability`, `l3-audit`, `remediation-approver`):
+
+```yaml
+apifrontend:
+  config:
+    rbac:
+      consoleAccessGroups:
+        - sre
+        - ai-orchestrator
+        - cicd
+        - observability
+        - l3-audit
+        - remediation-approver
+```
+
+!!! danger "Upgrade action required for custom persona groups"
+    If you deploy via Helm and configured a **custom** group under `apifrontend.config.rbac.personas` (renamed or added to the 6 defaults), that group's name is **not** automatically added to `consoleAccessGroups`. Members of that group will have **every** AF tool call denied after upgrading to v1.5.6+, even though their existing per-tool ClusterRoleBindings are unchanged and still correct. You must explicitly add the group name to `consoleAccessGroups`.
+
+    `helm install`/`helm upgrade` prints an `NOTES.txt` warning that lists any `personas` group missing from `consoleAccessGroups`, to catch this at deploy time rather than at first login.
+
+Deployments using only the 6 default persona group names need no changes.
+
+#### Kubernaut Operator: `spec.apiFrontend.rbac.consoleAccessGroups`
+
+The Operator CR field behaves differently from the Helm default by design (kubernaut-operator#289): when `consoleAccessGroups` is **unset** (the CR field is `nil`, not an explicit empty list), the operator derives it as the deduplicated union of every group already referenced in `spec.apiFrontend.rbac.roleBindings` — not the static 6-persona list. This means an existing Operator-managed deployment upgrading to an AF version that enforces this gate is **not** at risk of the lockout described above: every group with an existing per-tool binding automatically retains console access.
+
+- Leave the field unset to keep this auto-derived, upgrade-safe default.
+- Set it to an explicit non-empty list for independent, narrower control (e.g., granting console access to a strict subset of your tool-authorized groups).
+- Set it to an explicit empty list (`[]`) to opt out entirely (deny console access to everyone via this gate).
+
+See [Operator CR Reference: APIFrontendRBACSpec](../api-reference/operator-cr.md#apifrontendrbacspec) for the field definition.
+
 ### Custom ClusterRoles {: #custom-clusterroles }
 
 For organizations that need tool subsets not covered by the 6 built-in personas — for example, separation of duties where SREs can investigate but not approve — the operator supports **user-managed ClusterRoles** via the `clusterRoleName` field on `ToolRoleBinding`.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -54,7 +54,7 @@ For complete installation instructions, see the [Kubernaut Operator Installation
 !!! warning "CR validation"
     The operator **rejects the Kubernaut CR** if any of the following fields are missing or reference non-existent resources: `spec.kubernautAgent.llm.provider`, `spec.kubernautAgent.llm.model`, `spec.kubernautAgent.llm.credentialsSecretName`, `spec.signalProcessing.policy.configMapName`, `spec.aiAnalysis.policy.configMapName`. Create these resources before applying the CR.
 
-**Operator image:** `quay.io/kubernaut-ai/kubernaut-operator:{{ operator_image_tag }}` (note: no `v` prefix, unlike component images which use `{{ image_tag }}`).
+**Operator image:** `quay.io/kubernaut-ai/kubernaut-operator:{{ operator_image_tag }}` — no `v` prefix. This applies to component images (`{{ image_tag }}`) too; neither uses a `v` prefix on quay.io, despite the git tags themselves being `v`-prefixed (e.g. git tag `v1.5.6` publishes image tag `1.5.6`).
 
 ### Provision Prerequisites
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -20,7 +20,7 @@ The operator is available through OLM (Operator Lifecycle Manager) or direct man
 
 ```bash
 curl -fsSL \
-  https://raw.githubusercontent.com/jordigilh/kubernaut-operator/v1.5.4/dist/install.yaml \
+  https://github.com/jordigilh/kubernaut-operator/releases/latest/download/install.yaml \
   -o install.yaml
 
 oc apply -f install.yaml
@@ -29,6 +29,8 @@ oc rollout status deployment/kubernaut-operator-controller-manager \
 ```
 
 This creates the `kubernaut-operator-system` namespace, 11 CRDs (all under `kubernaut.ai`), RBAC, and the operator Deployment. With [IDMS](../operations/disconnected-install.md) in place, image references are transparently redirected to the mirror — no `RELATED_IMAGE_*` patching is needed.
+
+To pin to a specific operator release instead of the latest, replace `latest` in the URL with a tag, e.g. `.../releases/download/v1.5.10/install.yaml`. See the [operator releases page](https://github.com/jordigilh/kubernaut-operator/releases) for available tags — the operator has its own release cadence, independent of the core Kubernaut release version.
 
 For complete installation instructions, see the [Kubernaut Operator Installation Guide](https://github.com/jordigilh/kubernaut-operator/tree/main/docs/installation).
 

--- a/docs/operations/disconnected-install.md
+++ b/docs/operations/disconnected-install.md
@@ -215,34 +215,45 @@ The operator resolves images in this order:
 
 ## Operator (Direct Manifest) — Production {: #operator-direct }
 
-For environments where OLM is not available or not desired, the operator can be installed directly from a manifest file. This method has been **validated on OCP 4.18+ with operator v1.5.1** in fully air-gapped environments.
+For environments where OLM is not available or not desired, the operator can be installed directly from a manifest file. This method has been **validated on OCP 4.18+ with operator v1.5.10** in fully air-gapped environments.
 
 When using `oc mirror`, the generated `ImageDigestMirrorSet` (IDMS) instructs CRI-O to transparently redirect image pulls to your mirror registry. This means you do **not** need to manually rewrite image references in manifests or `RELATED_IMAGE_*` env vars — the original image references work as-is once IDMS is applied.
 
-### Image Inventory (v1.5.1)
+### Image Inventory (operator v1.5.10)
 
-#### Operator Image
+!!! warning "Digests rotate every release — always regenerate before mirroring"
+    Every digest below reflects the `imageset-config.yaml` asset published with [operator release v1.5.10](https://github.com/jordigilh/kubernaut-operator/releases/tag/v1.5.10) and **will be stale by the time you read this** — component images are rebuilt (and their digests change) on every release, independent of the operator's own version number. Do not copy these digests into a real mirroring run. Instead, download the current file directly from the bastion host in Step 1.1 below, which always matches the release you are installing.
 
-| Component | Source Image |
-|---|---|
-| kubernaut-operator | `quay.io/kubernaut-ai/kubernaut-operator@sha256:586e5344ec3897fa2e80bab5207f1eca1611fdc4c6db80113247a1539c7941b7` |
-
-#### Kubernaut v1.5.1 Component Images
+#### Operator Images
 
 | Component | Source Image |
 |---|---|
-| gateway | `quay.io/kubernaut-ai/gateway@sha256:8ef1d69db4508bfa0ab86e7f22100952ddae85c6e22d81293580d9defaf94004` |
-| datastorage | `quay.io/kubernaut-ai/datastorage@sha256:f10d8c98017c7df35133dc98f0e26e36054ec4584ac5c230b0252d3a5c9a0b44` |
-| aianalysis | `quay.io/kubernaut-ai/aianalysis@sha256:b31b8aaba5f4f3d5df1639213bca23c63438e257704ee0ac6d5f1d9ec82314b0` |
-| signalprocessing | `quay.io/kubernaut-ai/signalprocessing@sha256:de7393f8d0cbd07fadacf13ae0b9504cec321c09e1614c6839ccf1c65ec4d86e` |
-| remediationorchestrator | `quay.io/kubernaut-ai/remediationorchestrator@sha256:54778cdfd8e3a7fcef4cd871479c6101e566be0aa8fd0d5e37ed1a0c685eecb8` |
-| workflowexecution | `quay.io/kubernaut-ai/workflowexecution@sha256:47369cf7ab80bf398edca84ff4097028988303cfcc94a8a760cd4235faa7f008` |
-| effectivenessmonitor | `quay.io/kubernaut-ai/effectivenessmonitor@sha256:96aa70fcbd7d752632f18cd7ee57c009c99ab5667d7f070fbf33fd4e163e9752` |
-| notification | `quay.io/kubernaut-ai/notification@sha256:e1c4a270651fe05ca4c2d8e9588ebfb723584d5d0e80620af0cf7cf27ad643dd` |
-| kubernautagent | `quay.io/kubernaut-ai/kubernautagent@sha256:e4bf7bfbe1a3351266b9045ae19b4b012e12fd5a52b9f6559824918215dac184` |
-| authwebhook | `quay.io/kubernaut-ai/authwebhook@sha256:67b4093ca3d686077dd7816de88ce97ce729a32513e8e9fbe93433dae1434688` |
-| apifrontend | `quay.io/kubernaut-ai/apifrontend@sha256:54b57237ddbaa9d39cd6d7abf4fdabbc55406f1ef824fc020154ec5d20789946` |
-| db-migrate | `quay.io/kubernaut-ai/db-migrate@sha256:d94cdefac33c895524743697575425d3a458a97dc9c544deaa72b852b61637b3` |
+| kubernaut-operator | `quay.io/kubernaut-ai/kubernaut-operator@sha256:d93d632ce5d66f0d9e5ba79e14f6754252452a8b6833f6d8778db10f330ef692` |
+| kubernaut-operator-bundle | `quay.io/kubernaut-ai/kubernaut-operator-bundle@sha256:5c79c75b2fa1e610518640b871cc254a2df78165789a95d1dd071d555950d4b9` (OLM/CatalogSource path only — not needed for direct-manifest install) |
+
+#### Kubernaut Component Images
+
+| Component | Source Image |
+|---|---|
+| gateway | `quay.io/kubernaut-ai/gateway@sha256:1694c28ad2ef118ffaeba1fd9652234f8998fdfd06da2d412cc92bcf111c01d2` |
+| datastorage | `quay.io/kubernaut-ai/datastorage@sha256:4a2756b37fcfd122b9635058ee2d617b710706e7e5c2b52718a46f58c8fd6c52` |
+| aianalysis | `quay.io/kubernaut-ai/aianalysis@sha256:dc7643a7c39bd451f7e83ca1f853a15eaf6beb942a79867e2ad37e88276edd05` |
+| signalprocessing | `quay.io/kubernaut-ai/signalprocessing@sha256:df2d4dc75492f190517c71df5e0dccdbf54470ede5333a3c191d4027dbfa2367` |
+| remediationorchestrator | `quay.io/kubernaut-ai/remediationorchestrator@sha256:6dd491a467b412b2ad8492c074d15f4ba7306c3a097b543c1f24b117d0169567` |
+| workflowexecution | `quay.io/kubernaut-ai/workflowexecution@sha256:3d799c36d30ddb822edeb57ffc6bd81fb3b9bc4ff5cdf1ec90d5fbe7c0dfcd26` |
+| effectivenessmonitor | `quay.io/kubernaut-ai/effectivenessmonitor@sha256:87e263681209b115e61a2a4d3948a0e20367ac9ae0be1f4da9e967a240d90d8b` |
+| notification | `quay.io/kubernaut-ai/notification@sha256:098b8e2a8e32693f043957562c7236a7f7f741386cb74ab1ffb63fa8e71dfb87` |
+| kubernautagent | `quay.io/kubernaut-ai/kubernautagent@sha256:e722d66d97d5fd2b74850b78cc11c175674490cc3df2ef2abea6a3afb190ec19` |
+| authwebhook | `quay.io/kubernaut-ai/authwebhook@sha256:cdde1af3e5180300b9c25c49d55973b6182bf73fd5ea1740016991d5118bb830` |
+| apifrontend | `quay.io/kubernaut-ai/apifrontend@sha256:3dc9059c26ed65c88d98b422baf544a36630cdcc4068abd6f8cefd05fa0bbf53` |
+| db-migrate | `quay.io/kubernaut-ai/db-migrate@sha256:86cdd9c8d1269046e2eee9a9c09b7919ac6e4e91c29a48b525ae07870ef93215` |
+| kubernaut-console | `quay.io/kubernaut-ai/kubernaut-console@sha256:44fb41010769a26d9c8820758c3bb0f2d979c5c98738b67b0c269405733f66b0` |
+
+#### Console Sidecar
+
+| Component | Source Image |
+|---|---|
+| oauth2-proxy | `quay.io/oauth2-proxy/oauth2-proxy@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7` |
 
 #### Infrastructure Dependencies (BYO PostgreSQL & Valkey)
 
@@ -263,34 +274,47 @@ When using `oc mirror`, the generated `ImageDigestMirrorSet` (IDMS) instructs CR
 
 #### 1.1 Create the ImageSetConfiguration
 
-Save the following as `imageset-config.yaml`:
+The operator repository publishes a ready-to-use `imageset-config.yaml` as a release asset, generated from the exact image digests shipped in that release. Download the one matching your target release directly on the bastion host, rather than copying the example below (which will not match the digests you actually mirror):
 
-```yaml
-kind: ImageSetConfiguration
-apiVersion: mirror.openshift.io/v2alpha1
-mirror:
-  additionalImages:
-    # Operator
-    - name: quay.io/kubernaut-ai/kubernaut-operator@sha256:586e5344ec3897fa2e80bab5207f1eca1611fdc4c6db80113247a1539c7941b7
-    # Kubernaut v1.5.1 components
-    - name: quay.io/kubernaut-ai/gateway@sha256:8ef1d69db4508bfa0ab86e7f22100952ddae85c6e22d81293580d9defaf94004
-    - name: quay.io/kubernaut-ai/datastorage@sha256:f10d8c98017c7df35133dc98f0e26e36054ec4584ac5c230b0252d3a5c9a0b44
-    - name: quay.io/kubernaut-ai/aianalysis@sha256:b31b8aaba5f4f3d5df1639213bca23c63438e257704ee0ac6d5f1d9ec82314b0
-    - name: quay.io/kubernaut-ai/signalprocessing@sha256:de7393f8d0cbd07fadacf13ae0b9504cec321c09e1614c6839ccf1c65ec4d86e
-    - name: quay.io/kubernaut-ai/remediationorchestrator@sha256:54778cdfd8e3a7fcef4cd871479c6101e566be0aa8fd0d5e37ed1a0c685eecb8
-    - name: quay.io/kubernaut-ai/workflowexecution@sha256:47369cf7ab80bf398edca84ff4097028988303cfcc94a8a760cd4235faa7f008
-    - name: quay.io/kubernaut-ai/effectivenessmonitor@sha256:96aa70fcbd7d752632f18cd7ee57c009c99ab5667d7f070fbf33fd4e163e9752
-    - name: quay.io/kubernaut-ai/notification@sha256:e1c4a270651fe05ca4c2d8e9588ebfb723584d5d0e80620af0cf7cf27ad643dd
-    - name: quay.io/kubernaut-ai/kubernautagent@sha256:e4bf7bfbe1a3351266b9045ae19b4b012e12fd5a52b9f6559824918215dac184
-    - name: quay.io/kubernaut-ai/authwebhook@sha256:67b4093ca3d686077dd7816de88ce97ce729a32513e8e9fbe93433dae1434688
-    - name: quay.io/kubernaut-ai/apifrontend@sha256:54b57237ddbaa9d39cd6d7abf4fdabbc55406f1ef824fc020154ec5d20789946
-    - name: quay.io/kubernaut-ai/db-migrate@sha256:d94cdefac33c895524743697575425d3a458a97dc9c544deaa72b852b61637b3
-    # Infrastructure dependencies (PostgreSQL, Valkey)
-    - name: registry.redhat.io/rhel10/postgresql-16@sha256:877ac0f8207ada1559ef73b70e92616255b95d3b6ef6a1af314c0f67edfde96e
-    - name: registry.redhat.io/rhel10/valkey-8@sha256:7b478930b2d186a61c3af408c3228f3da5104c759b8bd52d62c683e33bdb9ee2
-    # Init containers
-    - name: registry.access.redhat.com/ubi10/ubi-minimal@sha256:7dc60d7777e010c50f5e041ff069112b379c3d5eef2823d20871c67cf663f10c
+```bash
+curl -fsSL \
+  https://github.com/jordigilh/kubernaut-operator/releases/latest/download/imageset-config.yaml \
+  -o imageset-config.yaml
 ```
+
+Or, to pin to a specific release, replace `latest` with a tag, e.g. `.../releases/download/v1.5.10/imageset-config.yaml`.
+
+??? example "imageset-config.yaml shape (operator v1.5.10 — illustrative only, do not copy digests)"
+    ```yaml
+    kind: ImageSetConfiguration
+    apiVersion: mirror.openshift.io/v2alpha1
+    mirror:
+      additionalImages:
+        # Operator
+        - name: quay.io/kubernaut-ai/kubernaut-operator@sha256:d93d632ce5d66f0d9e5ba79e14f6754252452a8b6833f6d8778db10f330ef692
+        # Operator bundle
+        - name: quay.io/kubernaut-ai/kubernaut-operator-bundle@sha256:5c79c75b2fa1e610518640b871cc254a2df78165789a95d1dd071d555950d4b9
+        # Operand and infrastructure images
+        - name: quay.io/kubernaut-ai/aianalysis@sha256:dc7643a7c39bd451f7e83ca1f853a15eaf6beb942a79867e2ad37e88276edd05
+        - name: quay.io/kubernaut-ai/apifrontend@sha256:3dc9059c26ed65c88d98b422baf544a36630cdcc4068abd6f8cefd05fa0bbf53
+        - name: quay.io/kubernaut-ai/authwebhook@sha256:cdde1af3e5180300b9c25c49d55973b6182bf73fd5ea1740016991d5118bb830
+        - name: quay.io/kubernaut-ai/datastorage@sha256:4a2756b37fcfd122b9635058ee2d617b710706e7e5c2b52718a46f58c8fd6c52
+        - name: quay.io/kubernaut-ai/db-migrate@sha256:86cdd9c8d1269046e2eee9a9c09b7919ac6e4e91c29a48b525ae07870ef93215
+        - name: quay.io/kubernaut-ai/effectivenessmonitor@sha256:87e263681209b115e61a2a4d3948a0e20367ac9ae0be1f4da9e967a240d90d8b
+        - name: quay.io/kubernaut-ai/gateway@sha256:1694c28ad2ef118ffaeba1fd9652234f8998fdfd06da2d412cc92bcf111c01d2
+        - name: quay.io/kubernaut-ai/kubernaut-console@sha256:44fb41010769a26d9c8820758c3bb0f2d979c5c98738b67b0c269405733f66b0
+        - name: quay.io/kubernaut-ai/kubernautagent@sha256:e722d66d97d5fd2b74850b78cc11c175674490cc3df2ef2abea6a3afb190ec19
+        - name: quay.io/kubernaut-ai/notification@sha256:098b8e2a8e32693f043957562c7236a7f7f741386cb74ab1ffb63fa8e71dfb87
+        - name: quay.io/kubernaut-ai/remediationorchestrator@sha256:6dd491a467b412b2ad8492c074d15f4ba7306c3a097b543c1f24b117d0169567
+        - name: quay.io/kubernaut-ai/signalprocessing@sha256:df2d4dc75492f190517c71df5e0dccdbf54470ede5333a3c191d4027dbfa2367
+        - name: quay.io/kubernaut-ai/workflowexecution@sha256:3d799c36d30ddb822edeb57ffc6bd81fb3b9bc4ff5cdf1ec90d5fbe7c0dfcd26
+        # Console oauth2-proxy sidecar
+        - name: quay.io/oauth2-proxy/oauth2-proxy@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+        - name: registry.access.redhat.com/ubi10/ubi-minimal@sha256:7dc60d7777e010c50f5e041ff069112b379c3d5eef2823d20871c67cf663f10c
+        - name: registry.redhat.io/rhel10/postgresql-16@sha256:877ac0f8207ada1559ef73b70e92616255b95d3b6ef6a1af314c0f67edfde96e
+        # Infrastructure dependencies (PostgreSQL, Valkey)
+        - name: registry.redhat.io/rhel10/valkey-8@sha256:7b478930b2d186a61c3af408c3228f3da5104c759b8bd52d62c683e33bdb9ee2
+    ```
 
 #### 1.2 Configure Registry Authentication
 
@@ -365,9 +389,11 @@ From the bastion host, download the operator install manifest:
 
 ```bash
 curl -fsSL \
-  https://raw.githubusercontent.com/jordigilh/kubernaut-operator/v1.5.1/dist/install.yaml \
+  https://github.com/jordigilh/kubernaut-operator/releases/latest/download/install.yaml \
   -o install.yaml
 ```
+
+To pin to a specific operator release instead of the latest, replace `latest` with a tag, e.g. `.../releases/download/v1.5.10/install.yaml`.
 
 #### 2.2 Apply the Manifest
 

--- a/docs/user-guide/configmap-kubernaut-agent.md
+++ b/docs/user-guide/configmap-kubernaut-agent.md
@@ -130,7 +130,10 @@ ai:
     vertexLocation: ""        # Vertex-specific
     bedrockRegion: ""         # Bedrock-specific
     structuredOutput: false   # Reserved; KA always enables JSON mode internally (see note below)
-    temperature: 0.7          # Creativity vs determinism (0.0--1.0)
+    temperature: 0.7          # Creativity vs determinism (0.0--1.0). Omit this key entirely to
+                              #   send no temperature parameter at all (v1.5.5+, #1749) -- required
+                              #   for models (e.g. claude-opus-4-8) that reject the parameter with
+                              #   an HTTP 400 if present. See "Temperature Tuning" below.
     maxRetries: 3             # LLM call retry count
     timeoutSeconds: 120       # Per-call timeout
     tlsCaFile: ""             # Custom CA cert for LLM endpoint (PEM, absolute path)
@@ -191,8 +194,9 @@ The `phaseModels` map in the `kubernaut-agent-llm-runtime` ConfigMap allows conf
 | `vertexProject` | GCP project override |
 | `vertexLocation` | GCP region override |
 | `bedrockRegion` | AWS Bedrock region override |
+| `temperature` | Override base/phase temperature (v1.5.5+, #1749). `nil`/omitted means inherit the base value unchanged. |
 
-`temperature`, `maxRetries`, and `timeoutSeconds` are always inherited from the base `LLMRuntimeConfig` and cannot be overridden per phase.
+`maxRetries` and `timeoutSeconds` are always inherited from the base `LLMRuntimeConfig` and cannot be overridden per phase.
 
 **Merge behavior**: `EffectivePhaseConfig()` copies the base config, then overlays non-empty override fields. If `phaseModels` is empty or the phase has no entry, the base config is used unchanged.
 
@@ -210,7 +214,7 @@ The `phaseModels` map in the `kubernaut-agent-llm-runtime` ConfigMap allows conf
     ```yaml
     model: gpt-4o
     endpoint: http://llm-gateway:8080/v1
-    temperature: 0.7
+    # temperature omitted here -- base calls send no temperature parameter (v1.5.5+ default)
     maxRetries: 3
     timeoutSeconds: 120
     phaseModels:
@@ -218,6 +222,7 @@ The `phaseModels` map in the `kubernaut-agent-llm-runtime` ConfigMap allows conf
         provider: anthropic
         endpoint: http://anthropic-api
         model: claude-sonnet-4-6
+        temperature: 0.4       # RCA phase overrides the (omitted) base temperature explicitly
       workflow_discovery:
         model: claude-haiku-3
       validation:
@@ -390,9 +395,16 @@ The Secret is marked `optional: true` — the agent starts without it but all LL
 
 ## Temperature Tuning
 
+!!! info "Default changed in v1.5.5 (#1749, BR-HAPI-199)"
+    `ai.llm.temperature` has **no default value** — if the key is absent from the runtime ConfigMap, KA sends no `temperature` parameter at all in LLM requests, rather than defaulting to `0.7`. This is required for models (e.g. `claude-opus-4-8`) that reject the request outright with an HTTP 400 if `temperature` is present at all. `Temperature` is a pointer end-to-end (`*float64`) so "unset" and "explicitly set to `0`" are distinguishable — an explicit `temperature: 0` is still sent as `0`, not omitted. Set the key explicitly (any value, including `0`) if your model supports and requires an explicit temperature.
+
+When you do set it explicitly:
+
 - **0.3--0.5**: More deterministic. Recommended for production.
-- **0.7** (default): Balanced.
+- **0.7**: Balanced — commonly used, but no longer applied automatically.
 - **0.8--1.0**: More creative. May discover non-obvious root causes but less consistent.
+
+`phaseModels.<phase>.temperature` can override the base value per phase (v1.5.5+) — see [Per-phase LLM routing](#per-phase-llm-routing-v151).
 
 ## mTLS for LLM Proxy (#1342)
 

--- a/docs/user-guide/configmap-policies.md
+++ b/docs/user-guide/configmap-policies.md
@@ -52,7 +52,10 @@ environment := {"environment": "production", "source": "namespace-labels"} if {
 }
 
 # ========== Severity ==========
-# Returns: string (critical/high/medium/low/unknown)
+# Returns: string (critical/high/warning/info/unknown) -- 4-level model, ADR-066/#1484 (v1.5.2+).
+# `input.signal.severity` may still carry legacy raw values like "medium"/"low"/"sev3" from the
+# alert source -- map those down explicitly (e.g. medium/sev3 -> "warning", low -> "info"); this
+# rule's *output* must always be one of the 5 values above.
 default severity := "unknown"
 severity := "critical" if { input.signal.severity == "critical" }
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -295,6 +295,10 @@ When deploying via the **Kubernaut Operator**, severity triage is auto-derived f
 | `apifrontend.config.auth.jwtProviders[].claimMappings.username` | CEL expression to extract username from JWT claims (e.g., `claims.email`). Falls back to `preferred_username` / `sub` when empty (#1392). | `""` |
 | `apifrontend.config.auth.jwtProviders[].claimMappings.groups` | CEL expression to extract groups from JWT claims (e.g., `claims.roles`). Falls back to `groups` claim when empty (#1392). | `""` |
 | `apifrontend.config.rbac.sarCacheTTL` | SAR result cache TTL | `30s` |
+| `apifrontend.config.rbac.consoleAccessGroups` | OIDC groups granted the coarse-grained `kubernaut.ai/console` "use" gate (v1.5.6, #1919). Checked in addition to the existing per-tool `kubernaut.ai/tools` grant on every `/mcp` and `/a2a/invoke` call. | All 6 built-in persona names: `sre`, `ai-orchestrator`, `cicd`, `observability`, `l3-audit`, `remediation-approver` |
+
+!!! danger "Upgrade action required for custom persona groups (v1.5.6)"
+    If you added or renamed a group under `apifrontend.config.rbac.personas` beyond the 6 defaults, that group is **not** automatically included in `consoleAccessGroups` — its members will have every AF tool call denied after upgrading, even though their per-tool grants are unchanged. Add the group name to `consoleAccessGroups` explicitly. `helm install`/`helm upgrade` prints a `NOTES.txt` warning listing any `personas` group missing from `consoleAccessGroups`. See [Security & RBAC: Console-access authorization gate](../architecture/security-rbac.md#console-access-gate) for the full model, including how the **Kubernaut Operator's** default for this field differs from the Helm chart's (auto-derived from existing `roleBindings` groups, rather than a static persona list).
 
 #### JWT Providers (v1.5.1) {: #jwt-providers-v151 }
 

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -6,6 +6,88 @@ Review the changes below to understand what differs from the version you are cur
 
 ---
 
+## v1.5.6
+
+### Security: Console-access authorization gate
+
+v1.5.6 adds a **coarse-grained console-access SAR check** in front of every AF tool call, independent of the existing per-tool authorization (#1919, #1941, AC-3/AC-6/AU-12). Every `POST /mcp` and `POST /a2a/invoke` request must now pass both the new `kubernaut.ai/console` "use" check and the pre-existing per-tool `kubernaut.ai/tools` check. A new advisory `GET /a2a/access` endpoint lets UI clients pre-flight the gate.
+
+!!! danger "Operator action may be required"
+    The Helm chart's `apifrontend.config.rbac.consoleAccessGroups` value defaults to all 6 built-in persona group names, so deployments using only those defaults need no changes. If you configured a **custom** group under `apifrontend.config.rbac.personas`, you must add that same group name to `consoleAccessGroups`, or its members will have **every** tool call denied after upgrading — even though their existing per-tool grants are unchanged. `helm install`/`helm upgrade` now prints a `NOTES.txt` warning listing any `personas` group missing from `consoleAccessGroups` to catch this at deploy time.
+
+    Deployments via the **Kubernaut Operator** are not at risk of this: when `spec.apiFrontend.rbac.consoleAccessGroups` is left unset, the operator auto-derives it as the union of groups already present in `roleBindings`, so every group with existing tool access keeps console access automatically.
+
+See [Security & RBAC: Console-access authorization gate](../architecture/security-rbac.md#console-access-gate) for the full model, and [Configuration: RBAC](../user-guide/configuration.md) for the Helm value.
+
+### Platform hardening
+
+Several reliability fixes to the interactive investigation pipeline, most notably:
+
+- **`kubernaut_present_decision` crashed the entire interactive approve/decline/dismiss flow on every grounded decision (#2110)** — a structured RCA substitution was assigned as a non-`gob`-registered struct pointer, which failed the a2a artifact deep-copy pipeline. Fixed by assigning a plain map instead.
+- **`workflow_discovery` could hang indefinitely** when a same-kind/API-version validation gate's non-streamed retry call exceeded AF's inactivity budget (#2086), or after the LLM's terminal decision response with no timeout at all (#1949) — both now emit keepalive events / are wired into inactivity-cancel paths.
+- **Interactive session capacity eroded under sustained load** before configured concurrency limits were reached (#2100), and the active-sessions gauge drifted upward instead of tracking real capacity (#2103) — the previously-unused `SessionJanitor` is now wired in, and every completion path decrements the gauge centrally.
+- **`apiVersion` could fail to reach KA's workflow-discovery filter**, silently degrading to kind-only matching and risking the wrong workflow being selected when a Kind exists in more than one API group (#2061, #2064, #2066) — closed across the CRD-fallback resolver, AA's request to KA, and Gateway's event/alert resolution.
+
+See the [v1.5.6 release notes](https://github.com/jordigilh/kubernaut/releases/tag/v1.5.6) for the complete list (23 fixed issues in this release).
+
+### Security: CVE remediation
+
+- **CVE-2026-56852** in `golang.org/x/text`, pulled in transitively by the `db-migrate` image's goose builder (#1763, #1781) — pinned to the patched version.
+
+---
+
+## v1.5.5
+
+### Fixed: Kubernaut Agent `temperature` is no longer sent unless explicitly configured
+
+Some models (e.g. `claude-opus-4-8`) reject the LLM `temperature` parameter outright with an HTTP 400, which previously surfaced to users as a generic `internal_error` during workflow discovery (#1749, BR-HAPI-199). `Temperature` is now a pointer end-to-end, and the `kubernaut-agent-llm-runtime` ConfigMap rendered by the Helm chart **omits `temperature` by default** instead of defaulting to `0.7`.
+
+!!! info "Action needed only if your model requires an explicit temperature"
+    Set `kubernautAgent.llm.temperature` explicitly (including `0`) if your model supports and requires it. See [Kubernaut Agent Config: Temperature Tuning](../user-guide/configmap-kubernaut-agent.md#temperature-tuning).
+
+---
+
+## v1.5.4
+
+Primarily a CI/Helm-smoke-test infrastructure release (a CI runner Kind version bump exposed four latent chart/test gaps, all backported fixes of issues already fixed independently on `main`). One change affects real cluster installs:
+
+- **`networkPolicies.apiServerCIDR` auto-discovery** — previously required manually setting the API-server CIDR/port for NetworkPolicy-selected pods to reach the Kubernetes API server (a hard requirement for `authwebhook`'s startup init container). The chart now auto-discovers the real backend endpoint IP(s) and port via a Helm `lookup` against the live `kubernetes` Endpoints object during any real `helm install`/`upgrade` — no manual `--set` needed in the common case. Manual override remains available and is **required** for `helm template`/GitOps rendering, where `lookup` has no live-cluster access.
+
+---
+
+## v1.5.3
+
+### Fixed: workflow registration no longer pre-flights the registry
+
+DataStorage no longer performs a registry existence check (`execution.bundle`) at workflow registration time (#1642) — that check ran from DataStorage's own network/credential context and couldn't validate self-signed or credential-required private registries reachable only by the workflow execution environment. An incorrect or unreachable image now registers successfully and fails later, at Job/PipelineRun image-pull time. See [Workflow Schema Reference: Bundle Digest Format](../user-guide/workflows.md#bundle-digest-format) for the operator-facing detail.
+
+---
+
+## v1.5.2
+
+### Breaking: 4-level severity model (ADR-066)
+
+The severity model was collapsed from a free-form scheme to 4 canonical values: `critical`, `high`, `warning`, `info` (plus `unknown` as the classification fallback) — replacing `medium` with `warning` and `low` with `info` across CRD enums, OpenAPI specs, Rego policies, LLM prompt templates, and mock-LLM fixtures (#1484).
+
+`medium` and `low` remain accepted as **input aliases** in the shipped example Rego policy (mapped down to `warning`/`info` respectively) for backward compatibility with existing AlertManager/webhook severity labels — but no Kubernaut component ever stores or emits `medium`/`low` as an output value anymore. If you have external tooling, dashboards, or custom Rego policies that branch on the literal strings `medium` or `low` coming out of Kubernaut's `SignalProcessing.status.severity` (or the equivalent `Signal.severity` audit field), update them to `warning`/`info`.
+
+### Added: OpenAI-compatible LLM adapter
+
+A new `openai_compatible` provider lets the **Kubernaut Agent** connect to OpenAI-compatible endpoints (LlamaStack, vLLM, Ollama, Azure OpenAI) over plain `net/http` with `http.Client` injection for mTLS transport chains — supporting streaming (SSE), tool-call accumulation, and generation-config forwarding (#1487, BR-INTEGRATION-1254). Configure via `ai.llm.provider: openai` and an `endpoint` pointing at the server origin. See [Kubernaut Agent Config: OpenAI-Compatible](../user-guide/configmap-kubernaut-agent.md#openai-compatible-vllm-localai-tgi).
+
+!!! warning "Not available for severity triage"
+    The API Frontend's `severityTriage.llm` block does **not** go through this adapter — it only supports `vertex_ai`, `gemini`, and `anthropic`. Setting `severityTriage.llm.provider: openai` or `openai_compatible` passes config validation but fails at runtime with `unsupported triage LLM provider`. See [Configuration: Severity Triage](../user-guide/configuration.md#severity-triage-v151).
+
+### Fixed
+
+- **Cluster-scoped namespace strip (#1480, #1477)** — Dynamic scope resolution via RESTMapper for `ka_investigate_mcp`, self-healing namespace strip for cluster-scoped resources in AF, and scope-aware namespace resolution in Effectiveness Monitor target resource fetch.
+
+### Security
+
+- **CVE remediation in db-migrate (#1485)** — Pinned `x/crypto` and `x/net` to resolve known CVEs.
+
+---
+
 ## v1.5.1
 
 ### Kubernaut Console

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,8 +43,13 @@ extra:
   # (kubernaut commit 55bd533ca) and only bump together occasionally. Verify
   # against the registry before bumping: `crane manifest quay.io/kubernaut-ai/charts/kubernaut:<version>`
   chart_version: "1.4.2"
-  image_tag: "v1.5.3"
-  operator_image_tag: "1.5.4"
+  # image_tag/operator_image_tag: both quay.io/kubernaut-ai repos tag images
+  # with the bare semver (no "v" prefix) -- verified against the live
+  # registry (`quay.io/api/v1/repository/kubernaut-ai/<repo>/tag/`) before
+  # each bump. image_tag tracks kubernaut's app release; operator_image_tag
+  # tracks kubernaut-operator's own, independently-versioned release.
+  image_tag: "1.5.6"
+  operator_image_tag: "1.5.10"
   version:
     provider: mike
     default: latest


### PR DESCRIPTION
## Summary

Closes the documentation gaps identified from a review of every change between upstream `kubernaut` v1.5.0 and v1.5.6. Each change is grounded directly in the relevant source at the matching release tag (Go structs, Helm templates, Rego policies) or the live container registry, rather than inferred from the changelog alone — see individual commit messages for exact file/line/API citations.

- **Critical**: the v1.5.6 console-access authorization gate (`kubernaut.ai/console` SAR check, #1919) was completely undocumented, including a real upgrade hazard for Helm deployments with custom persona groups vs. the Operator's (safer) auto-derived default (kubernaut-operator#289).
- **High**: `docs/whats-new/index.md` silently skipped v1.5.2 through v1.5.6 (jumped straight from v1.5.1 to v1.4); the Kubernaut Agent `temperature` default docs were stale after v1.5.5 made it optional (and per-phase override docs missed that the same change added phase-level override support); a Rego policy example's severity comment still listed the pre-ADR-066 4-level scheme.
- **Medium**: the direct-manifest operator install commands hardcoded stale version tags that go stale on every release; the air-gapped image inventory was pinned to v1.5.1 digests and missing two images added since (`kubernaut-console`, `oauth2-proxy` sidecar); the site-wide `image_tag` macro was 3 releases stale *and* had always carried an incorrect `v` prefix that doesn't exist on the real registry tags.

## Commits

1. `docs: document v1.5.6 console-access authorization gate` — `security-rbac.md`, `configuration.md`, `operator-cr.md`
2. `docs: backfill what's-new entries for v1.5.2 through v1.5.6` — `whats-new/index.md`
3. `docs: fix stale temperature default and per-phase override docs` — `configmap-kubernaut-agent.md`
4. `docs: fix stale severity enum comment in Rego policy example` — `configmap-policies.md`
5. `docs: use releases/latest URL for operator install, refresh image digests` — `installation.md`, `disconnected-install.md`
6. `docs: bump image_tag to latest kubernaut v1.5.6, fix stale v-prefix` — `mkdocs.yml`, `installation.md`

## Test plan

- [x] `mkdocs build --strict` succeeds with no new warnings
- [x] Every new/changed anchor link verified against actual `markdown.extensions.toc` slug output (not just eyeballed)
- [x] `releases/latest/download/install.yaml` and `imageset-config.yaml` URLs verified to resolve (HTTP 200) against the real `kubernaut-operator` GitHub release assets
- [x] Refreshed image digests pulled directly from the `imageset-config.yaml` asset published with `kubernaut-operator` v1.5.10 (not fabricated)
- [x] `image_tag`/`operator_image_tag` values and the "no `v` prefix" claim verified against the live `quay.io/api/v1/repository/kubernaut-ai/...` tag listing, not assumed
- [ ] Docs team spot-check of the console-access gate section for tone/completeness

## Note for follow-up (not included in this PR)

While verifying `chart_version`, I found the live `oci://quay.io/kubernaut-ai/charts/kubernaut` registry now has a `1.5.6` tag (matching the app version) *and* an already-published `1.6.0` tag. `chart_version` is currently `1.4.2` and its own code comment explicitly warns not to bump it casually since it's intentionally decoupled from the app release. Given the ambiguity of whether `1.6.0` is an in-progress/pre-release chart line, I left `chart_version` untouched — flagging here for a maintainer to decide separately.