### PR TITLE
ci: deploy v1.6 as preview without latest alias

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           VERSION="${{ github.event.inputs.version }}"
           if [ -z "$VERSION" ]; then
-            VERSION="v1.5"
+            VERSION="v1.6"
           fi
 
           if [ "$VERSION" = "v1.5" ]; then


### PR DESCRIPTION
## Summary

Second half of the v1.5 freeze / v1.6 prep plan (follow-up to #221, which froze v1.5 docs at v1.5.7 GA and confirmed the resulting deploy succeeded — `v1.5`/`latest` on gh-pages now serve the v1.5.7 content).

- Bumps the `deploy-docs.yml` fallback `VERSION` (used for untagged `push`/`repository_dispatch` triggers) from `v1.5` to `v1.6`.
- Leaves the `latest`/`set-default` alias logic gated to `v1.5` — mirrors the exact pattern used for the v1.4→v1.5 transition (commit `af24afe`, "ci: deploy v1.5 as preview without latest alias").

Net effect: future `main` pushes deploy a new, standalone `v1.6` mike version (visible via the version switcher) without disturbing `latest`, which stays pinned to the just-frozen `v1.5` snapshot. `v1.5` can still be explicitly redeployed later via `workflow_dispatch` with `version=v1.5` if a v1.5-only docs fix is needed.

## Test plan

- [x] `mkdocs build --strict` passes locally
- [ ] After merge: trigger a `main` push (or `workflow_dispatch`) and confirm mike publishes a new `v1.6` version without touching the `latest` alias