### PR TITLE
docs(fleet): replace hard-to-read mermaid diagram with graphical SVG

### DIFF
--- a/docs/architecture/fleet.md
+++ b/docs/architecture/fleet.md
@@ -24,49 +24,44 @@ The **MCP Gateway is external infrastructure** -- like PostgreSQL or Prometheus,
 
     ```mermaid
     flowchart TB
-        subgraph Mgmt["Hub Cluster"]
-            Thanos["Thanos Querier<br/><small>multi-cluster Prometheus</small>"] -->|alerts, cluster label| GW["Gateway"]
-            GW --> RO["Remediation<br/>Orchestrator"]
-            RO --> SP["Signal<br/>Processing"]
-            RO --> AA["AI Analysis"]
-            AA --> KA["Kubernaut Agent"]
-            RO --> WE["Workflow<br/>Execution"]
-            AF["API Frontend"] -->|creates RemediationRequest| RO
-            RO -->|creates EffectivenessAssessment| EM["Effectiveness<br/>Monitor"]
-            FMC["FMC<br/><small>Fleet Metadata Cache</small>"]
+        Thanos["Thanos Querier<br/><small>multi-cluster Prometheus</small>"] -->|alerts, cluster label| GW["Gateway"]
+        AF["API Frontend"]
 
-            GW -.->|"scope check<br/>p95 &lt; 50ms"| FSC["FederatedScopeChecker"]
-            RO -.->|scope check| FSC
-            FSC -->|local| K8sAPI["local K8s API"]
-            FSC -->|remote| Backend["scope.ScopeChecker<br/>backend adapter"]
-            Backend --> Valkey[("Valkey<br/>(FMC default)")]
-            FMC -->|polls, writes| Valkey
-
-            GW -.->|read| GWY
-            KA -.->|read| GWY
-            RO -.->|read| GWY
-            SP -.->|read| GWY
-            AF -.->|read| GWY
-            EM -.->|read| GWY
-            FMC -.->|read: cluster registry| GWY
-            WE -->|"read + write<br/>(remediation)"| GWY["MCP Gateway<br/><small>Kuadrant or Envoy AI Gateway</small>"]
-
-            IdP["OAuth2 Provider<br/><small>e.g. Keycloak, DEX</small>"]
-            GW -.->|"client-credentials<br/>(all 7 Fleet-dependent services)"| IdP
-            GWY -.->|validates token| IdP
+        subgraph Engine["Kubernaut Engine"]
+            direction LR
+            RO["Remediation<br/>Orchestrator"] --> SP["Signal<br/>Processing"]
+            SP --> AA["AI Analysis"] --> KA["Kubernaut Agent"]
+            AA --> WE["Workflow<br/>Execution"]
+            RO --> EM["Effectiveness<br/>Monitor"]
         end
 
-        GWY --> MCPa["K8s MCP Server<br/>Cluster A"]
-        GWY --> MCPb["K8s MCP Server<br/>Cluster B"]
-        GWY --> MCPc["K8s MCP Server<br/>Cluster C"]
+        GW -->|creates RemediationRequest| RO
+        AF -->|"creates +<br/>watches RemediationRequest"| RO
 
-        MCPa -.->|"requests token exchange<br/>RFC 8693"| IdP
-        MCPb -.->|"requests token exchange<br/>RFC 8693"| IdP
-        MCPc -.->|"requests token exchange<br/>RFC 8693"| IdP
+        subgraph ScopeBackend["Scope Check Backend"]
+            direction LR
+            FSC["FederatedScopeChecker"] -->|local| K8sAPI["local K8s API"]
+            FSC -->|remote| Backend["scope.ScopeChecker<br/>adapter (FMC / ACM / ...)"]
+            Backend --> Valkey[("Valkey<br/>(FMC default)")]
+            FMC["FMC<br/><small>Fleet Metadata Cache</small>"] -->|polls, writes| Valkey
+        end
 
-        MCPa --> ClusterA[("Cluster A")]
-        MCPb --> ClusterB[("Cluster B")]
-        MCPc --> ClusterC[("Cluster C")]
+        GW & RO -.->|scope check| FSC
+
+        IdP(["OAuth2 Provider<br/><small>e.g. Keycloak, DEX</small>"])
+        GW -.->|"client-credentials<br/>(all 7 Fleet-dependent services)"| IdP
+
+        Engine -.->|"read<br/>(6 services)"| GWY
+        WE -->|"read + write<br/>(remediation)"| GWY["MCP Gateway<br/><small>Kuadrant or Envoy AI Gateway</small>"]
+        AF -.->|read| GWY
+        FMC -.->|"read:<br/>cluster registry"| GWY
+        GWY <-.->|validates token| IdP
+
+        GWY --> MCPa["K8s MCP Server<br/>Cluster A"] --> ClusterA[("Cluster A")]
+        GWY --> MCPb["K8s MCP Server<br/>Cluster B"] --> ClusterB[("Cluster B")]
+        GWY -.->|"same pattern,<br/>100s more clusters"| MCPc["..."]
+
+        MCPa -.->|"requests token exchange, RFC 8693<br/><small>(every cluster's MCP server does this independently)</small>"| IdP
     ```
 
     Two distinct OAuth2 interactions happen against the same IdP, and the Gateway is not involved in either: the MCP Gateway only **validates** the caller's client-credentials token at the edge. The actual **RFC 8693 Standard Token Exchange** is performed by the **OAuth2 Provider itself** -- it is the only party that holds both the caller's identity (the passthrough token it already issued) and the target audience's requirements (the client-scope/audience-mapper assignment for `kube-mcp-server`), so only it can validate the old token and mint the new one. Each remote cluster's `kube-mcp-server` merely **requests** this exchange (`POST .../protocol/openid-connect/token` with `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`, per its `keycloak-v1` exchange strategy) and receives back a token newly scoped to its own Kubernetes API server.

--- a/docs/architecture/fleet.md
+++ b/docs/architecture/fleet.md
@@ -60,16 +60,16 @@ The **MCP Gateway is external infrastructure** -- like PostgreSQL or Prometheus,
         GWY --> MCPb["K8s MCP Server<br/>Cluster B"]
         GWY --> MCPc["K8s MCP Server<br/>Cluster C"]
 
-        MCPa -.->|"token exchange<br/>RFC 8693"| IdP
-        MCPb -.->|"token exchange<br/>RFC 8693"| IdP
-        MCPc -.->|"token exchange<br/>RFC 8693"| IdP
+        MCPa -.->|"requests token exchange<br/>RFC 8693"| IdP
+        MCPb -.->|"requests token exchange<br/>RFC 8693"| IdP
+        MCPc -.->|"requests token exchange<br/>RFC 8693"| IdP
 
         MCPa --> ClusterA[("Cluster A")]
         MCPb --> ClusterB[("Cluster B")]
         MCPc --> ClusterC[("Cluster C")]
     ```
 
-    Two distinct OAuth2 interactions happen against the same IdP: the MCP Gateway only **validates** the caller's client-credentials token at the edge; the actual **RFC 8693 Standard Token Exchange** -- swapping that passthrough token for one scoped to the local cluster's Kubernetes API server -- happens independently inside each remote cluster's `kube-mcp-server`, not in the Gateway itself.
+    Two distinct OAuth2 interactions happen against the same IdP, and the Gateway is not involved in either: the MCP Gateway only **validates** the caller's client-credentials token at the edge. The actual **RFC 8693 Standard Token Exchange** is performed by the **OAuth2 Provider itself** -- it is the only party that holds both the caller's identity (the passthrough token it already issued) and the target audience's requirements (the client-scope/audience-mapper assignment for `kube-mcp-server`), so only it can validate the old token and mint the new one. Each remote cluster's `kube-mcp-server` merely **requests** this exchange (`POST .../protocol/openid-connect/token` with `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`, per its `keycloak-v1` exchange strategy) and receives back a token newly scoped to its own Kubernetes API server.
 
 ## Component Responsibilities
 
@@ -81,7 +81,7 @@ The **MCP Gateway is external infrastructure** -- like PostgreSQL or Prometheus,
 | **FederatedScopeChecker** | Routes scope checks: `ClusterID == ""` -> local `scope.Manager`; `ClusterID != ""` -> the configured remote backend adapter |
 | **GatewayDiscoverer** | Cluster/tool discovery interface, implemented once per supported gateway (Kuadrant, EAIGW). Called **server-side only** -- never LLM-facing (see below) |
 | **CRDWatcher** | Discovers clusters from the gateway's own native CRDs (`MCPRoute`/`Backend` for EAIGW, `MCPServerRegistration` for Kuadrant); Kubernaut is a read-only consumer, never creates or modifies these |
-| **OAuth2 Provider** | External IdP (Keycloak, DEX, or any OIDC-compliant provider) issuing client-credentials tokens (`pkg/fleet/mcpclient`). All 7 Fleet-dependent services acquire, cache, and auto-refresh a token before calling the MCP Gateway; the Gateway validates it against the same IdP. Independently, each remote cluster's **K8s MCP Server** (`kube-mcp-server`) performs its own RFC 8693 Standard Token Exchange against the same IdP, swapping the passthrough token for one scoped to that cluster's own Kubernetes API server before serving the call. Not shipped by the Helm chart -- like the MCP Gateway itself, platform teams bring their own. |
+| **OAuth2 Provider** | External IdP (Keycloak, DEX, or any OIDC-compliant provider) issuing client-credentials tokens (`pkg/fleet/mcpclient`). All 7 Fleet-dependent services acquire, cache, and auto-refresh a token before calling the MCP Gateway; the Gateway validates it against the same IdP. Independently, each remote cluster's **K8s MCP Server** (`kube-mcp-server`) *requests* an RFC 8693 Standard Token Exchange from the same IdP -- the IdP itself performs the exchange (it alone holds both the caller's identity and the target audience's requirements) and returns a token newly scoped to that cluster's own Kubernetes API server. Not shipped by the Helm chart -- like the MCP Gateway itself, platform teams bring their own. |
 
 Signal Processing, API Frontend, and Effectiveness Monitor also participate as read-only MCP Gateway callers (remote enrichment, `list_clusters`/resource reads, and remote target reads respectively).
 

--- a/docs/architecture/fleet.md
+++ b/docs/architecture/fleet.md
@@ -29,8 +29,8 @@ The **MCP Gateway is external infrastructure** -- like PostgreSQL or Prometheus,
             RO --> AA["AI Analysis"]
             AA --> KA["Kubernaut Agent"]
             RO --> WE["Workflow<br/>Execution"]
-            AF["API Frontend"]
-            EM["Effectiveness<br/>Monitor"]
+            AF["API Frontend"] -->|creates RemediationRequest| RO
+            RO -->|creates EffectivenessAssessment| EM["Effectiveness<br/>Monitor"]
             FMC["FMC<br/><small>Fleet Metadata Cache</small>"]
 
             GW -.->|"scope check<br/>p95 &lt; 50ms"| FSC["FederatedScopeChecker"]

--- a/docs/architecture/fleet.md
+++ b/docs/architecture/fleet.md
@@ -13,50 +13,55 @@ Fleet is opt-in per deployment (`fleet.enabled: true` in Helm values / `spec.fle
 
 ## Architecture
 
-```mermaid
-flowchart TB
-    subgraph Mgmt["Management Cluster"]
-        Thanos["Thanos Querier<br/><small>multi-cluster Prometheus</small>"] -->|alerts, cluster label| GW["Gateway"]
-        GW --> RO["Remediation<br/>Orchestrator"]
-        RO --> SP["Signal<br/>Processing"]
-        RO --> AA["AI Analysis"]
-        AA --> KA["Kubernaut Agent"]
-        RO --> WE["Workflow<br/>Execution"]
-        AF["API Frontend"]
-        EM["Effectiveness<br/>Monitor"]
-        FMC["FMC<br/><small>Fleet Metadata Cache</small>"]
-
-        GW -.->|"scope check<br/>p95 &lt; 50ms"| FSC["FederatedScopeChecker"]
-        RO -.->|scope check| FSC
-        FSC -->|local| K8sAPI["local K8s API"]
-        FSC -->|remote| Backend["scope.ScopeChecker<br/>backend adapter"]
-        Backend --> Valkey[("Valkey<br/>(FMC default)")]
-        FMC -->|polls, writes| Valkey
-
-        GW -.->|read| GWY
-        KA -.->|read| GWY
-        RO -.->|read| GWY
-        SP -.->|read| GWY
-        AF -.->|read| GWY
-        EM -.->|read| GWY
-        FMC -.->|read: cluster registry| GWY
-        WE -->|"read + write<br/>(remediation)"| GWY["MCP Gateway<br/><small>Kuadrant or Envoy AI Gateway</small>"]
-
-        IdP["OAuth2 Provider<br/><small>e.g. Keycloak, DEX</small>"]
-        GW -.->|"client-credentials<br/>(all 7 Fleet-dependent services)"| IdP
-        GWY -.->|validates token| IdP
-    end
-
-    GWY --> MCPa["K8s MCP Server<br/>Cluster A"]
-    GWY --> MCPb["K8s MCP Server<br/>Cluster B"]
-    GWY --> MCPc["K8s MCP Server<br/>Cluster C"]
-
-    MCPa --> ClusterA[("Cluster A")]
-    MCPb --> ClusterB[("Cluster B")]
-    MCPc --> ClusterC[("Cluster C")]
-```
+![Fleet architecture: management-cluster services, scope-check backend, OAuth2 provider, and the MCP Gateway boundary to remote clusters](../assets/images/fleet-architecture.svg)
 
 The **MCP Gateway is external infrastructure** -- like PostgreSQL or Prometheus, it must be deployed before Kubernaut. The Helm chart does not install it; platform teams choose and deploy their preferred implementation (Kuadrant MCP Gateway or Envoy AI Gateway) and register per-cluster K8s MCP Server backends with it.
+
+??? note "Full detailed flowchart (Mermaid)"
+    The diagram above simplifies the exact edge-level relationships for readability. For the complete, precise call graph including every scope-check and MCP Gateway read/write edge:
+
+    ```mermaid
+    flowchart TB
+        subgraph Mgmt["Management Cluster"]
+            Thanos["Thanos Querier<br/><small>multi-cluster Prometheus</small>"] -->|alerts, cluster label| GW["Gateway"]
+            GW --> RO["Remediation<br/>Orchestrator"]
+            RO --> SP["Signal<br/>Processing"]
+            RO --> AA["AI Analysis"]
+            AA --> KA["Kubernaut Agent"]
+            RO --> WE["Workflow<br/>Execution"]
+            AF["API Frontend"]
+            EM["Effectiveness<br/>Monitor"]
+            FMC["FMC<br/><small>Fleet Metadata Cache</small>"]
+
+            GW -.->|"scope check<br/>p95 &lt; 50ms"| FSC["FederatedScopeChecker"]
+            RO -.->|scope check| FSC
+            FSC -->|local| K8sAPI["local K8s API"]
+            FSC -->|remote| Backend["scope.ScopeChecker<br/>backend adapter"]
+            Backend --> Valkey[("Valkey<br/>(FMC default)")]
+            FMC -->|polls, writes| Valkey
+
+            GW -.->|read| GWY
+            KA -.->|read| GWY
+            RO -.->|read| GWY
+            SP -.->|read| GWY
+            AF -.->|read| GWY
+            EM -.->|read| GWY
+            FMC -.->|read: cluster registry| GWY
+            WE -->|"read + write<br/>(remediation)"| GWY["MCP Gateway<br/><small>Kuadrant or Envoy AI Gateway</small>"]
+
+            IdP["OAuth2 Provider<br/><small>e.g. Keycloak, DEX</small>"]
+            GW -.->|"client-credentials<br/>(all 7 Fleet-dependent services)"| IdP
+            GWY -.->|validates token| IdP
+        end
+
+        GWY --> MCPa["K8s MCP Server<br/>Cluster A"]
+        GWY --> MCPb["K8s MCP Server<br/>Cluster B"]
+        GWY --> MCPc["K8s MCP Server<br/>Cluster C"]
+
+        MCPa --> ClusterA[("Cluster A")]
+        MCPb --> ClusterB[("Cluster B")]
+        MCPc --> ClusterC[("Cluster C")]
+    ```
 
 ## Component Responsibilities
 

--- a/docs/architecture/fleet.md
+++ b/docs/architecture/fleet.md
@@ -13,7 +13,7 @@ Fleet is opt-in per deployment (`fleet.enabled: true` in Helm values / `spec.fle
 
 ## Architecture
 
-![Fleet architecture: management-cluster services, scope-check backend, OAuth2 provider, and the MCP Gateway boundary to remote clusters](../assets/images/fleet-architecture.svg)
+![Fleet architecture: hub-cluster services, scope-check backend, OAuth2 provider, and the MCP Gateway boundary to remote clusters, each running a K8s MCP Server](../assets/images/fleet-architecture.svg)
 
 The **MCP Gateway is external infrastructure** -- like PostgreSQL or Prometheus, it must be deployed before Kubernaut. The Helm chart does not install it; platform teams choose and deploy their preferred implementation (Kuadrant MCP Gateway or Envoy AI Gateway) and register per-cluster K8s MCP Server backends with it.
 
@@ -22,7 +22,7 @@ The **MCP Gateway is external infrastructure** -- like PostgreSQL or Prometheus,
 
     ```mermaid
     flowchart TB
-        subgraph Mgmt["Management Cluster"]
+        subgraph Mgmt["Hub Cluster"]
             Thanos["Thanos Querier<br/><small>multi-cluster Prometheus</small>"] -->|alerts, cluster label| GW["Gateway"]
             GW --> RO["Remediation<br/>Orchestrator"]
             RO --> SP["Signal<br/>Processing"]

--- a/docs/architecture/fleet.md
+++ b/docs/architecture/fleet.md
@@ -13,7 +13,9 @@ Fleet is opt-in per deployment (`fleet.enabled: true` in Helm values / `spec.fle
 
 ## Architecture
 
-![Fleet architecture: hub-cluster services, scope-check backend, OAuth2 provider, and the MCP Gateway boundary to remote clusters, each running a K8s MCP Server](../assets/images/fleet-architecture.svg)
+![Fleet architecture: Kubernaut Engine (hub-cluster core services), scope-check backend, OAuth2 provider, and the MCP Gateway boundary to remote clusters, each running a K8s MCP Server](../assets/images/fleet-architecture.svg)
+
+**Kubernaut Engine** in the diagram above is a single box standing in for the six services that already communicate intra-cluster via CRD watches, regardless of Fleet mode: the **Remediation Orchestrator** (creates and sequences the other five), **Signal Processing**, **AI Analysis** (plus the **Kubernaut Agent** it delegates investigation and workflow selection to), **Workflow Execution** (the only one of the six with MCP Gateway *write* access -- everything else is read-only), **Effectiveness Monitor**, and **Notification**. Their internal call graph doesn't change under Fleet mode, so it's intentionally left out of this diagram; see [Remediation Routing](remediation-routing.md) for that detail, or expand the flowchart below for the fully expanded, edge-level version scoped to Fleet.
 
 The **MCP Gateway is external infrastructure** -- like PostgreSQL or Prometheus, it must be deployed before Kubernaut. The Helm chart does not install it; platform teams choose and deploy their preferred implementation (Kuadrant MCP Gateway or Envoy AI Gateway) and register per-cluster K8s MCP Server backends with it.
 

--- a/docs/architecture/fleet.md
+++ b/docs/architecture/fleet.md
@@ -60,10 +60,16 @@ The **MCP Gateway is external infrastructure** -- like PostgreSQL or Prometheus,
         GWY --> MCPb["K8s MCP Server<br/>Cluster B"]
         GWY --> MCPc["K8s MCP Server<br/>Cluster C"]
 
+        MCPa -.->|"token exchange<br/>RFC 8693"| IdP
+        MCPb -.->|"token exchange<br/>RFC 8693"| IdP
+        MCPc -.->|"token exchange<br/>RFC 8693"| IdP
+
         MCPa --> ClusterA[("Cluster A")]
         MCPb --> ClusterB[("Cluster B")]
         MCPc --> ClusterC[("Cluster C")]
     ```
+
+    Two distinct OAuth2 interactions happen against the same IdP: the MCP Gateway only **validates** the caller's client-credentials token at the edge; the actual **RFC 8693 Standard Token Exchange** -- swapping that passthrough token for one scoped to the local cluster's Kubernetes API server -- happens independently inside each remote cluster's `kube-mcp-server`, not in the Gateway itself.
 
 ## Component Responsibilities
 
@@ -75,7 +81,7 @@ The **MCP Gateway is external infrastructure** -- like PostgreSQL or Prometheus,
 | **FederatedScopeChecker** | Routes scope checks: `ClusterID == ""` -> local `scope.Manager`; `ClusterID != ""` -> the configured remote backend adapter |
 | **GatewayDiscoverer** | Cluster/tool discovery interface, implemented once per supported gateway (Kuadrant, EAIGW). Called **server-side only** -- never LLM-facing (see below) |
 | **CRDWatcher** | Discovers clusters from the gateway's own native CRDs (`MCPRoute`/`Backend` for EAIGW, `MCPServerRegistration` for Kuadrant); Kubernaut is a read-only consumer, never creates or modifies these |
-| **OAuth2 Provider** | External IdP (Keycloak, DEX, or any OIDC-compliant provider) issuing client-credentials tokens (`pkg/fleet/mcpclient`). All 7 Fleet-dependent services acquire, cache, and auto-refresh a token before calling the MCP Gateway; the Gateway validates it against the same IdP. Not shipped by the Helm chart -- like the MCP Gateway itself, platform teams bring their own. |
+| **OAuth2 Provider** | External IdP (Keycloak, DEX, or any OIDC-compliant provider) issuing client-credentials tokens (`pkg/fleet/mcpclient`). All 7 Fleet-dependent services acquire, cache, and auto-refresh a token before calling the MCP Gateway; the Gateway validates it against the same IdP. Independently, each remote cluster's **K8s MCP Server** (`kube-mcp-server`) performs its own RFC 8693 Standard Token Exchange against the same IdP, swapping the passthrough token for one scoped to that cluster's own Kubernetes API server before serving the call. Not shipped by the Helm chart -- like the MCP Gateway itself, platform teams bring their own. |
 
 Signal Processing, API Frontend, and Effectiveness Monitor also participate as read-only MCP Gateway callers (remote enrichment, `list_clusters`/resource reads, and remote target reads respectively).
 

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -3,13 +3,13 @@
     <filter id="sh" x="-4%" y="-6%" width="108%" height="118%">
       <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.10"/>
     </filter>
-    <marker id="ar" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+    <marker id="ar" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto-start-reverse">
       <polygon points="0,0 8,3 0,6" fill="#94A3B8"/>
     </marker>
-    <marker id="arw" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+    <marker id="arw" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto-start-reverse">
       <polygon points="0,0 9,3.5 0,7" fill="#D97706"/>
     </marker>
-    <marker id="ard" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+    <marker id="ard" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto-start-reverse">
       <polygon points="0,0 8,3 0,6" fill="#A78BFA"/>
     </marker>
     <linearGradient id="gwGrad" x1="0" y1="0" x2="1" y2="1">
@@ -130,13 +130,16 @@
   <rect x="40" y="596" width="180" height="32" rx="8" fill="#334155"/>
   <text x="130" y="617" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">REMOTE CLUSTERS</text>
 
-  <!-- straight vertical drops: each card is centered directly under its MCP Gateway source point.
-       Amber (reads + writes): the Gateway is a shared boundary, so every fan-out arrow carries the
-       combined superset (6 services' reads + workflow execution's writes) to that cluster's MCP server.
+  <!-- straight vertical drops: each cluster gets the same paired-line treatment as the Hub Cluster
+       boundary above - gray (reads, 6 services) + amber (writes, workflow execution only), so the
+       read/write distinction stays visible all the way down, not just at the top boundary.
        Double-headed: tool-call results flow back up through the same path. -->
-  <line x1="275" y1="552" x2="275" y2="636" stroke="#D97706" stroke-width="2.4" marker-start="url(#arw)" marker-end="url(#arw)"/>
-  <line x1="525" y1="552" x2="525" y2="636" stroke="#D97706" stroke-width="2.4" marker-start="url(#arw)" marker-end="url(#arw)"/>
-  <line x1="775" y1="552" x2="775" y2="636" stroke="#D97706" stroke-width="2.4" marker-start="url(#arw)" marker-end="url(#arw)"/>
+  <line x1="257" y1="552" x2="257" y2="636" stroke="#94A3B8" stroke-width="1.8" marker-start="url(#ar)" marker-end="url(#ar)"/>
+  <line x1="293" y1="552" x2="293" y2="636" stroke="#D97706" stroke-width="2.4" marker-start="url(#arw)" marker-end="url(#arw)"/>
+  <line x1="507" y1="552" x2="507" y2="636" stroke="#94A3B8" stroke-width="1.8" marker-start="url(#ar)" marker-end="url(#ar)"/>
+  <line x1="543" y1="552" x2="543" y2="636" stroke="#D97706" stroke-width="2.4" marker-start="url(#arw)" marker-end="url(#arw)"/>
+  <line x1="757" y1="552" x2="757" y2="636" stroke="#94A3B8" stroke-width="1.8" marker-start="url(#ar)" marker-end="url(#ar)"/>
+  <line x1="793" y1="552" x2="793" y2="636" stroke="#D97706" stroke-width="2.4" marker-start="url(#arw)" marker-end="url(#arw)"/>
 
   <!-- Cluster A -->
   <g filter="url(#sh)"><rect x="180" y="636" width="190" height="126" rx="12" fill="white"/></g>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -115,8 +115,9 @@
   <text x="660" y="235" font-size="10px" fill="#8B5CF6">(all 7 services)</text>
 
   <!-- OAuth2 <-> MCP Gateway: exits right edge, down to MCP Gateway. Double-headed: token presented, valid/invalid result returned.
-       Gateway only validates here - RFC 8693 token exchange happens in each remote cluster's kube-mcp-server, not the Gateway
-       (see the Mermaid flowchart and Component Responsibilities table below for that distinction). -->
+       Gateway only validates here - the RFC 8693 token exchange is performed by the OAuth2 Provider itself, merely
+       requested by each remote cluster's kube-mcp-server, not the Gateway (see the Mermaid flowchart and Component
+       Responsibilities table below for that distinction). -->
   <path d="M676,306 L712,306 L712,452" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="1,2,5,2" marker-start="url(#ard)" marker-end="url(#ard)"/>
   <text x="718" y="380" font-size="10px" fill="#A78BFA">validates token</text>
 

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 740" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 772" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
   <defs>
     <filter id="sh" x="-4%" y="-6%" width="108%" height="118%">
       <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.10"/>
@@ -23,12 +23,16 @@
     <symbol id="k8sLogo" viewBox="0 0 24 24">
       <path fill="white" d="M10.204 14.35l.007.01-.999 2.413a5.171 5.171 0 0 1-2.075-2.597l2.578-.437.004.005a.44.44 0 0 1 .484.606zm-.833-2.129a.44.44 0 0 0 .173-.756l.002-.011L7.585 9.7a5.143 5.143 0 0 0-.73 3.255l2.514-.725.002-.009zm1.145-1.98a.44.44 0 0 0 .699-.337l.01-.005.15-2.62a5.144 5.144 0 0 0-3.01 1.442l2.147 1.523.004-.002zm.76 2.75l.723.349.722-.347.18-.78-.5-.623h-.804l-.5.623.179.779zm1.5-3.095a.44.44 0 0 0 .7.336l.008.003 2.134-1.513a5.188 5.188 0 0 0-2.992-1.442l.148 2.615.002.001zm10.876 5.97l-5.773 7.181a1.6 1.6 0 0 1-1.248.594l-9.261.003a1.6 1.6 0 0 1-1.247-.596l-5.776-7.18a1.583 1.583 0 0 1-.307-1.34L2.1 5.573c.108-.47.425-.864.863-1.073L11.305.513a1.606 1.606 0 0 1 1.385 0l8.345 3.985c.438.209.755.604.863 1.073l2.062 8.955c.108.47-.005.963-.308 1.34zm-3.289-2.057c-.042-.01-.103-.026-.145-.034-.174-.033-.315-.025-.479-.038-.35-.037-.638-.067-.895-.148-.105-.04-.18-.165-.216-.216l-.201-.059a6.45 6.45 0 0 0-.105-2.332 6.465 6.465 0 0 0-.936-2.163c.052-.047.15-.133.177-.159.008-.09.001-.183.094-.282.197-.185.444-.338.743-.522.142-.084.273-.137.415-.242.032-.024.076-.062.11-.089.24-.191.295-.52.123-.736-.172-.216-.506-.236-.745-.045-.034.027-.08.062-.111.088-.134.116-.217.23-.33.35-.246.25-.45.458-.673.609-.097.056-.239.037-.303.033l-.19.135a6.545 6.545 0 0 0-4.146-2.003l-.012-.223c-.065-.062-.143-.115-.163-.25-.022-.268.015-.557.057-.905.023-.163.061-.298.068-.475.001-.04-.001-.099-.001-.142 0-.306-.224-.555-.5-.555-.275 0-.499.249-.499.555l.001.014c0 .041-.002.092 0 .128.006.177.044.312.067.475.042.348.078.637.056.906a.545.545 0 0 1-.162.258l-.012.211a6.424 6.424 0 0 0-4.166 2.003 8.373 8.373 0 0 1-.18-.128c-.09.012-.18.04-.297-.029-.223-.15-.427-.358-.673-.608-.113-.12-.195-.234-.329-.349-.03-.026-.077-.062-.111-.088a.594.594 0 0 0-.348-.132.481.481 0 0 0-.398.176c-.172.216-.117.546.123.737l.007.005.104.083c.142.105.272.159.414.242.299.185.546.338.743.522.076.082.09.226.1.288l.16.143a6.462 6.462 0 0 0-1.02 4.506l-.208.06c-.055.072-.133.184-.215.217-.257.081-.546.11-.895.147-.164.014-.305.006-.48.039-.037.007-.09.02-.133.03l-.004.002-.007.002c-.295.071-.484.342-.423.608.061.267.349.429.645.365l.007-.001.01-.003.129-.029c.17-.046.294-.113.448-.172.33-.118.604-.217.87-.256.112-.009.23.069.288.101l.217-.037a6.5 6.5 0 0 0 2.88 3.596l-.09.218c.033.084.069.199.044.282-.097.252-.263.517-.452.813-.091.136-.185.242-.268.399-.02.037-.045.095-.064.134-.128.275-.034.591.213.71.248.12.556-.007.69-.282v-.002c.02-.039.046-.09.062-.127.07-.162.094-.301.144-.458.132-.332.205-.68.387-.897.05-.06.13-.082.215-.105l.113-.205a6.453 6.453 0 0 0 4.609.012l.106.192c.086.028.18.042.256.155.136.232.229.507.342.84.05.156.074.295.145.457.016.037.043.09.062.129.133.276.442.402.69.282.247-.118.341-.435.213-.71-.02-.039-.045-.096-.065-.134-.083-.156-.177-.261-.268-.398-.19-.296-.346-.541-.443-.793-.04-.13.007-.21.038-.294-.018-.022-.059-.144-.083-.202a6.499 6.499 0 0 0 2.88-3.622c.064.01.176.03.213.038.075-.05.144-.114.28-.104.266.039.54.138.87.256.154.06.277.128.448.173.036.01.088.019.13.028l.009.003.007.001c.297.064.584-.098.645-.365.06-.266-.128-.537-.423-.608zM16.4 9.701l-1.95 1.746v.005a.44.44 0 0 0 .173.757l.003.01 2.526.728a5.199 5.199 0 0 0-.108-1.674A5.208 5.208 0 0 0 16.4 9.7zm-4.013 5.325a.437.437 0 0 0-.404-.232.44.44 0 0 0-.372.233h-.002l-1.268 2.292a5.164 5.164 0 0 0 3.326.003l-1.27-2.296h-.01zm1.888-1.293a.44.44 0 0 0-.27.036.44.44 0 0 0-.214.572l-.003.004 1.01 2.438a5.15 5.15 0 0 0 2.081-2.615l-2.6-.44-.004.005z"/>
     </symbol>
+    <symbol id="kubernautLogo" viewBox="0 0 200 200">
+      <path d="M100,92 C82,66 38,66 38,100 C38,134 82,134 100,108" fill="none" stroke="#E5E7EB" stroke-width="13" stroke-linecap="round"/>
+      <path d="M100,92 C118,66 162,66 162,100 C162,134 118,134 100,108" fill="none" stroke="#F59E0B" stroke-width="13" stroke-linecap="round"/>
+    </symbol>
   </defs>
 
-  <rect x="0" y="0" width="1400" height="740" fill="white"/>
+  <rect x="0" y="0" width="1400" height="772" fill="white"/>
 
   <!-- ═══════════ Hub Cluster container ═══════════ -->
-  <rect x="20" y="46" width="1010" height="330" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <rect x="20" y="46" width="1010" height="362" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
   <rect x="40" y="30" width="150" height="32" rx="8" fill="#0F172A"/>
   <text x="115" y="51" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">HUB CLUSTER</text>
 
@@ -49,13 +53,7 @@
 
   <!-- ═══════════ Kubernaut Engine (consolidated: RO, SP, AI Analysis+KA, WE, EM, Notification) ═══════════ -->
   <g filter="url(#sh)"><rect x="450" y="88" width="280" height="94" rx="18" fill="url(#engineGrad)"/></g>
-  <circle cx="495" cy="135" r="5" fill="white"/>
-  <circle cx="481" cy="119" r="3.2" fill="#C7D2FE"/>
-  <circle cx="509" cy="119" r="3.2" fill="#C7D2FE"/>
-  <circle cx="495" cy="153" r="3.2" fill="#C7D2FE"/>
-  <line x1="495" y1="135" x2="481" y2="119" stroke="#C7D2FE" stroke-width="1.6"/>
-  <line x1="495" y1="135" x2="509" y2="119" stroke="#C7D2FE" stroke-width="1.6"/>
-  <line x1="495" y1="135" x2="495" y2="153" stroke="#C7D2FE" stroke-width="1.6"/>
+  <use href="#kubernautLogo" x="473" y="113" width="44" height="44"/>
   <text x="538" y="127" font-size="15px" font-weight="800" fill="white">Kubernaut Engine</text>
   <text x="538" y="147" font-size="10px" fill="#E0E7FF">6 services · one pipeline</text>
 
@@ -69,85 +67,76 @@
   <line x1="256" y1="126" x2="450" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
   <line x1="929" y1="126" x2="730" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
 
-  <!-- Scope Check -->
-  <rect x="274" y="248" width="52" height="52" rx="12" fill="#0E7490"/>
-  <path d="M300,256 L316,262 v14 c0,10 -8,16 -16,20 c-8,-4 -16,-10 -16,-20 v-14 z" fill="none" stroke="white" stroke-width="2.2"/>
-  <polyline points="292,272 299,279 310,266" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
-  <text x="300" y="316" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Scope Check</text>
-  <text x="300" y="330" text-anchor="middle" font-size="10.5px" fill="#64748B">FMC (default) · ACM</text>
+  <!-- Scope Check (positioned so Gateway's and the Engine's check-arrows are equal length) -->
+  <rect x="320" y="280" width="52" height="52" rx="12" fill="#0E7490"/>
+  <path d="M346,288 L362,294 v14 c0,10 -8,16 -16,20 c-8,-4 -16,-10 -16,-20 v-14 z" fill="none" stroke="white" stroke-width="2.2"/>
+  <polyline points="338,304 345,311 356,298" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="346" y="348" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Scope Check</text>
+  <text x="346" y="362" text-anchor="middle" font-size="10.5px" fill="#64748B">FMC (default) · ACM</text>
 
   <!-- OAuth2 -->
-  <rect x="624" y="248" width="52" height="52" rx="12" fill="#475569" stroke="#94A3B8" stroke-width="1.4" stroke-dasharray="3,3"/>
-  <path d="M642,270 v-6 a8,8 0 0 1 16,0 v6" fill="none" stroke="white" stroke-width="2.4"/>
-  <rect x="638" y="270" width="24" height="16" rx="3" fill="white"/>
-  <text x="650" y="316" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">OAuth2 Provider</text>
-  <text x="650" y="330" text-anchor="middle" font-size="10.5px" fill="#64748B">external IdP</text>
+  <rect x="624" y="280" width="52" height="52" rx="12" fill="#475569" stroke="#94A3B8" stroke-width="1.4" stroke-dasharray="3,3"/>
+  <path d="M642,302 v-6 a8,8 0 0 1 16,0 v6" fill="none" stroke="white" stroke-width="2.4"/>
+  <rect x="638" y="302" width="24" height="16" rx="3" fill="white"/>
+  <text x="650" y="348" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">OAuth2 Provider</text>
+  <text x="650" y="362" text-anchor="middle" font-size="10.5px" fill="#64748B">external IdP</text>
 
-  <!-- scope-check: Gateway (entry, fail-fast) and the Engine (routing, temporal drift) each check independently -->
-  <line x1="222" y1="152" x2="288" y2="246" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
-  <line x1="490" y1="182" x2="312" y2="246" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
+  <!-- scope-check: Gateway (entry, fail-fast) and the Engine (routing, temporal drift) each check independently, equal-length arrows -->
+  <line x1="230" y1="152" x2="337" y2="278" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
+  <line x1="490" y1="182" x2="357" y2="278" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
 
   <!-- client-credentials: engine -> OAuth2 (straight, unobstructed) -->
-  <line x1="650" y1="182" x2="650" y2="246" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
-  <text x="660" y="210" font-size="10px" fill="#8B5CF6">client-credentials</text>
-  <text x="660" y="223" font-size="10px" fill="#8B5CF6">(all 7 services)</text>
+  <line x1="650" y1="182" x2="650" y2="278" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <text x="660" y="222" font-size="10px" fill="#8B5CF6">client-credentials</text>
+  <text x="660" y="235" font-size="10px" fill="#8B5CF6">(all 7 services)</text>
 
   <!-- OAuth2 validates token: exits right edge, down to MCP Gateway -->
-  <path d="M676,270 L712,270 L712,420" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
-  <text x="718" y="330" font-size="10px" fill="#A78BFA">validates token</text>
+  <path d="M676,306 L712,306 L712,452" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <text x="718" y="380" font-size="10px" fill="#A78BFA">validates token</text>
 
   <!-- boundary arrows: Hub Cluster -> MCP Gateway (straight, vertical) -->
-  <line x1="440" y1="376" x2="440" y2="420" stroke="#94A3B8" stroke-width="2" marker-end="url(#ar)"/>
-  <text x="455" y="402" font-size="12px" fill="#64748B">reads (6 services)</text>
-  <line x1="590" y1="376" x2="590" y2="420" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
-  <text x="605" y="402" font-size="12px" font-weight="600" fill="#B45309">+ writes (workflow execution)</text>
+  <line x1="440" y1="408" x2="440" y2="452" stroke="#94A3B8" stroke-width="2" marker-end="url(#ar)"/>
+  <text x="455" y="434" font-size="12px" fill="#64748B">reads (6 services)</text>
+  <line x1="590" y1="408" x2="590" y2="452" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
+  <text x="605" y="434" font-size="12px" font-weight="600" fill="#B45309">+ writes (workflow execution)</text>
 
   <!-- ═══════════ MCP Gateway (centered under the Hub Cluster container, x 20-1030 → center 525) ═══════════ -->
-  <g filter="url(#sh)"><rect x="225" y="420" width="600" height="80" rx="16" fill="url(#gwGrad)"/></g>
-  <text x="525" y="454" text-anchor="middle" font-size="20px" font-weight="800" fill="white">MCP Gateway</text>
-  <text x="525" y="478" text-anchor="middle" font-size="11.5px" fill="#DDD6FE">Kuadrant MCP Gateway or Envoy AI Gateway · external infra, bring your own</text>
+  <g filter="url(#sh)"><rect x="225" y="452" width="600" height="80" rx="16" fill="url(#gwGrad)"/></g>
+  <text x="525" y="486" text-anchor="middle" font-size="20px" font-weight="800" fill="white">MCP Gateway</text>
+  <text x="525" y="510" text-anchor="middle" font-size="11.5px" fill="#DDD6FE">Kuadrant MCP Gateway or Envoy AI Gateway · external infra, bring your own</text>
 
   <!-- ═══════════ Remote Clusters container (full width) ═══════════ -->
-  <rect x="20" y="560" width="1360" height="160" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
-  <rect x="40" y="544" width="180" height="32" rx="8" fill="#334155"/>
-  <text x="130" y="565" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">REMOTE CLUSTERS</text>
+  <rect x="20" y="592" width="1360" height="160" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <rect x="40" y="576" width="180" height="32" rx="8" fill="#334155"/>
+  <text x="130" y="597" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">REMOTE CLUSTERS</text>
 
-  <line x1="385" y1="500" x2="190" y2="584" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="455" y1="500" x2="530" y2="584" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="595" y1="500" x2="870" y2="584" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="665" y1="500" x2="1210" y2="584" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="265" y1="532" x2="360" y2="616" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="525" y1="532" x2="700" y2="616" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="785" y1="532" x2="1040" y2="616" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
 
   <!-- Cluster A -->
-  <g filter="url(#sh)"><rect x="95" y="584" width="190" height="126" rx="12" fill="white"/></g>
-  <rect x="168" y="596" width="44" height="44" rx="10" fill="#326CE5"/>
-  <use href="#k8sLogo" x="175" y="603" width="30" height="30"/>
-  <text x="190" y="658" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster A</text>
-  <rect x="125" y="670" width="130" height="22" rx="6" fill="#EEF2FF"/>
-  <text x="190" y="685" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
+  <g filter="url(#sh)"><rect x="265" y="616" width="190" height="126" rx="12" fill="white"/></g>
+  <rect x="338" y="628" width="44" height="44" rx="10" fill="#326CE5"/>
+  <use href="#k8sLogo" x="345" y="635" width="30" height="30"/>
+  <text x="360" y="690" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster A</text>
+  <rect x="295" y="702" width="130" height="22" rx="6" fill="#EEF2FF"/>
+  <text x="360" y="717" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
 
   <!-- Cluster B -->
-  <g filter="url(#sh)"><rect x="435" y="584" width="190" height="126" rx="12" fill="white"/></g>
-  <rect x="508" y="596" width="44" height="44" rx="10" fill="#326CE5"/>
-  <use href="#k8sLogo" x="515" y="603" width="30" height="30"/>
-  <text x="530" y="658" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster B</text>
-  <rect x="465" y="670" width="130" height="22" rx="6" fill="#EEF2FF"/>
-  <text x="530" y="685" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
+  <g filter="url(#sh)"><rect x="605" y="616" width="190" height="126" rx="12" fill="white"/></g>
+  <rect x="678" y="628" width="44" height="44" rx="10" fill="#326CE5"/>
+  <use href="#k8sLogo" x="685" y="635" width="30" height="30"/>
+  <text x="700" y="690" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster B</text>
+  <rect x="635" y="702" width="130" height="22" rx="6" fill="#EEF2FF"/>
+  <text x="700" y="717" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
 
-  <!-- Cluster C -->
-  <g filter="url(#sh)"><rect x="775" y="584" width="190" height="126" rx="12" fill="white"/></g>
-  <rect x="848" y="596" width="44" height="44" rx="10" fill="#326CE5"/>
-  <use href="#k8sLogo" x="855" y="603" width="30" height="30"/>
-  <text x="870" y="658" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster C</text>
-  <rect x="805" y="670" width="130" height="22" rx="6" fill="#EEF2FF"/>
-  <text x="870" y="685" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
-
-  <!-- + more clusters (ghost) -->
-  <rect x="1115" y="584" width="190" height="126" rx="12" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="5,4"/>
-  <circle cx="1198" cy="630" r="3.2" fill="#94A3B8"/>
-  <circle cx="1210" cy="630" r="3.2" fill="#94A3B8"/>
-  <circle cx="1222" cy="630" r="3.2" fill="#94A3B8"/>
-  <text x="1210" y="658" text-anchor="middle" font-size="13px" font-weight="700" fill="#64748B">100s more</text>
-  <text x="1210" y="677" text-anchor="middle" font-size="11px" fill="#94A3B8">same pattern</text>
+  <!-- + more clusters (ghost, replaces a third named example - same pattern repeats at fleet scale) -->
+  <rect x="945" y="616" width="190" height="126" rx="12" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="5,4"/>
+  <circle cx="1028" cy="662" r="3.2" fill="#94A3B8"/>
+  <circle cx="1040" cy="662" r="3.2" fill="#94A3B8"/>
+  <circle cx="1052" cy="662" r="3.2" fill="#94A3B8"/>
+  <text x="1040" y="690" text-anchor="middle" font-size="13px" font-weight="700" fill="#64748B">100s more</text>
+  <text x="1040" y="709" text-anchor="middle" font-size="11px" fill="#94A3B8">same pattern</text>
 
   <!-- ═══════════ Legend + note ═══════════ -->
   <g>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -105,38 +105,39 @@
   <text x="525" y="486" text-anchor="middle" font-size="20px" font-weight="800" fill="white">MCP Gateway</text>
   <text x="525" y="510" text-anchor="middle" font-size="11.5px" fill="#DDD6FE">Kuadrant MCP Gateway or Envoy AI Gateway · external infra, bring your own</text>
 
-  <!-- ═══════════ Remote Clusters container (full width) ═══════════ -->
-  <rect x="20" y="592" width="1360" height="160" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <!-- ═══════════ Remote Clusters container (matches Hub Cluster's width: x 20-1030) ═══════════ -->
+  <rect x="20" y="592" width="1010" height="160" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
   <rect x="40" y="576" width="180" height="32" rx="8" fill="#334155"/>
   <text x="130" y="597" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">REMOTE CLUSTERS</text>
 
-  <line x1="265" y1="532" x2="360" y2="616" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="525" y1="532" x2="700" y2="616" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="785" y1="532" x2="1040" y2="616" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <!-- straight vertical drops: each card is centered directly under its MCP Gateway source point -->
+  <line x1="275" y1="532" x2="275" y2="616" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="525" y1="532" x2="525" y2="616" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="775" y1="532" x2="775" y2="616" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
 
   <!-- Cluster A -->
-  <g filter="url(#sh)"><rect x="265" y="616" width="190" height="126" rx="12" fill="white"/></g>
-  <rect x="338" y="628" width="44" height="44" rx="10" fill="#326CE5"/>
-  <use href="#k8sLogo" x="345" y="635" width="30" height="30"/>
-  <text x="360" y="690" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster A</text>
-  <rect x="295" y="702" width="130" height="22" rx="6" fill="#EEF2FF"/>
-  <text x="360" y="717" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
+  <g filter="url(#sh)"><rect x="180" y="616" width="190" height="126" rx="12" fill="white"/></g>
+  <rect x="253" y="628" width="44" height="44" rx="10" fill="#326CE5"/>
+  <use href="#k8sLogo" x="260" y="635" width="30" height="30"/>
+  <text x="275" y="690" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster A</text>
+  <rect x="210" y="702" width="130" height="22" rx="6" fill="#EEF2FF"/>
+  <text x="275" y="717" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
 
   <!-- Cluster B -->
-  <g filter="url(#sh)"><rect x="605" y="616" width="190" height="126" rx="12" fill="white"/></g>
-  <rect x="678" y="628" width="44" height="44" rx="10" fill="#326CE5"/>
-  <use href="#k8sLogo" x="685" y="635" width="30" height="30"/>
-  <text x="700" y="690" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster B</text>
-  <rect x="635" y="702" width="130" height="22" rx="6" fill="#EEF2FF"/>
-  <text x="700" y="717" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
+  <g filter="url(#sh)"><rect x="430" y="616" width="190" height="126" rx="12" fill="white"/></g>
+  <rect x="503" y="628" width="44" height="44" rx="10" fill="#326CE5"/>
+  <use href="#k8sLogo" x="510" y="635" width="30" height="30"/>
+  <text x="525" y="690" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster B</text>
+  <rect x="460" y="702" width="130" height="22" rx="6" fill="#EEF2FF"/>
+  <text x="525" y="717" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
 
   <!-- + more clusters (ghost, replaces a third named example - same pattern repeats at fleet scale) -->
-  <rect x="945" y="616" width="190" height="126" rx="12" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="5,4"/>
-  <circle cx="1028" cy="662" r="3.2" fill="#94A3B8"/>
-  <circle cx="1040" cy="662" r="3.2" fill="#94A3B8"/>
-  <circle cx="1052" cy="662" r="3.2" fill="#94A3B8"/>
-  <text x="1040" y="690" text-anchor="middle" font-size="13px" font-weight="700" fill="#64748B">100s more</text>
-  <text x="1040" y="709" text-anchor="middle" font-size="11px" fill="#94A3B8">same pattern</text>
+  <rect x="680" y="616" width="190" height="126" rx="12" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="5,4"/>
+  <circle cx="763" cy="662" r="3.2" fill="#94A3B8"/>
+  <circle cx="775" cy="662" r="3.2" fill="#94A3B8"/>
+  <circle cx="787" cy="662" r="3.2" fill="#94A3B8"/>
+  <text x="775" y="690" text-anchor="middle" font-size="13px" font-weight="700" fill="#64748B">100s more</text>
+  <text x="775" y="709" text-anchor="middle" font-size="11px" fill="#94A3B8">same pattern</text>
 
   <!-- ═══════════ Legend + note ═══════════ -->
   <g>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -81,11 +81,13 @@
   <line x1="121" y1="126" x2="204" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
   <text x="162" y="116" text-anchor="middle" font-size="9.5px" fill="#64748B">alerts</text>
 
-  <!-- entry arrows: Gateway and API Frontend both WRITE - they create RemediationRequest, not read -->
+  <!-- Gateway: fire-and-forget WRITE. Gateway is stateless with no ongoing reconciliation, so single-headed. -->
   <line x1="256" y1="126" x2="450" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
   <text x="353" y="116" text-anchor="middle" font-size="9.5px" fill="#64748B">creates RemediationRequest</text>
-  <line x1="929" y1="126" x2="730" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
-  <text x="830" y="116" text-anchor="middle" font-size="9.5px" fill="#64748B">creates RemediationRequest</text>
+  <!-- API Frontend: creates RemediationRequest AND watches AgentSession/status back to relay results to
+       its interactive session - a real round trip, so double-headed unlike Gateway's fire-and-forget write. -->
+  <line x1="929" y1="126" x2="730" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-start="url(#ar)" marker-end="url(#ar)"/>
+  <text x="830" y="116" text-anchor="middle" font-size="9.5px" fill="#64748B">creates + watches RemediationRequest</text>
 
   <!-- Scope Check (positioned so Gateway's and the Engine's check-arrows are equal length) -->
   <rect x="320" y="280" width="52" height="52" rx="12" fill="#0E7490"/>
@@ -102,17 +104,20 @@
   <text x="650" y="362" text-anchor="middle" font-size="10.5px" fill="#64748B">external IdP</text>
 
   <!-- scope-check: Gateway (entry, fail-fast) and the Engine (routing, temporal drift) each check independently, equal-length
-       orthogonal (vertical/horizontal only) elbow connectors, matching every other arrow in the diagram -->
-  <path d="M230,152 L230,240 L337,240 L337,278" fill="none" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#arc)"/>
-  <path d="M490,182 L490,240 L357,240 L357,278" fill="none" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#arc)"/>
+       orthogonal (vertical/horizontal only) elbow connectors, matching every other arrow in the diagram.
+       Double-headed: IsManagedResource(ctx, ResourceIdentity) is a synchronous call that returns a result. -->
+  <path d="M230,152 L230,240 L337,240 L337,278" fill="none" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-start="url(#arc)" marker-end="url(#arc)"/>
+  <path d="M490,182 L490,240 L357,240 L357,278" fill="none" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-start="url(#arc)" marker-end="url(#arc)"/>
 
-  <!-- client-credentials: engine -> OAuth2 (straight, unobstructed) -->
-  <line x1="650" y1="182" x2="650" y2="278" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="1,2,5,2" marker-end="url(#ard)"/>
+  <!-- client-credentials: engine <-> OAuth2 (straight, unobstructed). Double-headed: token request/response round trip. -->
+  <line x1="650" y1="182" x2="650" y2="278" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="1,2,5,2" marker-start="url(#ard)" marker-end="url(#ard)"/>
   <text x="660" y="222" font-size="10px" fill="#8B5CF6">client-credentials</text>
   <text x="660" y="235" font-size="10px" fill="#8B5CF6">(all 7 services)</text>
 
-  <!-- OAuth2 validates token: exits right edge, down to MCP Gateway -->
-  <path d="M676,306 L712,306 L712,452" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="1,2,5,2" marker-end="url(#ard)"/>
+  <!-- OAuth2 <-> MCP Gateway: exits right edge, down to MCP Gateway. Double-headed: token presented, valid/invalid result returned.
+       Gateway only validates here - RFC 8693 token exchange happens in each remote cluster's kube-mcp-server, not the Gateway
+       (see the Mermaid flowchart and Component Responsibilities table below for that distinction). -->
+  <path d="M676,306 L712,306 L712,452" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="1,2,5,2" marker-start="url(#ard)" marker-end="url(#ard)"/>
   <text x="718" y="380" font-size="10px" fill="#A78BFA">validates token</text>
 
   <!-- boundary arrows: Hub Cluster <-> MCP Gateway (straight, vertical). Double-headed: MCP tool calls are request/response, results flow back up. -->

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 900" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 740" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
   <defs>
     <filter id="sh" x="-4%" y="-6%" width="108%" height="118%">
       <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.10"/>
@@ -16,19 +16,23 @@
       <stop offset="0" stop-color="#7C3AED"/>
       <stop offset="1" stop-color="#4C1D95"/>
     </linearGradient>
+    <linearGradient id="engineGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6366F1"/>
+      <stop offset="1" stop-color="#4338CA"/>
+    </linearGradient>
     <symbol id="k8sLogo" viewBox="0 0 24 24">
       <path fill="white" d="M10.204 14.35l.007.01-.999 2.413a5.171 5.171 0 0 1-2.075-2.597l2.578-.437.004.005a.44.44 0 0 1 .484.606zm-.833-2.129a.44.44 0 0 0 .173-.756l.002-.011L7.585 9.7a5.143 5.143 0 0 0-.73 3.255l2.514-.725.002-.009zm1.145-1.98a.44.44 0 0 0 .699-.337l.01-.005.15-2.62a5.144 5.144 0 0 0-3.01 1.442l2.147 1.523.004-.002zm.76 2.75l.723.349.722-.347.18-.78-.5-.623h-.804l-.5.623.179.779zm1.5-3.095a.44.44 0 0 0 .7.336l.008.003 2.134-1.513a5.188 5.188 0 0 0-2.992-1.442l.148 2.615.002.001zm10.876 5.97l-5.773 7.181a1.6 1.6 0 0 1-1.248.594l-9.261.003a1.6 1.6 0 0 1-1.247-.596l-5.776-7.18a1.583 1.583 0 0 1-.307-1.34L2.1 5.573c.108-.47.425-.864.863-1.073L11.305.513a1.606 1.606 0 0 1 1.385 0l8.345 3.985c.438.209.755.604.863 1.073l2.062 8.955c.108.47-.005.963-.308 1.34zm-3.289-2.057c-.042-.01-.103-.026-.145-.034-.174-.033-.315-.025-.479-.038-.35-.037-.638-.067-.895-.148-.105-.04-.18-.165-.216-.216l-.201-.059a6.45 6.45 0 0 0-.105-2.332 6.465 6.465 0 0 0-.936-2.163c.052-.047.15-.133.177-.159.008-.09.001-.183.094-.282.197-.185.444-.338.743-.522.142-.084.273-.137.415-.242.032-.024.076-.062.11-.089.24-.191.295-.52.123-.736-.172-.216-.506-.236-.745-.045-.034.027-.08.062-.111.088-.134.116-.217.23-.33.35-.246.25-.45.458-.673.609-.097.056-.239.037-.303.033l-.19.135a6.545 6.545 0 0 0-4.146-2.003l-.012-.223c-.065-.062-.143-.115-.163-.25-.022-.268.015-.557.057-.905.023-.163.061-.298.068-.475.001-.04-.001-.099-.001-.142 0-.306-.224-.555-.5-.555-.275 0-.499.249-.499.555l.001.014c0 .041-.002.092 0 .128.006.177.044.312.067.475.042.348.078.637.056.906a.545.545 0 0 1-.162.258l-.012.211a6.424 6.424 0 0 0-4.166 2.003 8.373 8.373 0 0 1-.18-.128c-.09.012-.18.04-.297-.029-.223-.15-.427-.358-.673-.608-.113-.12-.195-.234-.329-.349-.03-.026-.077-.062-.111-.088a.594.594 0 0 0-.348-.132.481.481 0 0 0-.398.176c-.172.216-.117.546.123.737l.007.005.104.083c.142.105.272.159.414.242.299.185.546.338.743.522.076.082.09.226.1.288l.16.143a6.462 6.462 0 0 0-1.02 4.506l-.208.06c-.055.072-.133.184-.215.217-.257.081-.546.11-.895.147-.164.014-.305.006-.48.039-.037.007-.09.02-.133.03l-.004.002-.007.002c-.295.071-.484.342-.423.608.061.267.349.429.645.365l.007-.001.01-.003.129-.029c.17-.046.294-.113.448-.172.33-.118.604-.217.87-.256.112-.009.23.069.288.101l.217-.037a6.5 6.5 0 0 0 2.88 3.596l-.09.218c.033.084.069.199.044.282-.097.252-.263.517-.452.813-.091.136-.185.242-.268.399-.02.037-.045.095-.064.134-.128.275-.034.591.213.71.248.12.556-.007.69-.282v-.002c.02-.039.046-.09.062-.127.07-.162.094-.301.144-.458.132-.332.205-.68.387-.897.05-.06.13-.082.215-.105l.113-.205a6.453 6.453 0 0 0 4.609.012l.106.192c.086.028.18.042.256.155.136.232.229.507.342.84.05.156.074.295.145.457.016.037.043.09.062.129.133.276.442.402.69.282.247-.118.341-.435.213-.71-.02-.039-.045-.096-.065-.134-.083-.156-.177-.261-.268-.398-.19-.296-.346-.541-.443-.793-.04-.13.007-.21.038-.294-.018-.022-.059-.144-.083-.202a6.499 6.499 0 0 0 2.88-3.622c.064.01.176.03.213.038.075-.05.144-.114.28-.104.266.039.54.138.87.256.154.06.277.128.448.173.036.01.088.019.13.028l.009.003.007.001c.297.064.584-.098.645-.365.06-.266-.128-.537-.423-.608zM16.4 9.701l-1.95 1.746v.005a.44.44 0 0 0 .173.757l.003.01 2.526.728a5.199 5.199 0 0 0-.108-1.674A5.208 5.208 0 0 0 16.4 9.7zm-4.013 5.325a.437.437 0 0 0-.404-.232.44.44 0 0 0-.372.233h-.002l-1.268 2.292a5.164 5.164 0 0 0 3.326.003l-1.27-2.296h-.01zm1.888-1.293a.44.44 0 0 0-.27.036.44.44 0 0 0-.214.572l-.003.004 1.01 2.438a5.15 5.15 0 0 0 2.081-2.615l-2.6-.44-.004.005z"/>
     </symbol>
   </defs>
 
-  <rect x="0" y="0" width="1400" height="900" fill="white"/>
+  <rect x="0" y="0" width="1400" height="740" fill="white"/>
 
   <!-- ═══════════ Hub Cluster container ═══════════ -->
-  <rect x="20" y="46" width="1010" height="500" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <rect x="20" y="46" width="1010" height="330" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
   <rect x="40" y="30" width="150" height="32" rx="8" fill="#0F172A"/>
   <text x="115" y="51" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">HUB CLUSTER</text>
 
-  <!-- Thanos (outside the engine) -->
+  <!-- Thanos (metrics, informational — no direct call arrow) -->
   <rect x="69" y="100" width="52" height="52" rx="12" fill="#0E7490"/>
   <rect x="83" y="122" width="6" height="18" fill="white"/>
   <rect x="93" y="114" width="6" height="26" fill="white"/>
@@ -36,164 +40,114 @@
   <text x="95" y="168" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Thanos</text>
   <text x="95" y="182" text-anchor="middle" font-size="10.5px" fill="#64748B">metrics</text>
 
-  <!-- Gateway (outside the engine, entry point #1) -->
+  <!-- Gateway (entry point #1) -->
   <rect x="204" y="100" width="52" height="52" rx="12" fill="#0891B2"/>
   <path d="M220,104 L244,104 L234,122 L230,122 Z" fill="white"/>
   <rect x="228" y="122" width="4" height="10" fill="white"/>
   <text x="230" y="168" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Gateway</text>
   <text x="230" y="182" text-anchor="middle" font-size="10.5px" fill="#64748B">ingest + dedup</text>
 
-  <!-- API Frontend (outside the engine, entry point #2) -->
+  <!-- ═══════════ Kubernaut Engine (consolidated: RO, SP, AI Analysis+KA, WE, EM, Notification) ═══════════ -->
+  <g filter="url(#sh)"><rect x="450" y="88" width="280" height="94" rx="18" fill="url(#engineGrad)"/></g>
+  <circle cx="495" cy="135" r="5" fill="white"/>
+  <circle cx="481" cy="119" r="3.2" fill="#C7D2FE"/>
+  <circle cx="509" cy="119" r="3.2" fill="#C7D2FE"/>
+  <circle cx="495" cy="153" r="3.2" fill="#C7D2FE"/>
+  <line x1="495" y1="135" x2="481" y2="119" stroke="#C7D2FE" stroke-width="1.6"/>
+  <line x1="495" y1="135" x2="509" y2="119" stroke="#C7D2FE" stroke-width="1.6"/>
+  <line x1="495" y1="135" x2="495" y2="153" stroke="#C7D2FE" stroke-width="1.6"/>
+  <text x="538" y="127" font-size="15px" font-weight="800" fill="white">Kubernaut Engine</text>
+  <text x="538" y="147" font-size="10px" fill="#E0E7FF">6 services · one pipeline</text>
+
+  <!-- API Frontend (entry point #2) -->
   <rect x="929" y="100" width="52" height="52" rx="12" fill="#64748B"/>
   <path d="M941,114 h28 a4,4 0 0 1 4,4 v12 a4,4 0 0 1 -4,4 h-16 l-8,7 v-7 h-4 a4,4 0 0 1 -4,-4 v-12 a4,4 0 0 1 4,-4 z" fill="white"/>
   <text x="955" y="168" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">API Frontend</text>
   <text x="955" y="182" text-anchor="middle" font-size="10.5px" fill="#64748B">interactive entry</text>
 
-  <!-- ═══════════ Kubernaut Engine (solid border = one cohesive product, not a cluster boundary) ═══════════ -->
-  <g filter="url(#sh)"><rect x="300" y="76" width="580" height="324" rx="20" fill="#EEF2FF" stroke="#6366F1" stroke-width="2"/></g>
-  <rect x="300" y="62" width="190" height="28" rx="7" fill="#4F46E5"/>
-  <text x="395" y="81" text-anchor="middle" font-size="11.5px" font-weight="700" fill="white" letter-spacing="0.5">KUBERNAUT ENGINE</text>
-
-  <!-- Remediation Orchestrator (hub, bigger) -->
-  <rect x="556" y="120" width="68" height="68" rx="14" fill="#0F172A"/>
-  <circle cx="590" cy="154" r="5" fill="white"/>
-  <circle cx="574" cy="138" r="3.4" fill="#94A3B8"/>
-  <circle cx="606" cy="138" r="3.4" fill="#94A3B8"/>
-  <circle cx="590" cy="172" r="3.4" fill="#94A3B8"/>
-  <line x1="590" y1="154" x2="574" y2="138" stroke="#94A3B8" stroke-width="1.6"/>
-  <line x1="590" y1="154" x2="606" y2="138" stroke="#94A3B8" stroke-width="1.6"/>
-  <line x1="590" y1="154" x2="590" y2="172" stroke="#94A3B8" stroke-width="1.6"/>
-  <text x="590" y="212" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Orchestrator</text>
-  <text x="590" y="226" text-anchor="middle" font-size="10.5px" fill="#64748B">6 child CRDs · ClusterID</text>
-
-  <!-- Signal Processing -->
-  <rect x="348" y="284" width="52" height="52" rx="12" fill="#0891B2"/>
-  <polyline points="358,310 366,310 370,298 376,322 381,310 390,310" fill="none" stroke="white" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round"/>
-  <text x="374" y="350" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Signal Proc.</text>
-  <text x="374" y="364" text-anchor="middle" font-size="10.5px" fill="#64748B">classify</text>
-
-  <!-- AI Analysis + KA -->
-  <rect x="452" y="280" width="60" height="60" rx="13" fill="#6366F1"/>
-  <polygon points="482,293 496,302 496,318 482,327 468,318 468,302" fill="none" stroke="white" stroke-width="2.2"/>
-  <circle cx="482" cy="310" r="3" fill="white"/>
-  <text x="482" y="350" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">AI Analysis + KA</text>
-  <text x="482" y="364" text-anchor="middle" font-size="10.5px" fill="#64748B">investigate + select WF</text>
-
-  <!-- Workflow Execution (centered under Orchestrator: the one write-path) -->
-  <rect x="564" y="284" width="52" height="52" rx="12" fill="#D97706"/>
-  <circle cx="590" cy="310" r="10" fill="none" stroke="white" stroke-width="2.4"/>
-  <circle cx="590" cy="310" r="3.5" fill="white"/>
-  <rect x="587" y="294" width="6" height="6" fill="white"/>
-  <rect x="587" y="320" width="6" height="6" fill="white"/>
-  <rect x="574" y="307" width="6" height="6" fill="white"/>
-  <rect x="600" y="307" width="6" height="6" fill="white"/>
-  <text x="590" y="350" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Workflow Exec.</text>
-  <text x="590" y="364" text-anchor="middle" font-size="10.5px" fill="#64748B">runs remediation</text>
-
-  <!-- Effectiveness Monitor -->
-  <rect x="672" y="284" width="52" height="52" rx="12" fill="#059669"/>
-  <polyline points="682,310 690,310 695,298 702,322 707,310 716,310" fill="none" stroke="white" stroke-width="2.6" stroke-linejoin="round" stroke-linecap="round"/>
-  <text x="698" y="350" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Effectiveness</text>
-  <text x="698" y="364" text-anchor="middle" font-size="10.5px" fill="#64748B">verify + learn</text>
-
-  <!-- Notification -->
-  <rect x="780" y="284" width="52" height="52" rx="12" fill="#DB2777"/>
-  <circle cx="806" cy="293" r="1.8" fill="white"/>
-  <path d="M793,314 Q793,295 806,295 Q819,295 819,314 L822,318 L790,318 Z" fill="white"/>
-  <circle cx="806" cy="323" r="2.3" fill="white"/>
-  <text x="806" y="350" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Notification</text>
-  <text x="806" y="364" text-anchor="middle" font-size="10.5px" fill="#64748B">notify outcome</text>
-
-  <!-- entry arrows: Gateway and API Frontend cross into the engine boundary -->
-  <line x1="121" y1="126" x2="204" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
-  <line x1="256" y1="126" x2="300" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
-  <line x1="929" y1="126" x2="880" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
-
-  <!-- Orchestrator creates the pipeline; SP -> AA -> WE -> EM -> NT reads left-to-right as the execution sequence -->
-  <line x1="567" y1="188" x2="374" y2="284" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="400" y1="310" x2="452" y2="310" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="512" y1="310" x2="564" y2="310" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="616" y1="310" x2="672" y2="310" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="724" y1="310" x2="780" y2="310" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <!-- entry arrows: Gateway and API Frontend both create RemediationRequest into the engine -->
+  <line x1="256" y1="126" x2="450" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
+  <line x1="929" y1="126" x2="730" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
 
   <!-- Scope Check -->
-  <rect x="274" y="430" width="52" height="52" rx="12" fill="#0E7490"/>
-  <path d="M300,438 L316,444 v14 c0,10 -8,16 -16,20 c-8,-4 -16,-10 -16,-20 v-14 z" fill="none" stroke="white" stroke-width="2.2"/>
-  <polyline points="292,454 299,461 310,448" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
-  <text x="300" y="498" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Scope Check</text>
-  <text x="300" y="512" text-anchor="middle" font-size="10.5px" fill="#64748B">FMC (default) · ACM</text>
+  <rect x="274" y="248" width="52" height="52" rx="12" fill="#0E7490"/>
+  <path d="M300,256 L316,262 v14 c0,10 -8,16 -16,20 c-8,-4 -16,-10 -16,-20 v-14 z" fill="none" stroke="white" stroke-width="2.2"/>
+  <polyline points="292,272 299,279 310,266" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="300" y="316" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Scope Check</text>
+  <text x="300" y="330" text-anchor="middle" font-size="10.5px" fill="#64748B">FMC (default) · ACM</text>
 
   <!-- OAuth2 -->
-  <rect x="624" y="430" width="52" height="52" rx="12" fill="#475569" stroke="#94A3B8" stroke-width="1.4" stroke-dasharray="3,3"/>
-  <path d="M642,452 v-6 a8,8 0 0 1 16,0 v6" fill="none" stroke="white" stroke-width="2.4"/>
-  <rect x="638" y="452" width="24" height="16" rx="3" fill="white"/>
-  <text x="650" y="498" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">OAuth2 Provider</text>
-  <text x="650" y="512" text-anchor="middle" font-size="10.5px" fill="#64748B">external IdP</text>
+  <rect x="624" y="248" width="52" height="52" rx="12" fill="#475569" stroke="#94A3B8" stroke-width="1.4" stroke-dasharray="3,3"/>
+  <path d="M642,270 v-6 a8,8 0 0 1 16,0 v6" fill="none" stroke="white" stroke-width="2.4"/>
+  <rect x="638" y="270" width="24" height="16" rx="3" fill="white"/>
+  <text x="650" y="316" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">OAuth2 Provider</text>
+  <text x="650" y="330" text-anchor="middle" font-size="10.5px" fill="#64748B">external IdP</text>
 
-  <!-- scope-check: Gateway (entry, fail-fast) and Orchestrator (routing, temporal drift) each check independently -->
-  <line x1="222" y1="152" x2="288" y2="428" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
-  <path d="M556,144 L300,246 L312,428" fill="none" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
+  <!-- scope-check: Gateway (entry, fail-fast) and the Engine (routing, temporal drift) each check independently -->
+  <line x1="222" y1="152" x2="288" y2="246" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
+  <line x1="490" y1="182" x2="312" y2="246" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
 
-  <!-- client-credentials: engine -> OAuth2 top edge (stays clear of the badge, no crossing) -->
-  <path d="M750,400 L750,415 L655,415 L655,430" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
-  <text x="687" y="391" text-anchor="middle" font-size="10.5px" fill="#8B5CF6">client-credentials (all 7 services)</text>
+  <!-- client-credentials: engine -> OAuth2 (straight, unobstructed) -->
+  <line x1="650" y1="182" x2="650" y2="246" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <text x="660" y="210" font-size="10px" fill="#8B5CF6">client-credentials</text>
+  <text x="660" y="223" font-size="10px" fill="#8B5CF6">(all 7 services)</text>
 
-  <!-- OAuth2 validates token: exits right edge (below client-credentials entry, no overlap), down to Gateway -->
-  <path d="M676,450 L712,450 L712,580" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
-  <text x="718" y="500" font-size="10px" fill="#A78BFA">validates token</text>
+  <!-- OAuth2 validates token: exits right edge, down to MCP Gateway -->
+  <path d="M676,270 L712,270 L712,420" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <text x="718" y="330" font-size="10px" fill="#A78BFA">validates token</text>
 
   <!-- boundary arrows: Hub Cluster -> MCP Gateway (straight, vertical) -->
-  <line x1="440" y1="546" x2="440" y2="580" stroke="#94A3B8" stroke-width="2" marker-end="url(#ar)"/>
-  <text x="455" y="566" font-size="12px" fill="#64748B">reads (6 services)</text>
-  <line x1="590" y1="546" x2="590" y2="580" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
-  <text x="605" y="566" font-size="12px" font-weight="600" fill="#B45309">+ writes (Workflow Exec.)</text>
+  <line x1="440" y1="376" x2="440" y2="420" stroke="#94A3B8" stroke-width="2" marker-end="url(#ar)"/>
+  <text x="455" y="402" font-size="12px" fill="#64748B">reads (6 services)</text>
+  <line x1="590" y1="376" x2="590" y2="420" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
+  <text x="605" y="402" font-size="12px" font-weight="600" fill="#B45309">+ writes (workflow execution)</text>
 
   <!-- ═══════════ MCP Gateway (centered under the Hub Cluster container, x 20-1030 → center 525) ═══════════ -->
-  <g filter="url(#sh)"><rect x="225" y="580" width="600" height="80" rx="16" fill="url(#gwGrad)"/></g>
-  <text x="525" y="614" text-anchor="middle" font-size="20px" font-weight="800" fill="white">MCP Gateway</text>
-  <text x="525" y="638" text-anchor="middle" font-size="11.5px" fill="#DDD6FE">Kuadrant MCP Gateway or Envoy AI Gateway · external infra, bring your own</text>
+  <g filter="url(#sh)"><rect x="225" y="420" width="600" height="80" rx="16" fill="url(#gwGrad)"/></g>
+  <text x="525" y="454" text-anchor="middle" font-size="20px" font-weight="800" fill="white">MCP Gateway</text>
+  <text x="525" y="478" text-anchor="middle" font-size="11.5px" fill="#DDD6FE">Kuadrant MCP Gateway or Envoy AI Gateway · external infra, bring your own</text>
 
   <!-- ═══════════ Remote Clusters container (full width) ═══════════ -->
-  <rect x="20" y="720" width="1360" height="160" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
-  <rect x="40" y="704" width="180" height="32" rx="8" fill="#334155"/>
-  <text x="130" y="725" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">REMOTE CLUSTERS</text>
+  <rect x="20" y="560" width="1360" height="160" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <rect x="40" y="544" width="180" height="32" rx="8" fill="#334155"/>
+  <text x="130" y="565" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">REMOTE CLUSTERS</text>
 
-  <line x1="385" y1="660" x2="190" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="455" y1="660" x2="530" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="595" y1="660" x2="870" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="665" y1="660" x2="1210" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="385" y1="500" x2="190" y2="584" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="455" y1="500" x2="530" y2="584" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="595" y1="500" x2="870" y2="584" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="665" y1="500" x2="1210" y2="584" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
 
   <!-- Cluster A -->
-  <g filter="url(#sh)"><rect x="95" y="744" width="190" height="126" rx="12" fill="white"/></g>
-  <rect x="168" y="756" width="44" height="44" rx="10" fill="#326CE5"/>
-  <use href="#k8sLogo" x="175" y="763" width="30" height="30"/>
-  <text x="190" y="818" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster A</text>
-  <rect x="125" y="830" width="130" height="22" rx="6" fill="#EEF2FF"/>
-  <text x="190" y="845" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
+  <g filter="url(#sh)"><rect x="95" y="584" width="190" height="126" rx="12" fill="white"/></g>
+  <rect x="168" y="596" width="44" height="44" rx="10" fill="#326CE5"/>
+  <use href="#k8sLogo" x="175" y="603" width="30" height="30"/>
+  <text x="190" y="658" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster A</text>
+  <rect x="125" y="670" width="130" height="22" rx="6" fill="#EEF2FF"/>
+  <text x="190" y="685" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
 
   <!-- Cluster B -->
-  <g filter="url(#sh)"><rect x="435" y="744" width="190" height="126" rx="12" fill="white"/></g>
-  <rect x="508" y="756" width="44" height="44" rx="10" fill="#326CE5"/>
-  <use href="#k8sLogo" x="515" y="763" width="30" height="30"/>
-  <text x="530" y="818" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster B</text>
-  <rect x="465" y="830" width="130" height="22" rx="6" fill="#EEF2FF"/>
-  <text x="530" y="845" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
+  <g filter="url(#sh)"><rect x="435" y="584" width="190" height="126" rx="12" fill="white"/></g>
+  <rect x="508" y="596" width="44" height="44" rx="10" fill="#326CE5"/>
+  <use href="#k8sLogo" x="515" y="603" width="30" height="30"/>
+  <text x="530" y="658" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster B</text>
+  <rect x="465" y="670" width="130" height="22" rx="6" fill="#EEF2FF"/>
+  <text x="530" y="685" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
 
   <!-- Cluster C -->
-  <g filter="url(#sh)"><rect x="775" y="744" width="190" height="126" rx="12" fill="white"/></g>
-  <rect x="848" y="756" width="44" height="44" rx="10" fill="#326CE5"/>
-  <use href="#k8sLogo" x="855" y="763" width="30" height="30"/>
-  <text x="870" y="818" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster C</text>
-  <rect x="805" y="830" width="130" height="22" rx="6" fill="#EEF2FF"/>
-  <text x="870" y="845" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
+  <g filter="url(#sh)"><rect x="775" y="584" width="190" height="126" rx="12" fill="white"/></g>
+  <rect x="848" y="596" width="44" height="44" rx="10" fill="#326CE5"/>
+  <use href="#k8sLogo" x="855" y="603" width="30" height="30"/>
+  <text x="870" y="658" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster C</text>
+  <rect x="805" y="670" width="130" height="22" rx="6" fill="#EEF2FF"/>
+  <text x="870" y="685" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
 
   <!-- + more clusters (ghost) -->
-  <rect x="1115" y="744" width="190" height="126" rx="12" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="5,4"/>
-  <circle cx="1198" cy="790" r="3.2" fill="#94A3B8"/>
-  <circle cx="1210" cy="790" r="3.2" fill="#94A3B8"/>
-  <circle cx="1222" cy="790" r="3.2" fill="#94A3B8"/>
-  <text x="1210" y="818" text-anchor="middle" font-size="13px" font-weight="700" fill="#64748B">100s more</text>
-  <text x="1210" y="837" text-anchor="middle" font-size="11px" fill="#94A3B8">same pattern</text>
+  <rect x="1115" y="584" width="190" height="126" rx="12" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="5,4"/>
+  <circle cx="1198" cy="630" r="3.2" fill="#94A3B8"/>
+  <circle cx="1210" cy="630" r="3.2" fill="#94A3B8"/>
+  <circle cx="1222" cy="630" r="3.2" fill="#94A3B8"/>
+  <text x="1210" y="658" text-anchor="middle" font-size="13px" font-weight="700" fill="#64748B">100s more</text>
+  <text x="1210" y="677" text-anchor="middle" font-size="11px" fill="#94A3B8">same pattern</text>
 
   <!-- ═══════════ Legend + note ═══════════ -->
   <g>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 800" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 890" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
   <defs>
     <filter id="sh" x="-4%" y="-6%" width="108%" height="118%">
       <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.10"/>
@@ -16,18 +16,30 @@
       <stop offset="0" stop-color="#7C3AED"/>
       <stop offset="1" stop-color="#4C1D95"/>
     </linearGradient>
-    <symbol id="hexCluster" viewBox="0 0 48 48">
-      <polygon points="24,4 42,14 42,34 24,44 6,34 6,14" fill="none" stroke="white" stroke-width="2.5"/>
-      <circle cx="24" cy="24" r="5" fill="white"/>
+    <symbol id="k8sWheel" viewBox="0 0 48 48">
+      <circle cx="24" cy="24" r="15" fill="none" stroke="white" stroke-width="2"/>
+      <circle cx="24" cy="24" r="4.5" fill="white"/>
+      <line x1="24" y1="9" x2="24" y2="17" stroke="white" stroke-width="2"/>
+      <line x1="24" y1="31" x2="24" y2="39" stroke="white" stroke-width="2"/>
+      <line x1="11.4" y1="16.5" x2="18.7" y2="20.7" stroke="white" stroke-width="2"/>
+      <line x1="29.3" y1="27.3" x2="36.6" y2="31.5" stroke="white" stroke-width="2"/>
+      <line x1="11.4" y1="31.5" x2="18.7" y2="27.3" stroke="white" stroke-width="2"/>
+      <line x1="29.3" y1="20.7" x2="36.6" y2="16.5" stroke="white" stroke-width="2"/>
+      <circle cx="24" cy="9" r="2" fill="white"/>
+      <circle cx="24" cy="39" r="2" fill="white"/>
+      <circle cx="11.4" cy="16.5" r="2" fill="white"/>
+      <circle cx="36.6" cy="31.5" r="2" fill="white"/>
+      <circle cx="11.4" cy="31.5" r="2" fill="white"/>
+      <circle cx="36.6" cy="16.5" r="2" fill="white"/>
     </symbol>
   </defs>
 
-  <rect x="0" y="0" width="1400" height="800" fill="white"/>
+  <rect x="0" y="0" width="1400" height="890" fill="white"/>
 
-  <!-- ═══════════ Management Cluster container ═══════════ -->
-  <rect x="20" y="46" width="1010" height="440" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
-  <rect x="40" y="30" width="204" height="32" rx="8" fill="#0F172A"/>
-  <text x="142" y="51" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">MANAGEMENT CLUSTER</text>
+  <!-- ═══════════ Hub Cluster container ═══════════ -->
+  <rect x="20" y="46" width="1010" height="460" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <rect x="40" y="30" width="150" height="32" rx="8" fill="#0F172A"/>
+  <text x="115" y="51" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">HUB CLUSTER</text>
 
   <!-- Node template: 52x52 icon badge, bold label below, optional gray subtitle -->
 
@@ -115,56 +127,72 @@
   <line x1="394" y1="148" x2="397" y2="250" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
   <line x1="406" y1="148" x2="490" y2="256" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
 
-  <!-- scope-check arrows (dashed, from Gateway + Orchestrator) -->
-  <line x1="215" y1="142" x2="165" y2="390" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
-  <line x1="378" y1="148" x2="165" y2="390" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
+  <!-- scope-check: Gateway + Orchestrator merge into one trunk, no crossing with pipeline arrows -->
+  <line x1="222" y1="142" x2="270" y2="190" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3"/>
+  <line x1="378" y1="148" x2="270" y2="190" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3"/>
+  <line x1="270" y1="190" x2="150" y2="386" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
 
-  <!-- OAuth2 arrow (dashed, client-credentials) -->
-  <path d="M222,142 L222,224 L560,224 L560,390" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
-  <text x="392" y="217" text-anchor="middle" font-size="10.5px" fill="#8B5CF6">client-credentials (7 services)</text>
+  <!-- OAuth2 arrow (dashed, client-credentials): routed under everything, enters OAuth2 from below -->
+  <path d="M222,142 L222,498 L586,498 L586,450" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <text x="404" y="491" text-anchor="middle" font-size="10.5px" fill="#8B5CF6">client-credentials (7 services)</text>
 
-  <!-- boundary arrows: Management Cluster -> MCP Gateway -->
-  <line x1="420" y1="486" x2="600" y2="560" stroke="#94A3B8" stroke-width="2" marker-end="url(#ar)"/>
-  <text x="470" y="512" font-size="12px" fill="#64748B">reads (6 services)</text>
-  <line x1="560" y1="486" x2="700" y2="560" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
-  <text x="620" y="524" font-size="12px" font-weight="600" fill="#B45309">+ writes (Workflow Exec.)</text>
+  <!-- boundary arrows: Hub Cluster -> MCP Gateway -->
+  <line x1="420" y1="506" x2="600" y2="580" stroke="#94A3B8" stroke-width="2" marker-end="url(#ar)"/>
+  <text x="470" y="532" font-size="12px" fill="#64748B">reads (6 services)</text>
+  <line x1="560" y1="506" x2="700" y2="580" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
+  <text x="620" y="544" font-size="12px" font-weight="600" fill="#B45309">+ writes (Workflow Exec.)</text>
 
   <!-- OAuth2 validates token -->
-  <line x1="612" y1="416" x2="900" y2="590" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
-  <text x="700" y="470" font-size="11px" fill="#A78BFA">validates token</text>
+  <line x1="612" y1="416" x2="900" y2="610" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <text x="700" y="490" font-size="11px" fill="#A78BFA">validates token</text>
 
   <!-- ═══════════ MCP Gateway ═══════════ -->
-  <g filter="url(#sh)"><rect x="400" y="560" width="600" height="100" rx="16" fill="url(#gwGrad)"/></g>
-  <text x="700" y="600" text-anchor="middle" font-size="22px" font-weight="800" fill="white">MCP Gateway</text>
-  <text x="700" y="622" text-anchor="middle" font-size="12.5px" fill="#E9D5FF">Kuadrant MCP Gateway or Envoy AI Gateway</text>
-  <text x="700" y="644" text-anchor="middle" font-size="11px" fill="#C4B5FD">external infra — bring your own, like PostgreSQL/Prometheus</text>
+  <g filter="url(#sh)"><rect x="400" y="580" width="600" height="100" rx="16" fill="url(#gwGrad)"/></g>
+  <text x="700" y="620" text-anchor="middle" font-size="22px" font-weight="800" fill="white">MCP Gateway</text>
+  <text x="700" y="642" text-anchor="middle" font-size="12.5px" fill="#E9D5FF">Kuadrant MCP Gateway or Envoy AI Gateway</text>
+  <text x="700" y="664" text-anchor="middle" font-size="11px" fill="#C4B5FD">external infra — bring your own, like PostgreSQL/Prometheus</text>
 
   <!-- ═══════════ Remote Clusters container (full width) ═══════════ -->
-  <rect x="20" y="700" width="1360" height="90" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
-  <rect x="40" y="684" width="180" height="32" rx="8" fill="#334155"/>
-  <text x="130" y="705" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">REMOTE CLUSTERS</text>
+  <rect x="20" y="720" width="1360" height="150" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <rect x="40" y="704" width="180" height="32" rx="8" fill="#334155"/>
+  <text x="130" y="725" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">REMOTE CLUSTERS</text>
 
-  <line x1="560" y1="660" x2="190" y2="722" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="630" y1="660" x2="530" y2="722" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="770" y1="660" x2="870" y2="722" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="840" y1="660" x2="1210" y2="722" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="560" y1="680" x2="190" y2="732" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="630" y1="680" x2="530" y2="732" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="770" y1="680" x2="870" y2="732" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="840" y1="680" x2="1210" y2="732" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
 
-  <rect x="166" y="722" width="48" height="48" rx="10" fill="#334155"/>
-  <use href="#hexCluster" x="172" y="728" width="36" height="36"/>
-  <text x="190" y="782" text-anchor="middle" font-size="12px" font-weight="700" fill="#0F172A">Cluster A</text>
+  <!-- Cluster A -->
+  <g filter="url(#sh)"><rect x="95" y="732" width="190" height="126" rx="12" fill="white"/></g>
+  <rect x="168" y="744" width="44" height="44" rx="10" fill="#334155"/>
+  <use href="#k8sWheel" x="172" y="748" width="36" height="36"/>
+  <text x="190" y="806" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster A</text>
+  <rect x="125" y="818" width="130" height="22" rx="6" fill="#EEF2FF"/>
+  <text x="190" y="833" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
 
-  <rect x="506" y="722" width="48" height="48" rx="10" fill="#334155"/>
-  <use href="#hexCluster" x="512" y="728" width="36" height="36"/>
-  <text x="530" y="782" text-anchor="middle" font-size="12px" font-weight="700" fill="#0F172A">Cluster B</text>
+  <!-- Cluster B -->
+  <g filter="url(#sh)"><rect x="435" y="732" width="190" height="126" rx="12" fill="white"/></g>
+  <rect x="508" y="744" width="44" height="44" rx="10" fill="#334155"/>
+  <use href="#k8sWheel" x="512" y="748" width="36" height="36"/>
+  <text x="530" y="806" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster B</text>
+  <rect x="465" y="818" width="130" height="22" rx="6" fill="#EEF2FF"/>
+  <text x="530" y="833" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
 
-  <rect x="846" y="722" width="48" height="48" rx="10" fill="#334155"/>
-  <use href="#hexCluster" x="852" y="728" width="36" height="36"/>
-  <text x="870" y="782" text-anchor="middle" font-size="12px" font-weight="700" fill="#0F172A">Cluster C</text>
+  <!-- Cluster C -->
+  <g filter="url(#sh)"><rect x="775" y="732" width="190" height="126" rx="12" fill="white"/></g>
+  <rect x="848" y="744" width="44" height="44" rx="10" fill="#334155"/>
+  <use href="#k8sWheel" x="852" y="748" width="36" height="36"/>
+  <text x="870" y="806" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster C</text>
+  <rect x="805" y="818" width="130" height="22" rx="6" fill="#EEF2FF"/>
+  <text x="870" y="833" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
 
-  <circle cx="1198" cy="740" r="3.2" fill="#94A3B8"/>
-  <circle cx="1210" cy="740" r="3.2" fill="#94A3B8"/>
-  <circle cx="1222" cy="740" r="3.2" fill="#94A3B8"/>
-  <text x="1210" y="782" text-anchor="middle" font-size="11.5px" fill="#64748B">100s more</text>
+  <!-- + more clusters (ghost) -->
+  <rect x="1115" y="732" width="190" height="126" rx="12" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="5,4"/>
+  <circle cx="1198" cy="778" r="3.2" fill="#94A3B8"/>
+  <circle cx="1210" cy="778" r="3.2" fill="#94A3B8"/>
+  <circle cx="1222" cy="778" r="3.2" fill="#94A3B8"/>
+  <text x="1210" y="806" text-anchor="middle" font-size="13px" font-weight="700" fill="#64748B">100s more</text>
+  <text x="1210" y="825" text-anchor="middle" font-size="11px" fill="#94A3B8">same pattern</text>
 
   <!-- ═══════════ Legend + note ═══════════ -->
   <g>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -107,12 +107,12 @@
   <path d="M490,182 L490,240 L357,240 L357,278" fill="none" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#arc)"/>
 
   <!-- client-credentials: engine -> OAuth2 (straight, unobstructed) -->
-  <line x1="650" y1="182" x2="650" y2="278" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <line x1="650" y1="182" x2="650" y2="278" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="1,2,5,2" marker-end="url(#ard)"/>
   <text x="660" y="222" font-size="10px" fill="#8B5CF6">client-credentials</text>
   <text x="660" y="235" font-size="10px" fill="#8B5CF6">(all 7 services)</text>
 
   <!-- OAuth2 validates token: exits right edge, down to MCP Gateway -->
-  <path d="M676,306 L712,306 L712,452" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <path d="M676,306 L712,306 L712,452" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="1,2,5,2" marker-end="url(#ard)"/>
   <text x="718" y="380" font-size="10px" fill="#A78BFA">validates token</text>
 
   <!-- boundary arrows: Hub Cluster <-> MCP Gateway (straight, vertical). Double-headed: MCP tool calls are request/response, results flow back up. -->
@@ -179,7 +179,7 @@
     <line x1="360" y1="810" x2="404" y2="810" stroke="#D97706" stroke-width="2.2" marker-start="url(#arw)" marker-end="url(#arw)"/>
     <text x="414" y="814" font-size="12px" fill="#374151">reads + writes</text>
 
-    <line x1="610" y1="810" x2="634" y2="810" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+    <line x1="610" y1="810" x2="634" y2="810" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="1,2,5,2" marker-end="url(#ard)"/>
     <text x="642" y="814" font-size="12px" fill="#374151">auth / token</text>
 
     <line x1="850" y1="810" x2="874" y2="810" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#arc)"/>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -16,160 +16,158 @@
       <stop offset="0" stop-color="#7C3AED"/>
       <stop offset="1" stop-color="#4C1D95"/>
     </linearGradient>
-    <symbol id="k8sWheel" viewBox="0 0 48 48">
-      <circle cx="24" cy="24" r="15" fill="none" stroke="white" stroke-width="2"/>
-      <circle cx="24" cy="24" r="4.5" fill="white"/>
-      <line x1="24" y1="9" x2="24" y2="17" stroke="white" stroke-width="2"/>
-      <line x1="24" y1="31" x2="24" y2="39" stroke="white" stroke-width="2"/>
-      <line x1="11.4" y1="16.5" x2="18.7" y2="20.7" stroke="white" stroke-width="2"/>
-      <line x1="29.3" y1="27.3" x2="36.6" y2="31.5" stroke="white" stroke-width="2"/>
-      <line x1="11.4" y1="31.5" x2="18.7" y2="27.3" stroke="white" stroke-width="2"/>
-      <line x1="29.3" y1="20.7" x2="36.6" y2="16.5" stroke="white" stroke-width="2"/>
-      <circle cx="24" cy="9" r="2" fill="white"/>
-      <circle cx="24" cy="39" r="2" fill="white"/>
-      <circle cx="11.4" cy="16.5" r="2" fill="white"/>
-      <circle cx="36.6" cy="31.5" r="2" fill="white"/>
-      <circle cx="11.4" cy="31.5" r="2" fill="white"/>
-      <circle cx="36.6" cy="16.5" r="2" fill="white"/>
+    <symbol id="k8sLogo" viewBox="0 0 24 24">
+      <path fill="white" d="M10.204 14.35l.007.01-.999 2.413a5.171 5.171 0 0 1-2.075-2.597l2.578-.437.004.005a.44.44 0 0 1 .484.606zm-.833-2.129a.44.44 0 0 0 .173-.756l.002-.011L7.585 9.7a5.143 5.143 0 0 0-.73 3.255l2.514-.725.002-.009zm1.145-1.98a.44.44 0 0 0 .699-.337l.01-.005.15-2.62a5.144 5.144 0 0 0-3.01 1.442l2.147 1.523.004-.002zm.76 2.75l.723.349.722-.347.18-.78-.5-.623h-.804l-.5.623.179.779zm1.5-3.095a.44.44 0 0 0 .7.336l.008.003 2.134-1.513a5.188 5.188 0 0 0-2.992-1.442l.148 2.615.002.001zm10.876 5.97l-5.773 7.181a1.6 1.6 0 0 1-1.248.594l-9.261.003a1.6 1.6 0 0 1-1.247-.596l-5.776-7.18a1.583 1.583 0 0 1-.307-1.34L2.1 5.573c.108-.47.425-.864.863-1.073L11.305.513a1.606 1.606 0 0 1 1.385 0l8.345 3.985c.438.209.755.604.863 1.073l2.062 8.955c.108.47-.005.963-.308 1.34zm-3.289-2.057c-.042-.01-.103-.026-.145-.034-.174-.033-.315-.025-.479-.038-.35-.037-.638-.067-.895-.148-.105-.04-.18-.165-.216-.216l-.201-.059a6.45 6.45 0 0 0-.105-2.332 6.465 6.465 0 0 0-.936-2.163c.052-.047.15-.133.177-.159.008-.09.001-.183.094-.282.197-.185.444-.338.743-.522.142-.084.273-.137.415-.242.032-.024.076-.062.11-.089.24-.191.295-.52.123-.736-.172-.216-.506-.236-.745-.045-.034.027-.08.062-.111.088-.134.116-.217.23-.33.35-.246.25-.45.458-.673.609-.097.056-.239.037-.303.033l-.19.135a6.545 6.545 0 0 0-4.146-2.003l-.012-.223c-.065-.062-.143-.115-.163-.25-.022-.268.015-.557.057-.905.023-.163.061-.298.068-.475.001-.04-.001-.099-.001-.142 0-.306-.224-.555-.5-.555-.275 0-.499.249-.499.555l.001.014c0 .041-.002.092 0 .128.006.177.044.312.067.475.042.348.078.637.056.906a.545.545 0 0 1-.162.258l-.012.211a6.424 6.424 0 0 0-4.166 2.003 8.373 8.373 0 0 1-.18-.128c-.09.012-.18.04-.297-.029-.223-.15-.427-.358-.673-.608-.113-.12-.195-.234-.329-.349-.03-.026-.077-.062-.111-.088a.594.594 0 0 0-.348-.132.481.481 0 0 0-.398.176c-.172.216-.117.546.123.737l.007.005.104.083c.142.105.272.159.414.242.299.185.546.338.743.522.076.082.09.226.1.288l.16.143a6.462 6.462 0 0 0-1.02 4.506l-.208.06c-.055.072-.133.184-.215.217-.257.081-.546.11-.895.147-.164.014-.305.006-.48.039-.037.007-.09.02-.133.03l-.004.002-.007.002c-.295.071-.484.342-.423.608.061.267.349.429.645.365l.007-.001.01-.003.129-.029c.17-.046.294-.113.448-.172.33-.118.604-.217.87-.256.112-.009.23.069.288.101l.217-.037a6.5 6.5 0 0 0 2.88 3.596l-.09.218c.033.084.069.199.044.282-.097.252-.263.517-.452.813-.091.136-.185.242-.268.399-.02.037-.045.095-.064.134-.128.275-.034.591.213.71.248.12.556-.007.69-.282v-.002c.02-.039.046-.09.062-.127.07-.162.094-.301.144-.458.132-.332.205-.68.387-.897.05-.06.13-.082.215-.105l.113-.205a6.453 6.453 0 0 0 4.609.012l.106.192c.086.028.18.042.256.155.136.232.229.507.342.84.05.156.074.295.145.457.016.037.043.09.062.129.133.276.442.402.69.282.247-.118.341-.435.213-.71-.02-.039-.045-.096-.065-.134-.083-.156-.177-.261-.268-.398-.19-.296-.346-.541-.443-.793-.04-.13.007-.21.038-.294-.018-.022-.059-.144-.083-.202a6.499 6.499 0 0 0 2.88-3.622c.064.01.176.03.213.038.075-.05.144-.114.28-.104.266.039.54.138.87.256.154.06.277.128.448.173.036.01.088.019.13.028l.009.003.007.001c.297.064.584-.098.645-.365.06-.266-.128-.537-.423-.608zM16.4 9.701l-1.95 1.746v.005a.44.44 0 0 0 .173.757l.003.01 2.526.728a5.199 5.199 0 0 0-.108-1.674A5.208 5.208 0 0 0 16.4 9.7zm-4.013 5.325a.437.437 0 0 0-.404-.232.44.44 0 0 0-.372.233h-.002l-1.268 2.292a5.164 5.164 0 0 0 3.326.003l-1.27-2.296h-.01zm1.888-1.293a.44.44 0 0 0-.27.036.44.44 0 0 0-.214.572l-.003.004 1.01 2.438a5.15 5.15 0 0 0 2.081-2.615l-2.6-.44-.004.005z"/>
     </symbol>
   </defs>
 
   <rect x="0" y="0" width="1400" height="900" fill="white"/>
 
   <!-- ═══════════ Hub Cluster container ═══════════ -->
-  <rect x="20" y="46" width="1010" height="460" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <rect x="20" y="46" width="1010" height="500" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
   <rect x="40" y="30" width="150" height="32" rx="8" fill="#0F172A"/>
   <text x="115" y="51" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">HUB CLUSTER</text>
 
-  <!-- Row 1 (evenly spread across full container width): Thanos@161 Gateway@343 Orchestrator@525 API Frontend@707 Effectiveness@889 -->
+  <!-- Thanos (outside the engine) -->
+  <rect x="69" y="100" width="52" height="52" rx="12" fill="#0E7490"/>
+  <rect x="83" y="122" width="6" height="18" fill="white"/>
+  <rect x="93" y="114" width="6" height="26" fill="white"/>
+  <rect x="103" y="126" width="6" height="14" fill="white"/>
+  <text x="95" y="168" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Thanos</text>
+  <text x="95" y="182" text-anchor="middle" font-size="10.5px" fill="#64748B">metrics</text>
 
-  <!-- Thanos -->
-  <rect x="135" y="90" width="52" height="52" rx="12" fill="#0E7490"/>
-  <rect x="149" y="112" width="6" height="18" fill="white"/>
-  <rect x="159" y="104" width="6" height="26" fill="white"/>
-  <rect x="169" y="116" width="6" height="14" fill="white"/>
-  <text x="161" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Thanos</text>
-  <text x="161" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">metrics</text>
+  <!-- Gateway (outside the engine, entry point #1) -->
+  <rect x="204" y="100" width="52" height="52" rx="12" fill="#0891B2"/>
+  <path d="M220,104 L244,104 L234,122 L230,122 Z" fill="white"/>
+  <rect x="228" y="122" width="4" height="10" fill="white"/>
+  <text x="230" y="168" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Gateway</text>
+  <text x="230" y="182" text-anchor="middle" font-size="10.5px" fill="#64748B">ingest + dedup</text>
 
-  <!-- Gateway -->
-  <rect x="317" y="90" width="52" height="52" rx="12" fill="#0891B2"/>
-  <path d="M333,104 L357,104 L347,122 L343,122 Z" fill="white"/>
-  <rect x="342" y="122" width="4" height="10" fill="white"/>
-  <text x="343" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Gateway</text>
-  <text x="343" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">ingest + dedup</text>
+  <!-- API Frontend (outside the engine, entry point #2) -->
+  <rect x="929" y="100" width="52" height="52" rx="12" fill="#64748B"/>
+  <path d="M941,114 h28 a4,4 0 0 1 4,4 v12 a4,4 0 0 1 -4,4 h-16 l-8,7 v-7 h-4 a4,4 0 0 1 -4,-4 v-12 a4,4 0 0 1 4,-4 z" fill="white"/>
+  <text x="955" y="168" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">API Frontend</text>
+  <text x="955" y="182" text-anchor="middle" font-size="10.5px" fill="#64748B">interactive entry</text>
+
+  <!-- ═══════════ Kubernaut Engine (solid border = one cohesive product, not a cluster boundary) ═══════════ -->
+  <g filter="url(#sh)"><rect x="300" y="76" width="580" height="324" rx="20" fill="#EEF2FF" stroke="#6366F1" stroke-width="2"/></g>
+  <rect x="300" y="62" width="190" height="28" rx="7" fill="#4F46E5"/>
+  <text x="395" y="81" text-anchor="middle" font-size="11.5px" font-weight="700" fill="white" letter-spacing="0.5">KUBERNAUT ENGINE</text>
 
   <!-- Remediation Orchestrator (hub, bigger) -->
-  <rect x="491" y="80" width="68" height="68" rx="14" fill="#0F172A"/>
-  <circle cx="525" cy="114" r="5" fill="white"/>
-  <circle cx="509" cy="98" r="3.4" fill="#94A3B8"/>
-  <circle cx="541" cy="98" r="3.4" fill="#94A3B8"/>
-  <circle cx="525" cy="132" r="3.4" fill="#94A3B8"/>
-  <line x1="525" y1="114" x2="509" y2="98" stroke="#94A3B8" stroke-width="1.6"/>
-  <line x1="525" y1="114" x2="541" y2="98" stroke="#94A3B8" stroke-width="1.6"/>
-  <line x1="525" y1="114" x2="525" y2="132" stroke="#94A3B8" stroke-width="1.6"/>
-  <text x="525" y="172" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Orchestrator</text>
-  <text x="525" y="186" text-anchor="middle" font-size="10.5px" fill="#64748B">6 child CRDs · ClusterID</text>
+  <rect x="556" y="120" width="68" height="68" rx="14" fill="#0F172A"/>
+  <circle cx="590" cy="154" r="5" fill="white"/>
+  <circle cx="574" cy="138" r="3.4" fill="#94A3B8"/>
+  <circle cx="606" cy="138" r="3.4" fill="#94A3B8"/>
+  <circle cx="590" cy="172" r="3.4" fill="#94A3B8"/>
+  <line x1="590" y1="154" x2="574" y2="138" stroke="#94A3B8" stroke-width="1.6"/>
+  <line x1="590" y1="154" x2="606" y2="138" stroke="#94A3B8" stroke-width="1.6"/>
+  <line x1="590" y1="154" x2="590" y2="172" stroke="#94A3B8" stroke-width="1.6"/>
+  <text x="590" y="212" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Orchestrator</text>
+  <text x="590" y="226" text-anchor="middle" font-size="10.5px" fill="#64748B">6 child CRDs · ClusterID</text>
 
-  <!-- API Frontend -->
-  <rect x="681" y="90" width="52" height="52" rx="12" fill="#64748B"/>
-  <path d="M693,104 h28 a4,4 0 0 1 4,4 v12 a4,4 0 0 1 -4,4 h-16 l-8,7 v-7 h-4 a4,4 0 0 1 -4,-4 v-12 a4,4 0 0 1 4,-4 z" fill="white"/>
-  <text x="707" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">API Frontend</text>
-  <text x="707" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">interactive entry</text>
+  <!-- Signal Processing -->
+  <rect x="348" y="284" width="52" height="52" rx="12" fill="#0891B2"/>
+  <polyline points="358,310 366,310 370,298 376,322 381,310 390,310" fill="none" stroke="white" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round"/>
+  <text x="374" y="350" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Signal Proc.</text>
+  <text x="374" y="364" text-anchor="middle" font-size="10.5px" fill="#64748B">classify</text>
+
+  <!-- AI Analysis + KA -->
+  <rect x="452" y="280" width="60" height="60" rx="13" fill="#6366F1"/>
+  <polygon points="482,293 496,302 496,318 482,327 468,318 468,302" fill="none" stroke="white" stroke-width="2.2"/>
+  <circle cx="482" cy="310" r="3" fill="white"/>
+  <text x="482" y="350" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">AI Analysis + KA</text>
+  <text x="482" y="364" text-anchor="middle" font-size="10.5px" fill="#64748B">investigate + select WF</text>
+
+  <!-- Workflow Execution (centered under Orchestrator: the one write-path) -->
+  <rect x="564" y="284" width="52" height="52" rx="12" fill="#D97706"/>
+  <circle cx="590" cy="310" r="10" fill="none" stroke="white" stroke-width="2.4"/>
+  <circle cx="590" cy="310" r="3.5" fill="white"/>
+  <rect x="587" y="294" width="6" height="6" fill="white"/>
+  <rect x="587" y="320" width="6" height="6" fill="white"/>
+  <rect x="574" y="307" width="6" height="6" fill="white"/>
+  <rect x="600" y="307" width="6" height="6" fill="white"/>
+  <text x="590" y="350" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Workflow Exec.</text>
+  <text x="590" y="364" text-anchor="middle" font-size="10.5px" fill="#64748B">runs remediation</text>
 
   <!-- Effectiveness Monitor -->
-  <rect x="863" y="90" width="52" height="52" rx="12" fill="#059669"/>
-  <polyline points="873,116 881,116 886,104 893,128 898,116 907,116" fill="none" stroke="white" stroke-width="2.6" stroke-linejoin="round" stroke-linecap="round"/>
-  <text x="889" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Effectiveness</text>
-  <text x="889" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">verify + learn</text>
+  <rect x="672" y="284" width="52" height="52" rx="12" fill="#059669"/>
+  <polyline points="682,310 690,310 695,298 702,322 707,310 716,310" fill="none" stroke="white" stroke-width="2.6" stroke-linejoin="round" stroke-linecap="round"/>
+  <text x="698" y="350" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Effectiveness</text>
+  <text x="698" y="364" text-anchor="middle" font-size="10.5px" fill="#64748B">verify + learn</text>
 
-  <!-- Row 2 (under Orchestrator): Signal Proc@365 AI Analysis+KA@525 Workflow Exec@685 -->
+  <!-- Notification -->
+  <rect x="780" y="284" width="52" height="52" rx="12" fill="#DB2777"/>
+  <circle cx="806" cy="293" r="1.8" fill="white"/>
+  <path d="M793,314 Q793,295 806,295 Q819,295 819,314 L822,318 L790,318 Z" fill="white"/>
+  <circle cx="806" cy="323" r="2.3" fill="white"/>
+  <text x="806" y="350" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Notification</text>
+  <text x="806" y="364" text-anchor="middle" font-size="10.5px" fill="#64748B">notify outcome</text>
 
-  <!-- Signal Processing (spoke) -->
-  <rect x="339" y="256" width="52" height="52" rx="12" fill="#0891B2"/>
-  <polyline points="349,282 357,282 361,270 367,294 372,282 381,282" fill="none" stroke="white" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round"/>
-  <text x="365" y="322" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Signal Proc.</text>
-  <text x="365" y="336" text-anchor="middle" font-size="10.5px" fill="#64748B">classify</text>
+  <!-- entry arrows: Gateway and API Frontend cross into the engine boundary -->
+  <line x1="121" y1="126" x2="204" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
+  <line x1="256" y1="126" x2="300" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
+  <line x1="929" y1="126" x2="880" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
 
-  <!-- AI Analysis + KA (spoke, slightly bigger) -->
-  <rect x="495" y="250" width="60" height="60" rx="13" fill="#6366F1"/>
-  <polygon points="525,266 539,275 539,291 525,300 511,291 511,275" fill="none" stroke="white" stroke-width="2.2"/>
-  <circle cx="525" cy="283" r="3" fill="white"/>
-  <text x="525" y="326" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">AI Analysis + KA</text>
-  <text x="525" y="340" text-anchor="middle" font-size="10.5px" fill="#64748B">investigate + select WF</text>
-
-  <!-- Workflow Execution (spoke) -->
-  <rect x="659" y="256" width="52" height="52" rx="12" fill="#D97706"/>
-  <circle cx="685" cy="282" r="10" fill="none" stroke="white" stroke-width="2.4"/>
-  <circle cx="685" cy="282" r="3.5" fill="white"/>
-  <rect x="682" y="266" width="6" height="6" fill="white"/>
-  <rect x="682" y="292" width="6" height="6" fill="white"/>
-  <rect x="669" y="279" width="6" height="6" fill="white"/>
-  <rect x="695" y="279" width="6" height="6" fill="white"/>
-  <text x="685" y="322" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Workflow Exec.</text>
-  <text x="685" y="336" text-anchor="middle" font-size="10.5px" fill="#64748B">runs remediation</text>
-
-  <!-- Row 3: Scope Check@400 OAuth2 Provider@650 -->
+  <!-- Orchestrator fans out to its 5 child CRDs, ordered left-to-right so lines never cross -->
+  <line x1="567" y1="188" x2="374" y2="284" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="579" y1="188" x2="482" y2="280" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="590" y1="188" x2="590" y2="284" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="601" y1="188" x2="698" y2="284" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="613" y1="188" x2="806" y2="284" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
 
   <!-- Scope Check -->
-  <rect x="374" y="390" width="52" height="52" rx="12" fill="#0E7490"/>
-  <path d="M400,398 L416,404 v14 c0,10 -8,16 -16,20 c-8,-4 -16,-10 -16,-20 v-14 z" fill="none" stroke="white" stroke-width="2.2"/>
-  <polyline points="392,414 399,421 410,408" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
-  <text x="400" y="458" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Scope Check</text>
-  <text x="400" y="472" text-anchor="middle" font-size="10.5px" fill="#64748B">FMC (default) · ACM</text>
+  <rect x="274" y="430" width="52" height="52" rx="12" fill="#0E7490"/>
+  <path d="M300,438 L316,444 v14 c0,10 -8,16 -16,20 c-8,-4 -16,-10 -16,-20 v-14 z" fill="none" stroke="white" stroke-width="2.2"/>
+  <polyline points="292,454 299,461 310,448" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="300" y="498" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Scope Check</text>
+  <text x="300" y="512" text-anchor="middle" font-size="10.5px" fill="#64748B">FMC (default) · ACM</text>
 
   <!-- OAuth2 -->
-  <rect x="624" y="390" width="52" height="52" rx="12" fill="#475569" stroke="#94A3B8" stroke-width="1.4" stroke-dasharray="3,3"/>
-  <path d="M642,412 v-6 a8,8 0 0 1 16,0 v6" fill="none" stroke="white" stroke-width="2.4"/>
-  <rect x="638" y="412" width="24" height="16" rx="3" fill="white"/>
-  <text x="650" y="458" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">OAuth2 Provider</text>
-  <text x="650" y="472" text-anchor="middle" font-size="10.5px" fill="#64748B">external IdP</text>
+  <rect x="624" y="430" width="52" height="52" rx="12" fill="#475569" stroke="#94A3B8" stroke-width="1.4" stroke-dasharray="3,3"/>
+  <path d="M642,452 v-6 a8,8 0 0 1 16,0 v6" fill="none" stroke="white" stroke-width="2.4"/>
+  <rect x="638" y="452" width="24" height="16" rx="3" fill="white"/>
+  <text x="650" y="498" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">OAuth2 Provider</text>
+  <text x="650" y="512" text-anchor="middle" font-size="10.5px" fill="#64748B">external IdP</text>
 
-  <!-- pipeline arrows -->
-  <line x1="187" y1="116" x2="317" y2="116" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
-  <line x1="369" y1="116" x2="491" y2="116" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
-  <line x1="509" y1="148" x2="365" y2="256" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="525" y1="148" x2="525" y2="250" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="541" y1="148" x2="685" y2="256" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <!-- scope-check: Gateway + Engine (RO) merge into one trunk -->
+  <line x1="230" y1="152" x2="265" y2="410" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3"/>
+  <line x1="590" y1="400" x2="265" y2="410" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3"/>
+  <line x1="265" y1="410" x2="300" y2="428" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
 
-  <!-- scope-check: Gateway + Orchestrator merge into one trunk, well clear of Signal Proc. -->
-  <line x1="343" y1="142" x2="450" y2="190" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3"/>
-  <line x1="497" y1="100" x2="450" y2="190" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3"/>
-  <line x1="450" y1="190" x2="400" y2="386" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
+  <!-- client-credentials: engine -> OAuth2 left edge (clear of its label) -->
+  <path d="M750,400 L750,450 L624,450" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <text x="687" y="391" text-anchor="middle" font-size="10.5px" fill="#8B5CF6">client-credentials (all 7 services)</text>
 
-  <!-- client-credentials: routed under everything, enters OAuth2's left edge (clear of its label) -->
-  <path d="M343,142 L343,498 L600,498 L600,405 L624,405" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
-  <text x="471" y="491" text-anchor="middle" font-size="10.5px" fill="#8B5CF6">client-credentials (7 services)</text>
+  <!-- OAuth2 validates token: exits right edge (offset from client-credentials entry), straight down to Gateway -->
+  <path d="M676,462 L710,462 L710,580" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <text x="716" y="458" font-size="10px" fill="#A78BFA">validates token</text>
 
   <!-- boundary arrows: Hub Cluster -> MCP Gateway (straight, vertical) -->
-  <line x1="525" y1="506" x2="525" y2="580" stroke="#94A3B8" stroke-width="2" marker-end="url(#ar)"/>
-  <text x="463" y="546" font-size="12px" fill="#64748B">reads (6 services)</text>
-  <line x1="685" y1="506" x2="685" y2="580" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
-  <text x="700" y="546" font-size="12px" font-weight="600" fill="#B45309">+ writes (Workflow Exec.)</text>
-
-  <!-- OAuth2 validates token: exits right edge (clear of its label), then straight down to Gateway -->
-  <path d="M676,405 L710,405 L710,580" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
-  <text x="716" y="401" font-size="10px" fill="#A78BFA">validates token</text>
+  <line x1="440" y1="546" x2="440" y2="580" stroke="#94A3B8" stroke-width="2" marker-end="url(#ar)"/>
+  <text x="455" y="566" font-size="12px" fill="#64748B">reads (6 services)</text>
+  <line x1="590" y1="546" x2="590" y2="580" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
+  <text x="605" y="566" font-size="12px" font-weight="600" fill="#B45309">+ writes (Workflow Exec.)</text>
 
   <!-- ═══════════ MCP Gateway ═══════════ -->
-  <g filter="url(#sh)"><rect x="400" y="580" width="600" height="100" rx="16" fill="url(#gwGrad)"/></g>
-  <text x="700" y="620" text-anchor="middle" font-size="22px" font-weight="800" fill="white">MCP Gateway</text>
-  <text x="700" y="642" text-anchor="middle" font-size="12.5px" fill="#E9D5FF">Kuadrant MCP Gateway or Envoy AI Gateway</text>
-  <text x="700" y="664" text-anchor="middle" font-size="11px" fill="#C4B5FD">external infra — bring your own, like PostgreSQL/Prometheus</text>
+  <g filter="url(#sh)"><rect x="400" y="580" width="600" height="80" rx="16" fill="url(#gwGrad)"/></g>
+  <text x="700" y="614" text-anchor="middle" font-size="20px" font-weight="800" fill="white">MCP Gateway</text>
+  <text x="700" y="638" text-anchor="middle" font-size="11.5px" fill="#DDD6FE">Kuadrant MCP Gateway or Envoy AI Gateway · external infra, bring your own</text>
 
   <!-- ═══════════ Remote Clusters container (full width) ═══════════ -->
   <rect x="20" y="720" width="1360" height="160" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
   <rect x="40" y="704" width="180" height="32" rx="8" fill="#334155"/>
   <text x="130" y="725" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">REMOTE CLUSTERS</text>
 
-  <line x1="560" y1="680" x2="190" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="630" y1="680" x2="530" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="770" y1="680" x2="870" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="840" y1="680" x2="1210" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="560" y1="660" x2="190" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="630" y1="660" x2="530" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="770" y1="660" x2="870" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="840" y1="660" x2="1210" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
 
   <!-- Cluster A -->
   <g filter="url(#sh)"><rect x="95" y="744" width="190" height="126" rx="12" fill="white"/></g>
   <rect x="168" y="756" width="44" height="44" rx="10" fill="#326CE5"/>
-  <use href="#k8sWheel" x="172" y="760" width="36" height="36"/>
+  <use href="#k8sLogo" x="175" y="763" width="30" height="30"/>
   <text x="190" y="818" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster A</text>
   <rect x="125" y="830" width="130" height="22" rx="6" fill="#EEF2FF"/>
   <text x="190" y="845" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
@@ -177,7 +175,7 @@
   <!-- Cluster B -->
   <g filter="url(#sh)"><rect x="435" y="744" width="190" height="126" rx="12" fill="white"/></g>
   <rect x="508" y="756" width="44" height="44" rx="10" fill="#326CE5"/>
-  <use href="#k8sWheel" x="512" y="760" width="36" height="36"/>
+  <use href="#k8sLogo" x="515" y="763" width="30" height="30"/>
   <text x="530" y="818" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster B</text>
   <rect x="465" y="830" width="130" height="22" rx="6" fill="#EEF2FF"/>
   <text x="530" y="845" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
@@ -185,7 +183,7 @@
   <!-- Cluster C -->
   <g filter="url(#sh)"><rect x="775" y="744" width="190" height="126" rx="12" fill="white"/></g>
   <rect x="848" y="756" width="44" height="44" rx="10" fill="#326CE5"/>
-  <use href="#k8sWheel" x="852" y="760" width="36" height="36"/>
+  <use href="#k8sLogo" x="855" y="763" width="30" height="30"/>
   <text x="870" y="818" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster C</text>
   <rect x="805" y="830" width="130" height="22" rx="6" fill="#EEF2FF"/>
   <text x="870" y="845" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 772" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1050 860" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
   <defs>
     <filter id="sh" x="-4%" y="-6%" width="108%" height="118%">
       <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.10"/>
@@ -29,7 +29,7 @@
     </symbol>
   </defs>
 
-  <rect x="0" y="0" width="1400" height="772" fill="white"/>
+  <rect x="0" y="0" width="1050" height="860" fill="white"/>
 
   <!-- ═══════════ Hub Cluster container ═══════════ -->
   <rect x="20" y="46" width="1010" height="362" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
@@ -139,26 +139,22 @@
   <text x="775" y="690" text-anchor="middle" font-size="13px" font-weight="700" fill="#64748B">100s more</text>
   <text x="775" y="709" text-anchor="middle" font-size="11px" fill="#94A3B8">same pattern</text>
 
-  <!-- ═══════════ Legend + note ═══════════ -->
+  <!-- ═══════════ Legend + note (horizontal strip, same width as the containers above) ═══════════ -->
+  <rect x="20" y="756" width="1010" height="80" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
+
   <g>
-    <line x1="1060" y1="100" x2="1090" y2="100" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
-    <text x="1098" y="104" font-size="12px" fill="#374151">reads</text>
+    <line x1="50" y1="790" x2="74" y2="790" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
+    <text x="82" y="794" font-size="12px" fill="#374151">reads</text>
 
-    <line x1="1060" y1="128" x2="1090" y2="128" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
-    <text x="1098" y="132" font-size="12px" fill="#374151">reads + writes</text>
+    <line x1="300" y1="790" x2="324" y2="790" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
+    <text x="332" y="794" font-size="12px" fill="#374151">reads + writes</text>
 
-    <line x1="1060" y1="156" x2="1090" y2="156" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
-    <text x="1098" y="160" font-size="12px" fill="#374151">auth / token</text>
+    <line x1="550" y1="790" x2="574" y2="790" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+    <text x="582" y="794" font-size="12px" fill="#374151">auth / token</text>
 
-    <line x1="1060" y1="184" x2="1090" y2="184" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
-    <text x="1098" y="188" font-size="12px" fill="#374151">scope check</text>
+    <line x1="800" y1="790" x2="824" y2="790" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
+    <text x="832" y="794" font-size="12px" fill="#374151">scope check</text>
   </g>
 
-  <rect x="1050" y="70" width="330" height="150" rx="12" fill="none" stroke="#E2E8F0" stroke-width="1.5"/>
-  <text x="1070" y="52" font-size="12px" font-weight="700" fill="#64748B">LEGEND</text>
-
-  <text x="1050" y="250" font-size="12.5px" fill="#64748B">Fleet is opt-in (<tspan font-family="monospace">fleet.enabled: true</tspan>),</text>
-  <text x="1050" y="270" font-size="12.5px" fill="#64748B">disabled by default — zero regression</text>
-  <text x="1050" y="290" font-size="12.5px" fill="#64748B">for single-cluster deployments.</text>
-  <text x="1050" y="316" font-size="11.5px" font-weight="600" fill="#94A3B8">v1.6 · ADR-068</text>
+  <text x="525" y="820" text-anchor="middle" font-size="11.5px" fill="#64748B">Fleet is opt-in (<tspan font-family="monospace">fleet.enabled: true</tspan>), disabled by default — zero regression for single-cluster deployments · v1.6 · ADR-068</text>
 </svg>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1050 860" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1050 852" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
   <defs>
     <filter id="sh" x="-4%" y="-6%" width="108%" height="118%">
       <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.10"/>
@@ -27,9 +27,22 @@
       <path d="M100,92 C82,66 38,66 38,100 C38,134 82,134 100,108" fill="none" stroke="#E5E7EB" stroke-width="13" stroke-linecap="round"/>
       <path d="M100,92 C118,66 162,66 162,100 C162,134 118,134 100,108" fill="none" stroke="#F59E0B" stroke-width="13" stroke-linecap="round"/>
     </symbol>
+    <!-- Official project marks (CNCF artwork, white/monochrome variants for placement on colored badges) -->
+    <symbol id="thanosLogo" viewBox="2.41 2.16 355.42 355.17">
+      <path fill="white" d="M9.49808 9.14822v341.59786h241.93485a99.66306 99.66306 0 0 0 99.657-99.663V9.14822zm266.263 215.32837h12.75033v12.75018h-12.75035zm-4.00963-54.89h20.71531v20.72131h-20.71533zm-3.186-54.10261h27.09335v27.11729h-27.09343zm-43.739 159.90321h12.7381v12.75018h-12.75017zm-3.98558-55.53932h20.72129V240.587h-20.72129zm-3.186-53.44731h27.12344v27.09337h-27.09339zm3.186-27.00322v-20.71528h20.72129v20.71527zm-97.82954 135.98981h12.75021v12.75018h-12.75021zm-3.98558-54.8901h20.72131v20.69121h-20.72124zm3.98558-34.1748v-12.75019h12.75021v12.75018zm-3.98558-67.64019h20.72131v20.71527h-20.72124zM72.10081 275.38715H84.875v12.75018H72.10081zm0-50.91056H84.875v12.75018H72.10081zm-3.97955-54.89h20.7153v20.72131h-20.7153zm-3.19206-54.10265h27.09939v27.11729H64.9292zM53.01459 52.67679h254.53469v50.91052H205.74622v203.6302h-50.90449v-203.6302H53.01459z"/>
+    </symbol>
+    <symbol id="kuadrantLogo" viewBox="0 0 1024 1024">
+      <path fill="white" d="M809,1C993.59,183.56 1065.7,449.65 998.12,699.05C964.778,821.823 899.519,933.607 809,1023L292.27,512L809,1Z"/>
+      <rect fill="white" x="1" y="1" width="218" height="1022"/>
+    </symbol>
+    <symbol id="envoyLogo" viewBox="-4.43 47.82 438.36 331.11">
+      <path fill="white" d="M109.3 208.2l.6 25.4 26.7 16.5-.6-25.4zm65.2 105.4l-.6-24.8-23.4-14.5c-.3-.2-.7-.5-1-.7l.6 24.9 24.4 15.1zm-83.4 33.5L30 309.2l-1.5-63.5 29.9-12.9-.6-25.4L10 228c-3.7 1.6-5.9 5-5.8 8.9L6 313.1c.1 3.9 2.5 7.8 6.3 10.1l73.3 45.4c3.4 2.1 7.5 2.7 11 1.6.4-.1.7-.2 1-.4l45-19.4-24.4-15.1-27.1 11.8zm197.4-140.4c-.1-4.6-2.9-9.1-7.3-11.8l-88.9-55.1-2.7 1.2.6 26.7 70.4 43.6 1.7 71.4 26.9 16.7 1.5-.6-2.2-92.1z"/>
+      <path fill="white" d="M182 332l-82.6-51.2-2-86 37.6-16.2-.7-29.6-58.4 25.2c-4.3 1.9-6.9 5.8-6.8 10.4l2.4 100.8c.1 4.6 2.9 9.1 7.3 11.8l96.8 60c4 2.5 8.8 3.1 12.8 1.9.4-.1.8-.3 1.2-.5l57.2-24.7-28.4-17.6L182 332z"/>
+      <path fill="white" d="M414.4 136.2l-124.2-77c-4.6-2.8-10-3.6-14.7-2.1-.5.1-.9.3-1.4.5L153 109.8c-4.9 2.1-7.9 6.6-7.7 11.9l3 129.2c.1 5.2 3.3 10.4 8.3 13.5l124.2 76.9c4.6 2.8 10 3.6 14.7 2.1.5-.1.9-.3 1.4-.5L418 290.7c4.9-2.1 7.8-6.6 7.7-11.9l-3-129.2c-.1-5.2-3.3-10.3-8.3-13.4zM288.2 312.5l-107.9-66.9-2.7-112.2L282.9 88l107.9 66.9 2.7 112.2-105.3 45.4z"/>
+    </symbol>
   </defs>
 
-  <rect x="0" y="0" width="1050" height="860" fill="white"/>
+  <rect x="0" y="0" width="1050" height="852" fill="white"/>
 
   <!-- ═══════════ Hub Cluster container ═══════════ -->
   <rect x="20" y="46" width="1010" height="362" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
@@ -38,9 +51,7 @@
 
   <!-- Thanos (metrics, informational — no direct call arrow) -->
   <rect x="69" y="100" width="52" height="52" rx="12" fill="#0E7490"/>
-  <rect x="83" y="122" width="6" height="18" fill="white"/>
-  <rect x="93" y="114" width="6" height="26" fill="white"/>
-  <rect x="103" y="126" width="6" height="14" fill="white"/>
+  <use href="#thanosLogo" x="80" y="111" width="30" height="30"/>
   <text x="95" y="168" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Thanos</text>
   <text x="95" y="182" text-anchor="middle" font-size="10.5px" fill="#64748B">metrics</text>
 
@@ -101,60 +112,61 @@
   <text x="605" y="434" font-size="12px" font-weight="600" fill="#B45309">+ writes (workflow execution)</text>
 
   <!-- ═══════════ MCP Gateway (centered under the Hub Cluster container, x 20-1030 → center 525) ═══════════ -->
-  <g filter="url(#sh)"><rect x="225" y="452" width="600" height="80" rx="16" fill="url(#gwGrad)"/></g>
-  <text x="525" y="486" text-anchor="middle" font-size="20px" font-weight="800" fill="white">MCP Gateway</text>
-  <text x="525" y="510" text-anchor="middle" font-size="11.5px" fill="#DDD6FE">Kuadrant MCP Gateway or Envoy AI Gateway · external infra, bring your own</text>
+  <g filter="url(#sh)"><rect x="225" y="452" width="600" height="100" rx="16" fill="url(#gwGrad)"/></g>
+  <text x="525" y="478" text-anchor="middle" font-size="20px" font-weight="800" fill="white">MCP Gateway</text>
+  <use href="#kuadrantLogo" x="486" y="492" width="20" height="20"/>
+  <text x="522" y="507" text-anchor="middle" font-size="10px" fill="#DDD6FE">or</text>
+  <use href="#envoyLogo" x="538" y="492" width="26" height="20"/>
+  <text x="525" y="534" text-anchor="middle" font-size="11.5px" fill="#DDD6FE">external infra · bring your own</text>
 
   <!-- ═══════════ Remote Clusters container (matches Hub Cluster's width: x 20-1030) ═══════════ -->
-  <rect x="20" y="592" width="1010" height="160" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
-  <rect x="40" y="576" width="180" height="32" rx="8" fill="#334155"/>
-  <text x="130" y="597" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">REMOTE CLUSTERS</text>
+  <rect x="20" y="612" width="1010" height="160" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <rect x="40" y="596" width="180" height="32" rx="8" fill="#334155"/>
+  <text x="130" y="617" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">REMOTE CLUSTERS</text>
 
   <!-- straight vertical drops: each card is centered directly under its MCP Gateway source point -->
-  <line x1="275" y1="532" x2="275" y2="616" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="525" y1="532" x2="525" y2="616" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="775" y1="532" x2="775" y2="616" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="275" y1="552" x2="275" y2="636" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="525" y1="552" x2="525" y2="636" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="775" y1="552" x2="775" y2="636" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
 
   <!-- Cluster A -->
-  <g filter="url(#sh)"><rect x="180" y="616" width="190" height="126" rx="12" fill="white"/></g>
-  <rect x="253" y="628" width="44" height="44" rx="10" fill="#326CE5"/>
-  <use href="#k8sLogo" x="260" y="635" width="30" height="30"/>
-  <text x="275" y="690" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster A</text>
-  <rect x="210" y="702" width="130" height="22" rx="6" fill="#EEF2FF"/>
-  <text x="275" y="717" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
+  <g filter="url(#sh)"><rect x="180" y="636" width="190" height="126" rx="12" fill="white"/></g>
+  <rect x="253" y="648" width="44" height="44" rx="10" fill="#326CE5"/>
+  <use href="#k8sLogo" x="260" y="655" width="30" height="30"/>
+  <text x="275" y="710" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster A</text>
+  <rect x="210" y="722" width="130" height="22" rx="6" fill="#EEF2FF"/>
+  <text x="275" y="737" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
 
   <!-- Cluster B -->
-  <g filter="url(#sh)"><rect x="430" y="616" width="190" height="126" rx="12" fill="white"/></g>
-  <rect x="503" y="628" width="44" height="44" rx="10" fill="#326CE5"/>
-  <use href="#k8sLogo" x="510" y="635" width="30" height="30"/>
-  <text x="525" y="690" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster B</text>
-  <rect x="460" y="702" width="130" height="22" rx="6" fill="#EEF2FF"/>
-  <text x="525" y="717" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
+  <g filter="url(#sh)"><rect x="430" y="636" width="190" height="126" rx="12" fill="white"/></g>
+  <rect x="503" y="648" width="44" height="44" rx="10" fill="#326CE5"/>
+  <use href="#k8sLogo" x="510" y="655" width="30" height="30"/>
+  <text x="525" y="710" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster B</text>
+  <rect x="460" y="722" width="130" height="22" rx="6" fill="#EEF2FF"/>
+  <text x="525" y="737" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
 
   <!-- + more clusters (ghost, replaces a third named example - same pattern repeats at fleet scale) -->
-  <rect x="680" y="616" width="190" height="126" rx="12" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="5,4"/>
-  <circle cx="763" cy="662" r="3.2" fill="#94A3B8"/>
-  <circle cx="775" cy="662" r="3.2" fill="#94A3B8"/>
-  <circle cx="787" cy="662" r="3.2" fill="#94A3B8"/>
-  <text x="775" y="690" text-anchor="middle" font-size="13px" font-weight="700" fill="#64748B">100s more</text>
-  <text x="775" y="709" text-anchor="middle" font-size="11px" fill="#94A3B8">same pattern</text>
+  <rect x="680" y="636" width="190" height="126" rx="12" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="5,4"/>
+  <circle cx="763" cy="682" r="3.2" fill="#94A3B8"/>
+  <circle cx="775" cy="682" r="3.2" fill="#94A3B8"/>
+  <circle cx="787" cy="682" r="3.2" fill="#94A3B8"/>
+  <text x="775" y="710" text-anchor="middle" font-size="13px" font-weight="700" fill="#64748B">100s more</text>
+  <text x="775" y="729" text-anchor="middle" font-size="11px" fill="#94A3B8">same pattern</text>
 
-  <!-- ═══════════ Legend + note (horizontal strip, same width as the containers above) ═══════════ -->
-  <rect x="20" y="756" width="1010" height="80" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
+  <!-- ═══════════ Legend (horizontal strip, same width as the containers above) ═══════════ -->
+  <rect x="20" y="776" width="1010" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
 
   <g>
-    <line x1="50" y1="790" x2="74" y2="790" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
-    <text x="82" y="794" font-size="12px" fill="#374151">reads</text>
+    <line x1="50" y1="810" x2="74" y2="810" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
+    <text x="82" y="814" font-size="12px" fill="#374151">reads</text>
 
-    <line x1="300" y1="790" x2="324" y2="790" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
-    <text x="332" y="794" font-size="12px" fill="#374151">reads + writes</text>
+    <line x1="300" y1="810" x2="324" y2="810" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
+    <text x="332" y="814" font-size="12px" fill="#374151">reads + writes</text>
 
-    <line x1="550" y1="790" x2="574" y2="790" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
-    <text x="582" y="794" font-size="12px" fill="#374151">auth / token</text>
+    <line x1="550" y1="810" x2="574" y2="810" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+    <text x="582" y="814" font-size="12px" fill="#374151">auth / token</text>
 
-    <line x1="800" y1="790" x2="824" y2="790" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
-    <text x="832" y="794" font-size="12px" fill="#374151">scope check</text>
+    <line x1="800" y1="810" x2="824" y2="810" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
+    <text x="832" y="814" font-size="12px" fill="#374151">scope check</text>
   </g>
-
-  <text x="525" y="820" text-anchor="middle" font-size="11.5px" fill="#64748B">Fleet is opt-in (<tspan font-family="monospace">fleet.enabled: true</tspan>), disabled by default — zero regression for single-cluster deployments · v1.6 · ADR-068</text>
 </svg>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -101,9 +101,10 @@
   <text x="650" y="348" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">OAuth2 Provider</text>
   <text x="650" y="362" text-anchor="middle" font-size="10.5px" fill="#64748B">external IdP</text>
 
-  <!-- scope-check: Gateway (entry, fail-fast) and the Engine (routing, temporal drift) each check independently, equal-length arrows -->
-  <line x1="230" y1="152" x2="337" y2="278" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#arc)"/>
-  <line x1="490" y1="182" x2="357" y2="278" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#arc)"/>
+  <!-- scope-check: Gateway (entry, fail-fast) and the Engine (routing, temporal drift) each check independently, equal-length
+       orthogonal (vertical/horizontal only) elbow connectors, matching every other arrow in the diagram -->
+  <path d="M230,152 L230,240 L337,240 L337,278" fill="none" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#arc)"/>
+  <path d="M490,182 L490,240 L357,240 L357,278" fill="none" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#arc)"/>
 
   <!-- client-credentials: engine -> OAuth2 (straight, unobstructed) -->
   <line x1="650" y1="182" x2="650" y2="278" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 890" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 900" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
   <defs>
     <filter id="sh" x="-4%" y="-6%" width="108%" height="118%">
       <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.10"/>
@@ -34,117 +34,121 @@
     </symbol>
   </defs>
 
-  <rect x="0" y="0" width="1400" height="890" fill="white"/>
+  <rect x="0" y="0" width="1400" height="900" fill="white"/>
 
   <!-- ═══════════ Hub Cluster container ═══════════ -->
   <rect x="20" y="46" width="1010" height="460" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
   <rect x="40" y="30" width="150" height="32" rx="8" fill="#0F172A"/>
   <text x="115" y="51" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">HUB CLUSTER</text>
 
-  <!-- Node template: 52x52 icon badge, bold label below, optional gray subtitle -->
+  <!-- Row 1 (evenly spread across full container width): Thanos@161 Gateway@343 Orchestrator@525 API Frontend@707 Effectiveness@889 -->
 
   <!-- Thanos -->
-  <rect x="66" y="90" width="52" height="52" rx="12" fill="#0E7490"/>
-  <rect x="80" y="112" width="6" height="18" fill="white"/>
-  <rect x="90" y="104" width="6" height="26" fill="white"/>
-  <rect x="100" y="116" width="6" height="14" fill="white"/>
-  <text x="92" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Thanos</text>
-  <text x="92" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">metrics</text>
+  <rect x="135" y="90" width="52" height="52" rx="12" fill="#0E7490"/>
+  <rect x="149" y="112" width="6" height="18" fill="white"/>
+  <rect x="159" y="104" width="6" height="26" fill="white"/>
+  <rect x="169" y="116" width="6" height="14" fill="white"/>
+  <text x="161" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Thanos</text>
+  <text x="161" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">metrics</text>
 
   <!-- Gateway -->
-  <rect x="196" y="90" width="52" height="52" rx="12" fill="#0891B2"/>
-  <path d="M212,104 L236,104 L226,122 L222,122 Z" fill="white"/>
-  <rect x="221" y="122" width="4" height="10" fill="white"/>
-  <text x="222" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Gateway</text>
-  <text x="222" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">ingest + dedup</text>
+  <rect x="317" y="90" width="52" height="52" rx="12" fill="#0891B2"/>
+  <path d="M333,104 L357,104 L347,122 L343,122 Z" fill="white"/>
+  <rect x="342" y="122" width="4" height="10" fill="white"/>
+  <text x="343" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Gateway</text>
+  <text x="343" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">ingest + dedup</text>
 
   <!-- Remediation Orchestrator (hub, bigger) -->
-  <rect x="360" y="80" width="68" height="68" rx="14" fill="#0F172A"/>
-  <circle cx="394" cy="114" r="5" fill="white"/>
-  <circle cx="378" cy="98" r="3.4" fill="#94A3B8"/>
-  <circle cx="410" cy="98" r="3.4" fill="#94A3B8"/>
-  <circle cx="394" cy="132" r="3.4" fill="#94A3B8"/>
-  <line x1="394" y1="114" x2="378" y2="98" stroke="#94A3B8" stroke-width="1.6"/>
-  <line x1="394" y1="114" x2="410" y2="98" stroke="#94A3B8" stroke-width="1.6"/>
-  <line x1="394" y1="114" x2="394" y2="132" stroke="#94A3B8" stroke-width="1.6"/>
-  <text x="394" y="172" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Orchestrator</text>
-  <text x="394" y="186" text-anchor="middle" font-size="10.5px" fill="#64748B">6 child CRDs · ClusterID</text>
+  <rect x="491" y="80" width="68" height="68" rx="14" fill="#0F172A"/>
+  <circle cx="525" cy="114" r="5" fill="white"/>
+  <circle cx="509" cy="98" r="3.4" fill="#94A3B8"/>
+  <circle cx="541" cy="98" r="3.4" fill="#94A3B8"/>
+  <circle cx="525" cy="132" r="3.4" fill="#94A3B8"/>
+  <line x1="525" y1="114" x2="509" y2="98" stroke="#94A3B8" stroke-width="1.6"/>
+  <line x1="525" y1="114" x2="541" y2="98" stroke="#94A3B8" stroke-width="1.6"/>
+  <line x1="525" y1="114" x2="525" y2="132" stroke="#94A3B8" stroke-width="1.6"/>
+  <text x="525" y="172" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Orchestrator</text>
+  <text x="525" y="186" text-anchor="middle" font-size="10.5px" fill="#64748B">6 child CRDs · ClusterID</text>
 
   <!-- API Frontend -->
-  <rect x="560" y="90" width="52" height="52" rx="12" fill="#64748B"/>
-  <path d="M572,104 h28 a4,4 0 0 1 4,4 v12 a4,4 0 0 1 -4,4 h-16 l-8,7 v-7 h-4 a4,4 0 0 1 -4,-4 v-12 a4,4 0 0 1 4,-4 z" fill="white"/>
-  <text x="586" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">API Frontend</text>
-  <text x="586" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">interactive entry</text>
+  <rect x="681" y="90" width="52" height="52" rx="12" fill="#64748B"/>
+  <path d="M693,104 h28 a4,4 0 0 1 4,4 v12 a4,4 0 0 1 -4,4 h-16 l-8,7 v-7 h-4 a4,4 0 0 1 -4,-4 v-12 a4,4 0 0 1 4,-4 z" fill="white"/>
+  <text x="707" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">API Frontend</text>
+  <text x="707" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">interactive entry</text>
 
   <!-- Effectiveness Monitor -->
-  <rect x="690" y="90" width="52" height="52" rx="12" fill="#059669"/>
-  <polyline points="700,116 708,116 713,104 720,128 725,116 734,116" fill="none" stroke="white" stroke-width="2.6" stroke-linejoin="round" stroke-linecap="round"/>
-  <text x="716" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Effectiveness</text>
-  <text x="716" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">verify + learn</text>
+  <rect x="863" y="90" width="52" height="52" rx="12" fill="#059669"/>
+  <polyline points="873,116 881,116 886,104 893,128 898,116 907,116" fill="none" stroke="white" stroke-width="2.6" stroke-linejoin="round" stroke-linecap="round"/>
+  <text x="889" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Effectiveness</text>
+  <text x="889" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">verify + learn</text>
+
+  <!-- Row 2 (under Orchestrator): Signal Proc@365 AI Analysis+KA@525 Workflow Exec@685 -->
 
   <!-- Signal Processing (spoke) -->
-  <rect x="260" y="256" width="52" height="52" rx="12" fill="#0891B2"/>
-  <polyline points="270,282 278,282 282,270 288,294 293,282 302,282" fill="none" stroke="white" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round"/>
-  <text x="286" y="322" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Signal Proc.</text>
-  <text x="286" y="336" text-anchor="middle" font-size="10.5px" fill="#64748B">classify</text>
+  <rect x="339" y="256" width="52" height="52" rx="12" fill="#0891B2"/>
+  <polyline points="349,282 357,282 361,270 367,294 372,282 381,282" fill="none" stroke="white" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round"/>
+  <text x="365" y="322" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Signal Proc.</text>
+  <text x="365" y="336" text-anchor="middle" font-size="10.5px" fill="#64748B">classify</text>
 
   <!-- AI Analysis + KA (spoke, slightly bigger) -->
-  <rect x="368" y="250" width="60" height="60" rx="13" fill="#6366F1"/>
-  <polygon points="398,266 412,275 412,291 398,300 384,291 384,275" fill="none" stroke="white" stroke-width="2.2"/>
-  <circle cx="398" cy="283" r="3" fill="white"/>
-  <text x="398" y="326" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">AI Analysis + KA</text>
-  <text x="398" y="340" text-anchor="middle" font-size="10.5px" fill="#64748B">investigate + select WF</text>
+  <rect x="495" y="250" width="60" height="60" rx="13" fill="#6366F1"/>
+  <polygon points="525,266 539,275 539,291 525,300 511,291 511,275" fill="none" stroke="white" stroke-width="2.2"/>
+  <circle cx="525" cy="283" r="3" fill="white"/>
+  <text x="525" y="326" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">AI Analysis + KA</text>
+  <text x="525" y="340" text-anchor="middle" font-size="10.5px" fill="#64748B">investigate + select WF</text>
 
   <!-- Workflow Execution (spoke) -->
-  <rect x="480" y="256" width="52" height="52" rx="12" fill="#D97706"/>
-  <circle cx="506" cy="282" r="10" fill="none" stroke="white" stroke-width="2.4"/>
-  <circle cx="506" cy="282" r="3.5" fill="white"/>
-  <rect x="503" y="266" width="6" height="6" fill="white"/>
-  <rect x="503" y="292" width="6" height="6" fill="white"/>
-  <rect x="490" y="279" width="6" height="6" fill="white"/>
-  <rect x="516" y="279" width="6" height="6" fill="white"/>
-  <text x="506" y="322" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Workflow Exec.</text>
-  <text x="506" y="336" text-anchor="middle" font-size="10.5px" fill="#64748B">runs remediation</text>
+  <rect x="659" y="256" width="52" height="52" rx="12" fill="#D97706"/>
+  <circle cx="685" cy="282" r="10" fill="none" stroke="white" stroke-width="2.4"/>
+  <circle cx="685" cy="282" r="3.5" fill="white"/>
+  <rect x="682" y="266" width="6" height="6" fill="white"/>
+  <rect x="682" y="292" width="6" height="6" fill="white"/>
+  <rect x="669" y="279" width="6" height="6" fill="white"/>
+  <rect x="695" y="279" width="6" height="6" fill="white"/>
+  <text x="685" y="322" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Workflow Exec.</text>
+  <text x="685" y="336" text-anchor="middle" font-size="10.5px" fill="#64748B">runs remediation</text>
+
+  <!-- Row 3: Scope Check@400 OAuth2 Provider@650 -->
 
   <!-- Scope Check -->
-  <rect x="120" y="390" width="52" height="52" rx="12" fill="#0E7490"/>
-  <path d="M146,398 L162,404 v14 c0,10 -8,16 -16,20 c-8,-4 -16,-10 -16,-20 v-14 z" fill="none" stroke="white" stroke-width="2.2"/>
-  <polyline points="138,414 145,421 156,408" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
-  <text x="146" y="458" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Scope Check</text>
-  <text x="146" y="472" text-anchor="middle" font-size="10.5px" fill="#64748B">FMC (default) · ACM</text>
+  <rect x="374" y="390" width="52" height="52" rx="12" fill="#0E7490"/>
+  <path d="M400,398 L416,404 v14 c0,10 -8,16 -16,20 c-8,-4 -16,-10 -16,-20 v-14 z" fill="none" stroke="white" stroke-width="2.2"/>
+  <polyline points="392,414 399,421 410,408" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="400" y="458" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Scope Check</text>
+  <text x="400" y="472" text-anchor="middle" font-size="10.5px" fill="#64748B">FMC (default) · ACM</text>
 
   <!-- OAuth2 -->
-  <rect x="560" y="390" width="52" height="52" rx="12" fill="#475569" stroke="#94A3B8" stroke-width="1.4" stroke-dasharray="3,3"/>
-  <path d="M578,412 v-6 a8,8 0 0 1 16,0 v6" fill="none" stroke="white" stroke-width="2.4"/>
-  <rect x="574" y="412" width="24" height="16" rx="3" fill="white"/>
-  <text x="586" y="458" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">OAuth2 Provider</text>
-  <text x="586" y="472" text-anchor="middle" font-size="10.5px" fill="#64748B">external IdP</text>
+  <rect x="624" y="390" width="52" height="52" rx="12" fill="#475569" stroke="#94A3B8" stroke-width="1.4" stroke-dasharray="3,3"/>
+  <path d="M642,412 v-6 a8,8 0 0 1 16,0 v6" fill="none" stroke="white" stroke-width="2.4"/>
+  <rect x="638" y="412" width="24" height="16" rx="3" fill="white"/>
+  <text x="650" y="458" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">OAuth2 Provider</text>
+  <text x="650" y="472" text-anchor="middle" font-size="10.5px" fill="#64748B">external IdP</text>
 
   <!-- pipeline arrows -->
-  <line x1="118" y1="116" x2="196" y2="116" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
-  <line x1="248" y1="116" x2="360" y2="116" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
-  <line x1="382" y1="148" x2="310" y2="256" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="394" y1="148" x2="397" y2="250" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="406" y1="148" x2="490" y2="256" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="187" y1="116" x2="317" y2="116" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
+  <line x1="369" y1="116" x2="491" y2="116" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
+  <line x1="509" y1="148" x2="365" y2="256" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="525" y1="148" x2="525" y2="250" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="541" y1="148" x2="685" y2="256" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
 
-  <!-- scope-check: Gateway + Orchestrator merge into one trunk, no crossing with pipeline arrows -->
-  <line x1="222" y1="142" x2="270" y2="190" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3"/>
-  <line x1="378" y1="148" x2="270" y2="190" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3"/>
-  <line x1="270" y1="190" x2="150" y2="386" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
+  <!-- scope-check: Gateway + Orchestrator merge into one trunk, well clear of Signal Proc. -->
+  <line x1="343" y1="142" x2="450" y2="190" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3"/>
+  <line x1="497" y1="100" x2="450" y2="190" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3"/>
+  <line x1="450" y1="190" x2="400" y2="386" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
 
-  <!-- OAuth2 arrow (dashed, client-credentials): routed under everything, enters OAuth2 from below -->
-  <path d="M222,142 L222,498 L586,498 L586,450" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
-  <text x="404" y="491" text-anchor="middle" font-size="10.5px" fill="#8B5CF6">client-credentials (7 services)</text>
+  <!-- client-credentials: routed under everything, enters OAuth2's left edge (clear of its label) -->
+  <path d="M343,142 L343,498 L600,498 L600,405 L624,405" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <text x="471" y="491" text-anchor="middle" font-size="10.5px" fill="#8B5CF6">client-credentials (7 services)</text>
 
-  <!-- boundary arrows: Hub Cluster -> MCP Gateway -->
-  <line x1="420" y1="506" x2="600" y2="580" stroke="#94A3B8" stroke-width="2" marker-end="url(#ar)"/>
-  <text x="470" y="532" font-size="12px" fill="#64748B">reads (6 services)</text>
-  <line x1="560" y1="506" x2="700" y2="580" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
-  <text x="620" y="544" font-size="12px" font-weight="600" fill="#B45309">+ writes (Workflow Exec.)</text>
+  <!-- boundary arrows: Hub Cluster -> MCP Gateway (straight, vertical) -->
+  <line x1="525" y1="506" x2="525" y2="580" stroke="#94A3B8" stroke-width="2" marker-end="url(#ar)"/>
+  <text x="463" y="546" font-size="12px" fill="#64748B">reads (6 services)</text>
+  <line x1="685" y1="506" x2="685" y2="580" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
+  <text x="700" y="546" font-size="12px" font-weight="600" fill="#B45309">+ writes (Workflow Exec.)</text>
 
-  <!-- OAuth2 validates token -->
-  <line x1="612" y1="416" x2="900" y2="610" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
-  <text x="700" y="490" font-size="11px" fill="#A78BFA">validates token</text>
+  <!-- OAuth2 validates token: exits right edge (clear of its label), then straight down to Gateway -->
+  <path d="M676,405 L710,405 L710,580" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <text x="716" y="401" font-size="10px" fill="#A78BFA">validates token</text>
 
   <!-- ═══════════ MCP Gateway ═══════════ -->
   <g filter="url(#sh)"><rect x="400" y="580" width="600" height="100" rx="16" fill="url(#gwGrad)"/></g>
@@ -153,46 +157,46 @@
   <text x="700" y="664" text-anchor="middle" font-size="11px" fill="#C4B5FD">external infra — bring your own, like PostgreSQL/Prometheus</text>
 
   <!-- ═══════════ Remote Clusters container (full width) ═══════════ -->
-  <rect x="20" y="720" width="1360" height="150" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <rect x="20" y="720" width="1360" height="160" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
   <rect x="40" y="704" width="180" height="32" rx="8" fill="#334155"/>
   <text x="130" y="725" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">REMOTE CLUSTERS</text>
 
-  <line x1="560" y1="680" x2="190" y2="732" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="630" y1="680" x2="530" y2="732" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="770" y1="680" x2="870" y2="732" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="840" y1="680" x2="1210" y2="732" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="560" y1="680" x2="190" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="630" y1="680" x2="530" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="770" y1="680" x2="870" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="840" y1="680" x2="1210" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
 
   <!-- Cluster A -->
-  <g filter="url(#sh)"><rect x="95" y="732" width="190" height="126" rx="12" fill="white"/></g>
-  <rect x="168" y="744" width="44" height="44" rx="10" fill="#334155"/>
-  <use href="#k8sWheel" x="172" y="748" width="36" height="36"/>
-  <text x="190" y="806" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster A</text>
-  <rect x="125" y="818" width="130" height="22" rx="6" fill="#EEF2FF"/>
-  <text x="190" y="833" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
+  <g filter="url(#sh)"><rect x="95" y="744" width="190" height="126" rx="12" fill="white"/></g>
+  <rect x="168" y="756" width="44" height="44" rx="10" fill="#326CE5"/>
+  <use href="#k8sWheel" x="172" y="760" width="36" height="36"/>
+  <text x="190" y="818" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster A</text>
+  <rect x="125" y="830" width="130" height="22" rx="6" fill="#EEF2FF"/>
+  <text x="190" y="845" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
 
   <!-- Cluster B -->
-  <g filter="url(#sh)"><rect x="435" y="732" width="190" height="126" rx="12" fill="white"/></g>
-  <rect x="508" y="744" width="44" height="44" rx="10" fill="#334155"/>
-  <use href="#k8sWheel" x="512" y="748" width="36" height="36"/>
-  <text x="530" y="806" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster B</text>
-  <rect x="465" y="818" width="130" height="22" rx="6" fill="#EEF2FF"/>
-  <text x="530" y="833" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
+  <g filter="url(#sh)"><rect x="435" y="744" width="190" height="126" rx="12" fill="white"/></g>
+  <rect x="508" y="756" width="44" height="44" rx="10" fill="#326CE5"/>
+  <use href="#k8sWheel" x="512" y="760" width="36" height="36"/>
+  <text x="530" y="818" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster B</text>
+  <rect x="465" y="830" width="130" height="22" rx="6" fill="#EEF2FF"/>
+  <text x="530" y="845" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
 
   <!-- Cluster C -->
-  <g filter="url(#sh)"><rect x="775" y="732" width="190" height="126" rx="12" fill="white"/></g>
-  <rect x="848" y="744" width="44" height="44" rx="10" fill="#334155"/>
-  <use href="#k8sWheel" x="852" y="748" width="36" height="36"/>
-  <text x="870" y="806" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster C</text>
-  <rect x="805" y="818" width="130" height="22" rx="6" fill="#EEF2FF"/>
-  <text x="870" y="833" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
+  <g filter="url(#sh)"><rect x="775" y="744" width="190" height="126" rx="12" fill="white"/></g>
+  <rect x="848" y="756" width="44" height="44" rx="10" fill="#326CE5"/>
+  <use href="#k8sWheel" x="852" y="760" width="36" height="36"/>
+  <text x="870" y="818" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Cluster C</text>
+  <rect x="805" y="830" width="130" height="22" rx="6" fill="#EEF2FF"/>
+  <text x="870" y="845" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
 
   <!-- + more clusters (ghost) -->
-  <rect x="1115" y="732" width="190" height="126" rx="12" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="5,4"/>
-  <circle cx="1198" cy="778" r="3.2" fill="#94A3B8"/>
-  <circle cx="1210" cy="778" r="3.2" fill="#94A3B8"/>
-  <circle cx="1222" cy="778" r="3.2" fill="#94A3B8"/>
-  <text x="1210" y="806" text-anchor="middle" font-size="13px" font-weight="700" fill="#64748B">100s more</text>
-  <text x="1210" y="825" text-anchor="middle" font-size="11px" fill="#94A3B8">same pattern</text>
+  <rect x="1115" y="744" width="190" height="126" rx="12" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="5,4"/>
+  <circle cx="1198" cy="790" r="3.2" fill="#94A3B8"/>
+  <circle cx="1210" cy="790" r="3.2" fill="#94A3B8"/>
+  <circle cx="1222" cy="790" r="3.2" fill="#94A3B8"/>
+  <text x="1210" y="818" text-anchor="middle" font-size="13px" font-weight="700" fill="#64748B">100s more</text>
+  <text x="1210" y="837" text-anchor="middle" font-size="11px" fill="#94A3B8">same pattern</text>
 
   <!-- ═══════════ Legend + note ═══════════ -->
   <g>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -3,14 +3,17 @@
     <filter id="sh" x="-4%" y="-6%" width="108%" height="118%">
       <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.10"/>
     </filter>
-    <marker id="ar" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto-start-reverse">
-      <polygon points="0,0 8,3 0,6" fill="#94A3B8"/>
+    <marker id="ar" markerWidth="6" markerHeight="4.5" refX="5" refY="2.25" orient="auto-start-reverse">
+      <polygon points="0,0 6,2.25 0,4.5" fill="#94A3B8"/>
     </marker>
-    <marker id="arw" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto-start-reverse">
-      <polygon points="0,0 9,3.5 0,7" fill="#D97706"/>
+    <marker id="arw" markerWidth="6.5" markerHeight="5" refX="5.5" refY="2.5" orient="auto-start-reverse">
+      <polygon points="0,0 6.5,2.5 0,5" fill="#D97706"/>
     </marker>
-    <marker id="ard" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto-start-reverse">
-      <polygon points="0,0 8,3 0,6" fill="#A78BFA"/>
+    <marker id="ard" markerWidth="6" markerHeight="4.5" refX="5" refY="2.25" orient="auto-start-reverse">
+      <polygon points="0,0 6,2.25 0,4.5" fill="#A78BFA"/>
+    </marker>
+    <marker id="arc" markerWidth="6" markerHeight="4.5" refX="5" refY="2.25" orient="auto-start-reverse">
+      <polygon points="0,0 6,2.25 0,4.5" fill="#67E8F9"/>
     </marker>
     <linearGradient id="gwGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#7C3AED"/>
@@ -99,8 +102,8 @@
   <text x="650" y="362" text-anchor="middle" font-size="10.5px" fill="#64748B">external IdP</text>
 
   <!-- scope-check: Gateway (entry, fail-fast) and the Engine (routing, temporal drift) each check independently, equal-length arrows -->
-  <line x1="230" y1="152" x2="337" y2="278" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
-  <line x1="490" y1="182" x2="357" y2="278" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
+  <line x1="230" y1="152" x2="337" y2="278" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#arc)"/>
+  <line x1="490" y1="182" x2="357" y2="278" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#arc)"/>
 
   <!-- client-credentials: engine -> OAuth2 (straight, unobstructed) -->
   <line x1="650" y1="182" x2="650" y2="278" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
@@ -112,9 +115,9 @@
   <text x="718" y="380" font-size="10px" fill="#A78BFA">validates token</text>
 
   <!-- boundary arrows: Hub Cluster <-> MCP Gateway (straight, vertical). Double-headed: MCP tool calls are request/response, results flow back up. -->
-  <line x1="440" y1="408" x2="440" y2="452" stroke="#94A3B8" stroke-width="2" marker-start="url(#ar)" marker-end="url(#ar)"/>
+  <line x1="440" y1="408" x2="440" y2="452" stroke="#94A3B8" stroke-width="1.8" marker-start="url(#ar)" marker-end="url(#ar)"/>
   <text x="455" y="434" font-size="12px" fill="#64748B">reads (6 services)</text>
-  <line x1="590" y1="408" x2="590" y2="452" stroke="#D97706" stroke-width="3" marker-start="url(#arw)" marker-end="url(#arw)"/>
+  <line x1="590" y1="408" x2="590" y2="452" stroke="#D97706" stroke-width="2.2" marker-start="url(#arw)" marker-end="url(#arw)"/>
   <text x="605" y="434" font-size="12px" font-weight="600" fill="#B45309">+ writes (workflow execution)</text>
 
   <!-- ═══════════ MCP Gateway (centered under the Hub Cluster container, x 20-1030 → center 525) ═══════════ -->
@@ -169,16 +172,16 @@
   <rect x="20" y="776" width="1010" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
 
   <g>
-    <line x1="50" y1="810" x2="74" y2="810" stroke="#94A3B8" stroke-width="1.8" marker-start="url(#ar)" marker-end="url(#ar)"/>
-    <text x="82" y="814" font-size="12px" fill="#374151">reads (call + response)</text>
+    <line x1="50" y1="810" x2="94" y2="810" stroke="#94A3B8" stroke-width="1.8" marker-start="url(#ar)" marker-end="url(#ar)"/>
+    <text x="104" y="814" font-size="12px" fill="#374151">reads (call + response)</text>
 
-    <line x1="330" y1="810" x2="354" y2="810" stroke="#D97706" stroke-width="3" marker-start="url(#arw)" marker-end="url(#arw)"/>
-    <text x="362" y="814" font-size="12px" fill="#374151">reads + writes</text>
+    <line x1="360" y1="810" x2="404" y2="810" stroke="#D97706" stroke-width="2.2" marker-start="url(#arw)" marker-end="url(#arw)"/>
+    <text x="414" y="814" font-size="12px" fill="#374151">reads + writes</text>
 
-    <line x1="550" y1="810" x2="574" y2="810" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
-    <text x="582" y="814" font-size="12px" fill="#374151">auth / token</text>
+    <line x1="610" y1="810" x2="634" y2="810" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+    <text x="642" y="814" font-size="12px" fill="#374151">auth / token</text>
 
-    <line x1="800" y1="810" x2="824" y2="810" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
-    <text x="832" y="814" font-size="12px" fill="#374151">scope check</text>
+    <line x1="850" y1="810" x2="874" y2="810" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#arc)"/>
+    <text x="882" y="814" font-size="12px" fill="#374151">scope check</text>
   </g>
 </svg>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -1,0 +1,166 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 645" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+  <defs>
+    <filter id="sh" x="-2%" y="-4%" width="104%" height="112%">
+      <feDropShadow dx="0" dy="3" stdDeviation="6" flood-color="#000" flood-opacity="0.06"/>
+    </filter>
+    <marker id="ar" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0,0 8,3 0,6" fill="#94A3B8"/>
+    </marker>
+    <marker id="ard" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0,0 8,3 0,6" fill="#CBD5E1"/>
+    </marker>
+    <linearGradient id="gwGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#4C1D95"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0" y="0" width="1400" height="645" fill="white"/>
+
+  <!-- ═══════════ Row 1: Management-cluster services ═══════════ -->
+
+  <!-- Card 1: Signal Entry -->
+  <g filter="url(#sh)"><rect x="20" y="20" width="440" height="170" rx="12" fill="white"/></g>
+  <rect x="20" y="20" width="440" height="42" rx="12" fill="#0891B2"/>
+  <rect x="20" y="50" width="440" height="12" fill="#0891B2"/>
+  <text x="44" y="48" font-size="17px" font-weight="700" fill="white">Signal Entry</text>
+  <text x="44" y="88" font-size="14px" fill="#374151">Thanos Querier — multi-cluster Prometheus</text>
+  <text x="44" y="112" font-size="14px" fill="#374151">Gateway extracts the <tspan font-weight="600">cluster</tspan> label per alert</text>
+  <text x="44" y="136" font-size="14px" fill="#374151">Cluster-aware fingerprinting (no cross-cluster dedup)</text>
+  <rect x="44" y="152" width="130" height="26" rx="7" fill="#F8FAFC"/>
+  <text x="109" y="169" text-anchor="middle" font-size="12px" font-weight="600" fill="#64748B">Gateway</text>
+
+  <!-- Card 2: Orchestration -->
+  <g filter="url(#sh)"><rect x="480" y="20" width="440" height="170" rx="12" fill="white"/></g>
+  <rect x="480" y="20" width="440" height="42" rx="12" fill="#0F172A"/>
+  <rect x="480" y="50" width="440" height="12" fill="#0F172A"/>
+  <text x="504" y="48" font-size="17px" font-weight="700" fill="white">Orchestration</text>
+  <text x="504" y="88" font-size="14px" fill="#374151">Remediation Orchestrator creates 6 child CRDs</text>
+  <text x="504" y="112" font-size="14px" fill="#374151">Routes: Signal Processing → AI Analysis → Execution</text>
+  <text x="504" y="136" font-size="14px" fill="#374151">Propagates <tspan font-weight="600">ClusterID</tspan> to every child CRD + audit event</text>
+  <rect x="504" y="152" width="220" height="26" rx="7" fill="#F8FAFC"/>
+  <text x="614" y="169" text-anchor="middle" font-size="12px" font-weight="600" fill="#64748B">Remediation Orchestrator</text>
+
+  <!-- Card 3: Fleet-aware roster (pills) -->
+  <g filter="url(#sh)"><rect x="940" y="20" width="440" height="170" rx="12" fill="white"/></g>
+  <rect x="940" y="20" width="440" height="42" rx="12" fill="#475569"/>
+  <rect x="940" y="50" width="440" height="12" fill="#475569"/>
+  <text x="964" y="48" font-size="17px" font-weight="700" fill="white">7 Fleet-Dependent Services</text>
+
+  <!-- pill row 1 -->
+  <rect x="964" y="76" width="98" height="26" rx="13" fill="#0891B2"/>
+  <text x="1013" y="93" text-anchor="middle" font-size="11.5px" font-weight="600" fill="white">Gateway</text>
+  <rect x="1072" y="76" width="98" height="26" rx="13" fill="#0F172A"/>
+  <text x="1121" y="93" text-anchor="middle" font-size="11.5px" font-weight="600" fill="white">Orchestrator</text>
+  <rect x="1180" y="76" width="98" height="26" rx="13" fill="#0891B2"/>
+  <text x="1229" y="93" text-anchor="middle" font-size="11.5px" font-weight="600" fill="white">Signal Proc.</text>
+  <rect x="1288" y="76" width="72" height="26" rx="13" fill="#6366F1"/>
+  <text x="1324" y="93" text-anchor="middle" font-size="11.5px" font-weight="600" fill="white">AI + KA</text>
+
+  <!-- pill row 2 -->
+  <rect x="964" y="110" width="130" height="26" rx="13" fill="#D97706"/>
+  <text x="1029" y="127" text-anchor="middle" font-size="11.5px" font-weight="600" fill="white">Workflow Exec.</text>
+  <rect x="1102" y="110" width="118" height="26" rx="13" fill="#64748B"/>
+  <text x="1161" y="127" text-anchor="middle" font-size="11.5px" font-weight="600" fill="white">API Frontend</text>
+  <rect x="1228" y="110" width="132" height="26" rx="13" fill="#059669"/>
+  <text x="1294" y="127" text-anchor="middle" font-size="11.5px" font-weight="600" fill="white">Effectiveness Mon.</text>
+
+  <text x="964" y="156" font-size="13px" fill="#374151">All 7 <tspan font-weight="600">read</tspan> the MCP Gateway;</text>
+  <text x="964" y="176" font-size="13px" fill="#374151">Workflow Execution also <tspan font-weight="600">writes</tspan> (remote runs)</text>
+
+  <!-- converging arrows row1 -> row2 -->
+  <line x1="240" y1="190" x2="620" y2="235" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#ar)"/>
+  <line x1="700" y1="190" x2="700" y2="235" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#ar)"/>
+  <line x1="1160" y1="190" x2="780" y2="235" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#ar)"/>
+  <!-- roster -> OAuth2 -->
+  <line x1="1180" y1="190" x2="1150" y2="235" stroke="#CBD5E1" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+
+  <!-- ═══════════ Row 2: Scope Check · MCP Gateway · OAuth2 ═══════════ -->
+
+  <!-- Scope Check card -->
+  <g filter="url(#sh)"><rect x="20" y="235" width="340" height="110" rx="12" fill="white"/></g>
+  <rect x="20" y="235" width="340" height="38" rx="12" fill="#0E7490"/>
+  <rect x="20" y="261" width="340" height="12" fill="#0E7490"/>
+  <text x="40" y="260" font-size="15px" font-weight="700" fill="white">Scope Check</text>
+  <text x="40" y="292" font-size="12.5px" fill="#374151">Pluggable backend: FederatedScopeChecker routes local</text>
+  <text x="40" y="310" font-size="12.5px" fill="#374151">ClusterID → own K8s API; remote → adapter. FMC polls</text>
+  <text x="40" y="328" font-size="12.5px" fill="#374151">the MCP Gateway, caches managed resources in Valkey.</text>
+  <rect x="228" y="238" width="126" height="22" rx="6" fill="#F0FDFA"/>
+  <text x="291" y="253" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#0E7490">FMC &lt;1ms · ACM 10-50ms</text>
+
+  <!-- MCP Gateway banner -->
+  <g filter="url(#sh)"><rect x="390" y="235" width="620" height="110" rx="14" fill="url(#gwGrad)"/></g>
+  <text x="700" y="278" text-anchor="middle" font-size="24px" font-weight="800" fill="white">MCP Gateway</text>
+  <text x="700" y="302" text-anchor="middle" font-size="13px" fill="#E9D5FF">Kuadrant MCP Gateway or Envoy AI Gateway (EAIGW)</text>
+  <rect x="490" y="313" width="420" height="22" rx="6" fill="rgba(255,255,255,0.15)"/>
+  <text x="700" y="328" text-anchor="middle" font-size="11px" font-weight="600" fill="white">external infra — bring your own, like PostgreSQL/Prometheus</text>
+
+  <!-- OAuth2 card -->
+  <g filter="url(#sh)"><rect x="1040" y="235" width="340" height="110" rx="12" fill="white" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="5,4"/></g>
+  <rect x="1040" y="235" width="340" height="38" rx="12" fill="#64748B"/>
+  <rect x="1040" y="261" width="340" height="12" fill="#64748B"/>
+  <text x="1060" y="260" font-size="15px" font-weight="700" fill="white">OAuth2 Provider</text>
+  <text x="1060" y="295" font-size="12.5px" fill="#374151">External IdP — Keycloak, DEX, or any OIDC provider</text>
+  <text x="1060" y="313" font-size="12.5px" fill="#374151">All 7 services acquire + auto-refresh client-credential tokens</text>
+  <text x="1060" y="331" font-size="12.5px" fill="#374151">Gateway validates every token against the same IdP</text>
+
+  <!-- horizontal connectors around gateway -->
+  <line x1="360" y1="290" x2="390" y2="290" stroke="#0E7490" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="1010" y1="290" x2="1040" y2="290" stroke="#CBD5E1" stroke-width="1.6" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <text x="985" y="282" text-anchor="end" font-size="10.5px" fill="#94A3B8">validates token</text>
+
+  <!-- ═══════════ Row 3: Remote / spoke clusters ═══════════ -->
+
+  <line x1="580" y1="345" x2="182" y2="390" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#ar)"/>
+  <line x1="660" y1="345" x2="527" y2="390" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#ar)"/>
+  <line x1="740" y1="345" x2="872" y2="390" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#ar)"/>
+  <line x1="820" y1="345" x2="1217" y2="390" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#ar)"/>
+
+  <!-- Cluster A -->
+  <g filter="url(#sh)"><rect x="20" y="390" width="325" height="150" rx="12" fill="white"/></g>
+  <rect x="20" y="390" width="325" height="36" rx="12" fill="#334155"/>
+  <rect x="20" y="414" width="325" height="12" fill="#334155"/>
+  <text x="42" y="413" font-size="15px" font-weight="700" fill="white">Cluster A</text>
+  <rect x="42" y="446" width="150" height="26" rx="7" fill="#EEF2FF"/>
+  <text x="117" y="463" text-anchor="middle" font-size="11.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
+  <line x1="117" y1="472" x2="117" y2="488" stroke="#CBD5E1" stroke-width="1.4" marker-end="url(#ar)"/>
+  <text x="42" y="512" font-size="12.5px" fill="#374151">Remote resource reads +</text>
+  <text x="42" y="530" font-size="12.5px" fill="#374151">remediation (Jobs / Tekton)</text>
+
+  <!-- Cluster B -->
+  <g filter="url(#sh)"><rect x="365" y="390" width="325" height="150" rx="12" fill="white"/></g>
+  <rect x="365" y="390" width="325" height="36" rx="12" fill="#334155"/>
+  <rect x="365" y="414" width="325" height="12" fill="#334155"/>
+  <text x="387" y="413" font-size="15px" font-weight="700" fill="white">Cluster B</text>
+  <rect x="387" y="446" width="150" height="26" rx="7" fill="#EEF2FF"/>
+  <text x="462" y="463" text-anchor="middle" font-size="11.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
+  <line x1="462" y1="472" x2="462" y2="488" stroke="#CBD5E1" stroke-width="1.4" marker-end="url(#ar)"/>
+  <text x="387" y="512" font-size="12.5px" fill="#374151">Remote resource reads +</text>
+  <text x="387" y="530" font-size="12.5px" fill="#374151">remediation (Jobs / Tekton)</text>
+
+  <!-- Cluster C -->
+  <g filter="url(#sh)"><rect x="710" y="390" width="325" height="150" rx="12" fill="white"/></g>
+  <rect x="710" y="390" width="325" height="36" rx="12" fill="#334155"/>
+  <rect x="710" y="414" width="325" height="12" fill="#334155"/>
+  <text x="732" y="413" font-size="15px" font-weight="700" fill="white">Cluster C</text>
+  <rect x="732" y="446" width="150" height="26" rx="7" fill="#EEF2FF"/>
+  <text x="807" y="463" text-anchor="middle" font-size="11.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
+  <line x1="807" y1="472" x2="807" y2="488" stroke="#CBD5E1" stroke-width="1.4" marker-end="url(#ar)"/>
+  <text x="732" y="512" font-size="12.5px" fill="#374151">Remote resource reads +</text>
+  <text x="732" y="530" font-size="12.5px" fill="#374151">remediation (Jobs / Tekton)</text>
+
+  <!-- + more clusters -->
+  <g><rect x="1055" y="390" width="325" height="150" rx="12" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="5,4"/></g>
+  <text x="1217" y="460" text-anchor="middle" font-size="15px" font-weight="700" fill="#64748B">+ up to 100s more</text>
+  <text x="1217" y="482" text-anchor="middle" font-size="13px" fill="#94A3B8">clusters, same pattern</text>
+  <circle cx="1187" cy="512" r="4" fill="#CBD5E1"/>
+  <circle cx="1217" cy="512" r="4" fill="#CBD5E1"/>
+  <circle cx="1247" cy="512" r="4" fill="#CBD5E1"/>
+
+  <!-- ═══════════ Footer ═══════════ -->
+  <g filter="url(#sh)"><rect x="20" y="565" width="1360" height="56" rx="12" fill="#0F172A"/></g>
+  <text x="44" y="588" font-size="14px" font-weight="700" fill="white">Fleet is opt-in</text>
+  <text x="44" y="608" font-size="12.5px" fill="#E2E8F0">Disabled by default (<tspan font-family="monospace">fleet.enabled: true</tspan>) — zero regression for single-cluster deployments</text>
+  <rect x="1220" y="579" width="140" height="26" rx="6" fill="rgba(255,255,255,0.15)"/>
+  <text x="1290" y="596" text-anchor="middle" font-size="12px" font-weight="600" fill="white">v1.6 · ADR-068</text>
+</svg>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -109,12 +109,12 @@
   <line x1="256" y1="126" x2="300" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
   <line x1="929" y1="126" x2="880" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
 
-  <!-- Orchestrator fans out to its 5 child CRDs, ordered left-to-right so lines never cross -->
+  <!-- Orchestrator creates the pipeline; SP -> AA -> WE -> EM -> NT reads left-to-right as the execution sequence -->
   <line x1="567" y1="188" x2="374" y2="284" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="579" y1="188" x2="482" y2="280" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="590" y1="188" x2="590" y2="284" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="601" y1="188" x2="698" y2="284" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="613" y1="188" x2="806" y2="284" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="400" y1="310" x2="452" y2="310" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="512" y1="310" x2="564" y2="310" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="616" y1="310" x2="672" y2="310" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="724" y1="310" x2="780" y2="310" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
 
   <!-- Scope Check -->
   <rect x="274" y="430" width="52" height="52" rx="12" fill="#0E7490"/>
@@ -130,18 +130,17 @@
   <text x="650" y="498" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">OAuth2 Provider</text>
   <text x="650" y="512" text-anchor="middle" font-size="10.5px" fill="#64748B">external IdP</text>
 
-  <!-- scope-check: Gateway + Engine (RO) merge into one trunk -->
-  <line x1="230" y1="152" x2="265" y2="410" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3"/>
-  <line x1="590" y1="400" x2="265" y2="410" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3"/>
-  <line x1="265" y1="410" x2="300" y2="428" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
+  <!-- scope-check: Gateway (entry, fail-fast) and Orchestrator (routing, temporal drift) each check independently -->
+  <line x1="222" y1="152" x2="288" y2="428" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
+  <path d="M556,144 L300,246 L312,428" fill="none" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
 
-  <!-- client-credentials: engine -> OAuth2 left edge (clear of its label) -->
-  <path d="M750,400 L750,450 L624,450" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <!-- client-credentials: engine -> OAuth2 top edge (stays clear of the badge, no crossing) -->
+  <path d="M750,400 L750,415 L655,415 L655,430" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
   <text x="687" y="391" text-anchor="middle" font-size="10.5px" fill="#8B5CF6">client-credentials (all 7 services)</text>
 
-  <!-- OAuth2 validates token: exits right edge (offset from client-credentials entry), straight down to Gateway -->
-  <path d="M676,462 L710,462 L710,580" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
-  <text x="716" y="458" font-size="10px" fill="#A78BFA">validates token</text>
+  <!-- OAuth2 validates token: exits right edge (below client-credentials entry, no overlap), down to Gateway -->
+  <path d="M676,450 L712,450 L712,580" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <text x="718" y="500" font-size="10px" fill="#A78BFA">validates token</text>
 
   <!-- boundary arrows: Hub Cluster -> MCP Gateway (straight, vertical) -->
   <line x1="440" y1="546" x2="440" y2="580" stroke="#94A3B8" stroke-width="2" marker-end="url(#ar)"/>
@@ -149,20 +148,20 @@
   <line x1="590" y1="546" x2="590" y2="580" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
   <text x="605" y="566" font-size="12px" font-weight="600" fill="#B45309">+ writes (Workflow Exec.)</text>
 
-  <!-- ═══════════ MCP Gateway ═══════════ -->
-  <g filter="url(#sh)"><rect x="400" y="580" width="600" height="80" rx="16" fill="url(#gwGrad)"/></g>
-  <text x="700" y="614" text-anchor="middle" font-size="20px" font-weight="800" fill="white">MCP Gateway</text>
-  <text x="700" y="638" text-anchor="middle" font-size="11.5px" fill="#DDD6FE">Kuadrant MCP Gateway or Envoy AI Gateway · external infra, bring your own</text>
+  <!-- ═══════════ MCP Gateway (centered under the Hub Cluster container, x 20-1030 → center 525) ═══════════ -->
+  <g filter="url(#sh)"><rect x="225" y="580" width="600" height="80" rx="16" fill="url(#gwGrad)"/></g>
+  <text x="525" y="614" text-anchor="middle" font-size="20px" font-weight="800" fill="white">MCP Gateway</text>
+  <text x="525" y="638" text-anchor="middle" font-size="11.5px" fill="#DDD6FE">Kuadrant MCP Gateway or Envoy AI Gateway · external infra, bring your own</text>
 
   <!-- ═══════════ Remote Clusters container (full width) ═══════════ -->
   <rect x="20" y="720" width="1360" height="160" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
   <rect x="40" y="704" width="180" height="32" rx="8" fill="#334155"/>
   <text x="130" y="725" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">REMOTE CLUSTERS</text>
 
-  <line x1="560" y1="660" x2="190" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="630" y1="660" x2="530" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="770" y1="660" x2="870" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="840" y1="660" x2="1210" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="385" y1="660" x2="190" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="455" y1="660" x2="530" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="595" y1="660" x2="870" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="665" y1="660" x2="1210" y2="744" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
 
   <!-- Cluster A -->
   <g filter="url(#sh)"><rect x="95" y="744" width="190" height="126" rx="12" fill="white"/></g>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -1,166 +1,191 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 645" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 800" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
   <defs>
-    <filter id="sh" x="-2%" y="-4%" width="104%" height="112%">
-      <feDropShadow dx="0" dy="3" stdDeviation="6" flood-color="#000" flood-opacity="0.06"/>
+    <filter id="sh" x="-4%" y="-6%" width="108%" height="118%">
+      <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.10"/>
     </filter>
     <marker id="ar" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
       <polygon points="0,0 8,3 0,6" fill="#94A3B8"/>
     </marker>
+    <marker id="arw" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0,0 9,3.5 0,7" fill="#D97706"/>
+    </marker>
     <marker id="ard" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <polygon points="0,0 8,3 0,6" fill="#CBD5E1"/>
+      <polygon points="0,0 8,3 0,6" fill="#A78BFA"/>
     </marker>
     <linearGradient id="gwGrad" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#7C3AED"/>
       <stop offset="1" stop-color="#4C1D95"/>
     </linearGradient>
+    <symbol id="hexCluster" viewBox="0 0 48 48">
+      <polygon points="24,4 42,14 42,34 24,44 6,34 6,14" fill="none" stroke="white" stroke-width="2.5"/>
+      <circle cx="24" cy="24" r="5" fill="white"/>
+    </symbol>
   </defs>
 
-  <rect x="0" y="0" width="1400" height="645" fill="white"/>
+  <rect x="0" y="0" width="1400" height="800" fill="white"/>
 
-  <!-- ═══════════ Row 1: Management-cluster services ═══════════ -->
+  <!-- ═══════════ Management Cluster container ═══════════ -->
+  <rect x="20" y="46" width="1010" height="440" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <rect x="40" y="30" width="204" height="32" rx="8" fill="#0F172A"/>
+  <text x="142" y="51" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">MANAGEMENT CLUSTER</text>
 
-  <!-- Card 1: Signal Entry -->
-  <g filter="url(#sh)"><rect x="20" y="20" width="440" height="170" rx="12" fill="white"/></g>
-  <rect x="20" y="20" width="440" height="42" rx="12" fill="#0891B2"/>
-  <rect x="20" y="50" width="440" height="12" fill="#0891B2"/>
-  <text x="44" y="48" font-size="17px" font-weight="700" fill="white">Signal Entry</text>
-  <text x="44" y="88" font-size="14px" fill="#374151">Thanos Querier — multi-cluster Prometheus</text>
-  <text x="44" y="112" font-size="14px" fill="#374151">Gateway extracts the <tspan font-weight="600">cluster</tspan> label per alert</text>
-  <text x="44" y="136" font-size="14px" fill="#374151">Cluster-aware fingerprinting (no cross-cluster dedup)</text>
-  <rect x="44" y="152" width="130" height="26" rx="7" fill="#F8FAFC"/>
-  <text x="109" y="169" text-anchor="middle" font-size="12px" font-weight="600" fill="#64748B">Gateway</text>
+  <!-- Node template: 52x52 icon badge, bold label below, optional gray subtitle -->
 
-  <!-- Card 2: Orchestration -->
-  <g filter="url(#sh)"><rect x="480" y="20" width="440" height="170" rx="12" fill="white"/></g>
-  <rect x="480" y="20" width="440" height="42" rx="12" fill="#0F172A"/>
-  <rect x="480" y="50" width="440" height="12" fill="#0F172A"/>
-  <text x="504" y="48" font-size="17px" font-weight="700" fill="white">Orchestration</text>
-  <text x="504" y="88" font-size="14px" fill="#374151">Remediation Orchestrator creates 6 child CRDs</text>
-  <text x="504" y="112" font-size="14px" fill="#374151">Routes: Signal Processing → AI Analysis → Execution</text>
-  <text x="504" y="136" font-size="14px" fill="#374151">Propagates <tspan font-weight="600">ClusterID</tspan> to every child CRD + audit event</text>
-  <rect x="504" y="152" width="220" height="26" rx="7" fill="#F8FAFC"/>
-  <text x="614" y="169" text-anchor="middle" font-size="12px" font-weight="600" fill="#64748B">Remediation Orchestrator</text>
+  <!-- Thanos -->
+  <rect x="66" y="90" width="52" height="52" rx="12" fill="#0E7490"/>
+  <rect x="80" y="112" width="6" height="18" fill="white"/>
+  <rect x="90" y="104" width="6" height="26" fill="white"/>
+  <rect x="100" y="116" width="6" height="14" fill="white"/>
+  <text x="92" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Thanos</text>
+  <text x="92" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">metrics</text>
 
-  <!-- Card 3: Fleet-aware roster (pills) -->
-  <g filter="url(#sh)"><rect x="940" y="20" width="440" height="170" rx="12" fill="white"/></g>
-  <rect x="940" y="20" width="440" height="42" rx="12" fill="#475569"/>
-  <rect x="940" y="50" width="440" height="12" fill="#475569"/>
-  <text x="964" y="48" font-size="17px" font-weight="700" fill="white">7 Fleet-Dependent Services</text>
+  <!-- Gateway -->
+  <rect x="196" y="90" width="52" height="52" rx="12" fill="#0891B2"/>
+  <path d="M212,104 L236,104 L226,122 L222,122 Z" fill="white"/>
+  <rect x="221" y="122" width="4" height="10" fill="white"/>
+  <text x="222" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Gateway</text>
+  <text x="222" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">ingest + dedup</text>
 
-  <!-- pill row 1 -->
-  <rect x="964" y="76" width="98" height="26" rx="13" fill="#0891B2"/>
-  <text x="1013" y="93" text-anchor="middle" font-size="11.5px" font-weight="600" fill="white">Gateway</text>
-  <rect x="1072" y="76" width="98" height="26" rx="13" fill="#0F172A"/>
-  <text x="1121" y="93" text-anchor="middle" font-size="11.5px" font-weight="600" fill="white">Orchestrator</text>
-  <rect x="1180" y="76" width="98" height="26" rx="13" fill="#0891B2"/>
-  <text x="1229" y="93" text-anchor="middle" font-size="11.5px" font-weight="600" fill="white">Signal Proc.</text>
-  <rect x="1288" y="76" width="72" height="26" rx="13" fill="#6366F1"/>
-  <text x="1324" y="93" text-anchor="middle" font-size="11.5px" font-weight="600" fill="white">AI + KA</text>
+  <!-- Remediation Orchestrator (hub, bigger) -->
+  <rect x="360" y="80" width="68" height="68" rx="14" fill="#0F172A"/>
+  <circle cx="394" cy="114" r="5" fill="white"/>
+  <circle cx="378" cy="98" r="3.4" fill="#94A3B8"/>
+  <circle cx="410" cy="98" r="3.4" fill="#94A3B8"/>
+  <circle cx="394" cy="132" r="3.4" fill="#94A3B8"/>
+  <line x1="394" y1="114" x2="378" y2="98" stroke="#94A3B8" stroke-width="1.6"/>
+  <line x1="394" y1="114" x2="410" y2="98" stroke="#94A3B8" stroke-width="1.6"/>
+  <line x1="394" y1="114" x2="394" y2="132" stroke="#94A3B8" stroke-width="1.6"/>
+  <text x="394" y="172" text-anchor="middle" font-size="13px" font-weight="700" fill="#0F172A">Orchestrator</text>
+  <text x="394" y="186" text-anchor="middle" font-size="10.5px" fill="#64748B">6 child CRDs · ClusterID</text>
 
-  <!-- pill row 2 -->
-  <rect x="964" y="110" width="130" height="26" rx="13" fill="#D97706"/>
-  <text x="1029" y="127" text-anchor="middle" font-size="11.5px" font-weight="600" fill="white">Workflow Exec.</text>
-  <rect x="1102" y="110" width="118" height="26" rx="13" fill="#64748B"/>
-  <text x="1161" y="127" text-anchor="middle" font-size="11.5px" font-weight="600" fill="white">API Frontend</text>
-  <rect x="1228" y="110" width="132" height="26" rx="13" fill="#059669"/>
-  <text x="1294" y="127" text-anchor="middle" font-size="11.5px" font-weight="600" fill="white">Effectiveness Mon.</text>
+  <!-- API Frontend -->
+  <rect x="560" y="90" width="52" height="52" rx="12" fill="#64748B"/>
+  <path d="M572,104 h28 a4,4 0 0 1 4,4 v12 a4,4 0 0 1 -4,4 h-16 l-8,7 v-7 h-4 a4,4 0 0 1 -4,-4 v-12 a4,4 0 0 1 4,-4 z" fill="white"/>
+  <text x="586" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">API Frontend</text>
+  <text x="586" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">interactive entry</text>
 
-  <text x="964" y="156" font-size="13px" fill="#374151">All 7 <tspan font-weight="600">read</tspan> the MCP Gateway;</text>
-  <text x="964" y="176" font-size="13px" fill="#374151">Workflow Execution also <tspan font-weight="600">writes</tspan> (remote runs)</text>
+  <!-- Effectiveness Monitor -->
+  <rect x="690" y="90" width="52" height="52" rx="12" fill="#059669"/>
+  <polyline points="700,116 708,116 713,104 720,128 725,116 734,116" fill="none" stroke="white" stroke-width="2.6" stroke-linejoin="round" stroke-linecap="round"/>
+  <text x="716" y="158" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Effectiveness</text>
+  <text x="716" y="172" text-anchor="middle" font-size="10.5px" fill="#64748B">verify + learn</text>
 
-  <!-- converging arrows row1 -> row2 -->
-  <line x1="240" y1="190" x2="620" y2="235" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#ar)"/>
-  <line x1="700" y1="190" x2="700" y2="235" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#ar)"/>
-  <line x1="1160" y1="190" x2="780" y2="235" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#ar)"/>
-  <!-- roster -> OAuth2 -->
-  <line x1="1180" y1="190" x2="1150" y2="235" stroke="#CBD5E1" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <!-- Signal Processing (spoke) -->
+  <rect x="260" y="256" width="52" height="52" rx="12" fill="#0891B2"/>
+  <polyline points="270,282 278,282 282,270 288,294 293,282 302,282" fill="none" stroke="white" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round"/>
+  <text x="286" y="322" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Signal Proc.</text>
+  <text x="286" y="336" text-anchor="middle" font-size="10.5px" fill="#64748B">classify</text>
 
-  <!-- ═══════════ Row 2: Scope Check · MCP Gateway · OAuth2 ═══════════ -->
+  <!-- AI Analysis + KA (spoke, slightly bigger) -->
+  <rect x="368" y="250" width="60" height="60" rx="13" fill="#6366F1"/>
+  <polygon points="398,266 412,275 412,291 398,300 384,291 384,275" fill="none" stroke="white" stroke-width="2.2"/>
+  <circle cx="398" cy="283" r="3" fill="white"/>
+  <text x="398" y="326" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">AI Analysis + KA</text>
+  <text x="398" y="340" text-anchor="middle" font-size="10.5px" fill="#64748B">investigate + select WF</text>
 
-  <!-- Scope Check card -->
-  <g filter="url(#sh)"><rect x="20" y="235" width="340" height="110" rx="12" fill="white"/></g>
-  <rect x="20" y="235" width="340" height="38" rx="12" fill="#0E7490"/>
-  <rect x="20" y="261" width="340" height="12" fill="#0E7490"/>
-  <text x="40" y="260" font-size="15px" font-weight="700" fill="white">Scope Check</text>
-  <text x="40" y="292" font-size="12.5px" fill="#374151">Pluggable backend: FederatedScopeChecker routes local</text>
-  <text x="40" y="310" font-size="12.5px" fill="#374151">ClusterID → own K8s API; remote → adapter. FMC polls</text>
-  <text x="40" y="328" font-size="12.5px" fill="#374151">the MCP Gateway, caches managed resources in Valkey.</text>
-  <rect x="228" y="238" width="126" height="22" rx="6" fill="#F0FDFA"/>
-  <text x="291" y="253" text-anchor="middle" font-size="10.5px" font-weight="600" fill="#0E7490">FMC &lt;1ms · ACM 10-50ms</text>
+  <!-- Workflow Execution (spoke) -->
+  <rect x="480" y="256" width="52" height="52" rx="12" fill="#D97706"/>
+  <circle cx="506" cy="282" r="10" fill="none" stroke="white" stroke-width="2.4"/>
+  <circle cx="506" cy="282" r="3.5" fill="white"/>
+  <rect x="503" y="266" width="6" height="6" fill="white"/>
+  <rect x="503" y="292" width="6" height="6" fill="white"/>
+  <rect x="490" y="279" width="6" height="6" fill="white"/>
+  <rect x="516" y="279" width="6" height="6" fill="white"/>
+  <text x="506" y="322" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Workflow Exec.</text>
+  <text x="506" y="336" text-anchor="middle" font-size="10.5px" fill="#64748B">runs remediation</text>
 
-  <!-- MCP Gateway banner -->
-  <g filter="url(#sh)"><rect x="390" y="235" width="620" height="110" rx="14" fill="url(#gwGrad)"/></g>
-  <text x="700" y="278" text-anchor="middle" font-size="24px" font-weight="800" fill="white">MCP Gateway</text>
-  <text x="700" y="302" text-anchor="middle" font-size="13px" fill="#E9D5FF">Kuadrant MCP Gateway or Envoy AI Gateway (EAIGW)</text>
-  <rect x="490" y="313" width="420" height="22" rx="6" fill="rgba(255,255,255,0.15)"/>
-  <text x="700" y="328" text-anchor="middle" font-size="11px" font-weight="600" fill="white">external infra — bring your own, like PostgreSQL/Prometheus</text>
+  <!-- Scope Check -->
+  <rect x="120" y="390" width="52" height="52" rx="12" fill="#0E7490"/>
+  <path d="M146,398 L162,404 v14 c0,10 -8,16 -16,20 c-8,-4 -16,-10 -16,-20 v-14 z" fill="none" stroke="white" stroke-width="2.2"/>
+  <polyline points="138,414 145,421 156,408" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="146" y="458" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Scope Check</text>
+  <text x="146" y="472" text-anchor="middle" font-size="10.5px" fill="#64748B">FMC (default) · ACM</text>
 
-  <!-- OAuth2 card -->
-  <g filter="url(#sh)"><rect x="1040" y="235" width="340" height="110" rx="12" fill="white" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="5,4"/></g>
-  <rect x="1040" y="235" width="340" height="38" rx="12" fill="#64748B"/>
-  <rect x="1040" y="261" width="340" height="12" fill="#64748B"/>
-  <text x="1060" y="260" font-size="15px" font-weight="700" fill="white">OAuth2 Provider</text>
-  <text x="1060" y="295" font-size="12.5px" fill="#374151">External IdP — Keycloak, DEX, or any OIDC provider</text>
-  <text x="1060" y="313" font-size="12.5px" fill="#374151">All 7 services acquire + auto-refresh client-credential tokens</text>
-  <text x="1060" y="331" font-size="12.5px" fill="#374151">Gateway validates every token against the same IdP</text>
+  <!-- OAuth2 -->
+  <rect x="560" y="390" width="52" height="52" rx="12" fill="#475569" stroke="#94A3B8" stroke-width="1.4" stroke-dasharray="3,3"/>
+  <path d="M578,412 v-6 a8,8 0 0 1 16,0 v6" fill="none" stroke="white" stroke-width="2.4"/>
+  <rect x="574" y="412" width="24" height="16" rx="3" fill="white"/>
+  <text x="586" y="458" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">OAuth2 Provider</text>
+  <text x="586" y="472" text-anchor="middle" font-size="10.5px" fill="#64748B">external IdP</text>
 
-  <!-- horizontal connectors around gateway -->
-  <line x1="360" y1="290" x2="390" y2="290" stroke="#0E7490" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="1010" y1="290" x2="1040" y2="290" stroke="#CBD5E1" stroke-width="1.6" stroke-dasharray="4,3" marker-end="url(#ard)"/>
-  <text x="985" y="282" text-anchor="end" font-size="10.5px" fill="#94A3B8">validates token</text>
+  <!-- pipeline arrows -->
+  <line x1="118" y1="116" x2="196" y2="116" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
+  <line x1="248" y1="116" x2="360" y2="116" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
+  <line x1="382" y1="148" x2="310" y2="256" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="394" y1="148" x2="397" y2="250" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="406" y1="148" x2="490" y2="256" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
 
-  <!-- ═══════════ Row 3: Remote / spoke clusters ═══════════ -->
+  <!-- scope-check arrows (dashed, from Gateway + Orchestrator) -->
+  <line x1="215" y1="142" x2="165" y2="390" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
+  <line x1="378" y1="148" x2="165" y2="390" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
 
-  <line x1="580" y1="345" x2="182" y2="390" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#ar)"/>
-  <line x1="660" y1="345" x2="527" y2="390" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#ar)"/>
-  <line x1="740" y1="345" x2="872" y2="390" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#ar)"/>
-  <line x1="820" y1="345" x2="1217" y2="390" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#ar)"/>
+  <!-- OAuth2 arrow (dashed, client-credentials) -->
+  <path d="M222,142 L222,224 L560,224 L560,390" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <text x="392" y="217" text-anchor="middle" font-size="10.5px" fill="#8B5CF6">client-credentials (7 services)</text>
 
-  <!-- Cluster A -->
-  <g filter="url(#sh)"><rect x="20" y="390" width="325" height="150" rx="12" fill="white"/></g>
-  <rect x="20" y="390" width="325" height="36" rx="12" fill="#334155"/>
-  <rect x="20" y="414" width="325" height="12" fill="#334155"/>
-  <text x="42" y="413" font-size="15px" font-weight="700" fill="white">Cluster A</text>
-  <rect x="42" y="446" width="150" height="26" rx="7" fill="#EEF2FF"/>
-  <text x="117" y="463" text-anchor="middle" font-size="11.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
-  <line x1="117" y1="472" x2="117" y2="488" stroke="#CBD5E1" stroke-width="1.4" marker-end="url(#ar)"/>
-  <text x="42" y="512" font-size="12.5px" fill="#374151">Remote resource reads +</text>
-  <text x="42" y="530" font-size="12.5px" fill="#374151">remediation (Jobs / Tekton)</text>
+  <!-- boundary arrows: Management Cluster -> MCP Gateway -->
+  <line x1="420" y1="486" x2="600" y2="560" stroke="#94A3B8" stroke-width="2" marker-end="url(#ar)"/>
+  <text x="470" y="512" font-size="12px" fill="#64748B">reads (6 services)</text>
+  <line x1="560" y1="486" x2="700" y2="560" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
+  <text x="620" y="524" font-size="12px" font-weight="600" fill="#B45309">+ writes (Workflow Exec.)</text>
 
-  <!-- Cluster B -->
-  <g filter="url(#sh)"><rect x="365" y="390" width="325" height="150" rx="12" fill="white"/></g>
-  <rect x="365" y="390" width="325" height="36" rx="12" fill="#334155"/>
-  <rect x="365" y="414" width="325" height="12" fill="#334155"/>
-  <text x="387" y="413" font-size="15px" font-weight="700" fill="white">Cluster B</text>
-  <rect x="387" y="446" width="150" height="26" rx="7" fill="#EEF2FF"/>
-  <text x="462" y="463" text-anchor="middle" font-size="11.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
-  <line x1="462" y1="472" x2="462" y2="488" stroke="#CBD5E1" stroke-width="1.4" marker-end="url(#ar)"/>
-  <text x="387" y="512" font-size="12.5px" fill="#374151">Remote resource reads +</text>
-  <text x="387" y="530" font-size="12.5px" fill="#374151">remediation (Jobs / Tekton)</text>
+  <!-- OAuth2 validates token -->
+  <line x1="612" y1="416" x2="900" y2="590" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+  <text x="700" y="470" font-size="11px" fill="#A78BFA">validates token</text>
 
-  <!-- Cluster C -->
-  <g filter="url(#sh)"><rect x="710" y="390" width="325" height="150" rx="12" fill="white"/></g>
-  <rect x="710" y="390" width="325" height="36" rx="12" fill="#334155"/>
-  <rect x="710" y="414" width="325" height="12" fill="#334155"/>
-  <text x="732" y="413" font-size="15px" font-weight="700" fill="white">Cluster C</text>
-  <rect x="732" y="446" width="150" height="26" rx="7" fill="#EEF2FF"/>
-  <text x="807" y="463" text-anchor="middle" font-size="11.5px" font-weight="600" fill="#4338CA">K8s MCP Server</text>
-  <line x1="807" y1="472" x2="807" y2="488" stroke="#CBD5E1" stroke-width="1.4" marker-end="url(#ar)"/>
-  <text x="732" y="512" font-size="12.5px" fill="#374151">Remote resource reads +</text>
-  <text x="732" y="530" font-size="12.5px" fill="#374151">remediation (Jobs / Tekton)</text>
+  <!-- ═══════════ MCP Gateway ═══════════ -->
+  <g filter="url(#sh)"><rect x="400" y="560" width="600" height="100" rx="16" fill="url(#gwGrad)"/></g>
+  <text x="700" y="600" text-anchor="middle" font-size="22px" font-weight="800" fill="white">MCP Gateway</text>
+  <text x="700" y="622" text-anchor="middle" font-size="12.5px" fill="#E9D5FF">Kuadrant MCP Gateway or Envoy AI Gateway</text>
+  <text x="700" y="644" text-anchor="middle" font-size="11px" fill="#C4B5FD">external infra — bring your own, like PostgreSQL/Prometheus</text>
 
-  <!-- + more clusters -->
-  <g><rect x="1055" y="390" width="325" height="150" rx="12" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="5,4"/></g>
-  <text x="1217" y="460" text-anchor="middle" font-size="15px" font-weight="700" fill="#64748B">+ up to 100s more</text>
-  <text x="1217" y="482" text-anchor="middle" font-size="13px" fill="#94A3B8">clusters, same pattern</text>
-  <circle cx="1187" cy="512" r="4" fill="#CBD5E1"/>
-  <circle cx="1217" cy="512" r="4" fill="#CBD5E1"/>
-  <circle cx="1247" cy="512" r="4" fill="#CBD5E1"/>
+  <!-- ═══════════ Remote Clusters container (full width) ═══════════ -->
+  <rect x="20" y="700" width="1360" height="90" rx="16" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <rect x="40" y="684" width="180" height="32" rx="8" fill="#334155"/>
+  <text x="130" y="705" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">REMOTE CLUSTERS</text>
 
-  <!-- ═══════════ Footer ═══════════ -->
-  <g filter="url(#sh)"><rect x="20" y="565" width="1360" height="56" rx="12" fill="#0F172A"/></g>
-  <text x="44" y="588" font-size="14px" font-weight="700" fill="white">Fleet is opt-in</text>
-  <text x="44" y="608" font-size="12.5px" fill="#E2E8F0">Disabled by default (<tspan font-family="monospace">fleet.enabled: true</tspan>) — zero regression for single-cluster deployments</text>
-  <rect x="1220" y="579" width="140" height="26" rx="6" fill="rgba(255,255,255,0.15)"/>
-  <text x="1290" y="596" text-anchor="middle" font-size="12px" font-weight="600" fill="white">v1.6 · ADR-068</text>
+  <line x1="560" y1="660" x2="190" y2="722" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="630" y1="660" x2="530" y2="722" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="770" y1="660" x2="870" y2="722" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <line x1="840" y1="660" x2="1210" y2="722" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+
+  <rect x="166" y="722" width="48" height="48" rx="10" fill="#334155"/>
+  <use href="#hexCluster" x="172" y="728" width="36" height="36"/>
+  <text x="190" y="782" text-anchor="middle" font-size="12px" font-weight="700" fill="#0F172A">Cluster A</text>
+
+  <rect x="506" y="722" width="48" height="48" rx="10" fill="#334155"/>
+  <use href="#hexCluster" x="512" y="728" width="36" height="36"/>
+  <text x="530" y="782" text-anchor="middle" font-size="12px" font-weight="700" fill="#0F172A">Cluster B</text>
+
+  <rect x="846" y="722" width="48" height="48" rx="10" fill="#334155"/>
+  <use href="#hexCluster" x="852" y="728" width="36" height="36"/>
+  <text x="870" y="782" text-anchor="middle" font-size="12px" font-weight="700" fill="#0F172A">Cluster C</text>
+
+  <circle cx="1198" cy="740" r="3.2" fill="#94A3B8"/>
+  <circle cx="1210" cy="740" r="3.2" fill="#94A3B8"/>
+  <circle cx="1222" cy="740" r="3.2" fill="#94A3B8"/>
+  <text x="1210" y="782" text-anchor="middle" font-size="11.5px" fill="#64748B">100s more</text>
+
+  <!-- ═══════════ Legend + note ═══════════ -->
+  <g>
+    <line x1="1060" y1="100" x2="1090" y2="100" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
+    <text x="1098" y="104" font-size="12px" fill="#374151">reads</text>
+
+    <line x1="1060" y1="128" x2="1090" y2="128" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
+    <text x="1098" y="132" font-size="12px" fill="#374151">reads + writes</text>
+
+    <line x1="1060" y1="156" x2="1090" y2="156" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
+    <text x="1098" y="160" font-size="12px" fill="#374151">auth / token</text>
+
+    <line x1="1060" y1="184" x2="1090" y2="184" stroke="#67E8F9" stroke-width="1.4" stroke-dasharray="4,3" marker-end="url(#ar)"/>
+    <text x="1098" y="188" font-size="12px" fill="#374151">scope check</text>
+  </g>
+
+  <rect x="1050" y="70" width="330" height="150" rx="12" fill="none" stroke="#E2E8F0" stroke-width="1.5"/>
+  <text x="1070" y="52" font-size="12px" font-weight="700" fill="#64748B">LEGEND</text>
+
+  <text x="1050" y="250" font-size="12.5px" fill="#64748B">Fleet is opt-in (<tspan font-family="monospace">fleet.enabled: true</tspan>),</text>
+  <text x="1050" y="270" font-size="12.5px" fill="#64748B">disabled by default — zero regression</text>
+  <text x="1050" y="290" font-size="12.5px" fill="#64748B">for single-cluster deployments.</text>
+  <text x="1050" y="316" font-size="11.5px" font-weight="600" fill="#94A3B8">v1.6 · ADR-068</text>
 </svg>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -49,7 +49,7 @@
   <rect x="40" y="30" width="150" height="32" rx="8" fill="#0F172A"/>
   <text x="115" y="51" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">HUB CLUSTER</text>
 
-  <!-- Thanos (metrics, informational — no direct call arrow) -->
+  <!-- Thanos (feeds Gateway with alerts carrying the cluster label) -->
   <rect x="69" y="100" width="52" height="52" rx="12" fill="#0E7490"/>
   <use href="#thanosLogo" x="80" y="111" width="30" height="30"/>
   <text x="95" y="168" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Thanos</text>
@@ -74,9 +74,15 @@
   <text x="955" y="168" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">API Frontend</text>
   <text x="955" y="182" text-anchor="middle" font-size="10.5px" fill="#64748B">interactive entry</text>
 
-  <!-- entry arrows: Gateway and API Frontend both create RemediationRequest into the engine -->
+  <!-- Thanos -> Gateway: alerts carrying the cluster label (matches the detailed Mermaid flowchart) -->
+  <line x1="121" y1="126" x2="204" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
+  <text x="162" y="116" text-anchor="middle" font-size="9.5px" fill="#64748B">alerts</text>
+
+  <!-- entry arrows: Gateway and API Frontend both WRITE - they create RemediationRequest, not read -->
   <line x1="256" y1="126" x2="450" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
+  <text x="353" y="116" text-anchor="middle" font-size="9.5px" fill="#64748B">creates RemediationRequest</text>
   <line x1="929" y1="126" x2="730" y2="126" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
+  <text x="830" y="116" text-anchor="middle" font-size="9.5px" fill="#64748B">creates RemediationRequest</text>
 
   <!-- Scope Check (positioned so Gateway's and the Engine's check-arrows are equal length) -->
   <rect x="320" y="280" width="52" height="52" rx="12" fill="#0E7490"/>
@@ -105,10 +111,10 @@
   <path d="M676,306 L712,306 L712,452" fill="none" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
   <text x="718" y="380" font-size="10px" fill="#A78BFA">validates token</text>
 
-  <!-- boundary arrows: Hub Cluster -> MCP Gateway (straight, vertical) -->
-  <line x1="440" y1="408" x2="440" y2="452" stroke="#94A3B8" stroke-width="2" marker-end="url(#ar)"/>
+  <!-- boundary arrows: Hub Cluster <-> MCP Gateway (straight, vertical). Double-headed: MCP tool calls are request/response, results flow back up. -->
+  <line x1="440" y1="408" x2="440" y2="452" stroke="#94A3B8" stroke-width="2" marker-start="url(#ar)" marker-end="url(#ar)"/>
   <text x="455" y="434" font-size="12px" fill="#64748B">reads (6 services)</text>
-  <line x1="590" y1="408" x2="590" y2="452" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
+  <line x1="590" y1="408" x2="590" y2="452" stroke="#D97706" stroke-width="3" marker-start="url(#arw)" marker-end="url(#arw)"/>
   <text x="605" y="434" font-size="12px" font-weight="600" fill="#B45309">+ writes (workflow execution)</text>
 
   <!-- ═══════════ MCP Gateway (centered under the Hub Cluster container, x 20-1030 → center 525) ═══════════ -->
@@ -124,10 +130,13 @@
   <rect x="40" y="596" width="180" height="32" rx="8" fill="#334155"/>
   <text x="130" y="617" text-anchor="middle" font-size="12px" font-weight="700" fill="white" letter-spacing="0.5">REMOTE CLUSTERS</text>
 
-  <!-- straight vertical drops: each card is centered directly under its MCP Gateway source point -->
-  <line x1="275" y1="552" x2="275" y2="636" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="525" y1="552" x2="525" y2="636" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
-  <line x1="775" y1="552" x2="775" y2="636" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ar)"/>
+  <!-- straight vertical drops: each card is centered directly under its MCP Gateway source point.
+       Amber (reads + writes): the Gateway is a shared boundary, so every fan-out arrow carries the
+       combined superset (6 services' reads + workflow execution's writes) to that cluster's MCP server.
+       Double-headed: tool-call results flow back up through the same path. -->
+  <line x1="275" y1="552" x2="275" y2="636" stroke="#D97706" stroke-width="2.4" marker-start="url(#arw)" marker-end="url(#arw)"/>
+  <line x1="525" y1="552" x2="525" y2="636" stroke="#D97706" stroke-width="2.4" marker-start="url(#arw)" marker-end="url(#arw)"/>
+  <line x1="775" y1="552" x2="775" y2="636" stroke="#D97706" stroke-width="2.4" marker-start="url(#arw)" marker-end="url(#arw)"/>
 
   <!-- Cluster A -->
   <g filter="url(#sh)"><rect x="180" y="636" width="190" height="126" rx="12" fill="white"/></g>
@@ -157,11 +166,11 @@
   <rect x="20" y="776" width="1010" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="1.5"/>
 
   <g>
-    <line x1="50" y1="810" x2="74" y2="810" stroke="#94A3B8" stroke-width="1.8" marker-end="url(#ar)"/>
-    <text x="82" y="814" font-size="12px" fill="#374151">reads</text>
+    <line x1="50" y1="810" x2="74" y2="810" stroke="#94A3B8" stroke-width="1.8" marker-start="url(#ar)" marker-end="url(#ar)"/>
+    <text x="82" y="814" font-size="12px" fill="#374151">reads (call + response)</text>
 
-    <line x1="300" y1="810" x2="324" y2="810" stroke="#D97706" stroke-width="3" marker-end="url(#arw)"/>
-    <text x="332" y="814" font-size="12px" fill="#374151">reads + writes</text>
+    <line x1="330" y1="810" x2="354" y2="810" stroke="#D97706" stroke-width="3" marker-start="url(#arw)" marker-end="url(#arw)"/>
+    <text x="362" y="814" font-size="12px" fill="#374151">reads + writes</text>
 
     <line x1="550" y1="810" x2="574" y2="810" stroke="#A78BFA" stroke-width="1.3" stroke-dasharray="4,3" marker-end="url(#ard)"/>
     <text x="582" y="814" font-size="12px" fill="#374151">auth / token</text>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -94,7 +94,8 @@
   <path d="M346,288 L362,294 v14 c0,10 -8,16 -16,20 c-8,-4 -16,-10 -16,-20 v-14 z" fill="none" stroke="white" stroke-width="2.2"/>
   <polyline points="338,304 345,311 356,298" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
   <text x="346" y="348" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Scope Check</text>
-  <text x="346" y="362" text-anchor="middle" font-size="10.5px" fill="#64748B">FMC (default) · bring your own</text>
+  <text x="346" y="362" text-anchor="middle" font-size="10.5px" fill="#64748B">against fleet control plane</text>
+  <text x="346" y="376" text-anchor="middle" font-size="10.5px" fill="#64748B">FMC (default) · bring your own</text>
 
   <!-- OAuth2 -->
   <rect x="624" y="280" width="52" height="52" rx="12" fill="#475569" stroke="#94A3B8" stroke-width="1.4" stroke-dasharray="3,3"/>

--- a/docs/assets/images/fleet-architecture.svg
+++ b/docs/assets/images/fleet-architecture.svg
@@ -94,7 +94,7 @@
   <path d="M346,288 L362,294 v14 c0,10 -8,16 -16,20 c-8,-4 -16,-10 -16,-20 v-14 z" fill="none" stroke="white" stroke-width="2.2"/>
   <polyline points="338,304 345,311 356,298" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
   <text x="346" y="348" text-anchor="middle" font-size="12.5px" font-weight="700" fill="#0F172A">Scope Check</text>
-  <text x="346" y="362" text-anchor="middle" font-size="10.5px" fill="#64748B">FMC (default) · ACM</text>
+  <text x="346" y="362" text-anchor="middle" font-size="10.5px" fill="#64748B">FMC (default) · bring your own</text>
 
   <!-- OAuth2 -->
   <rect x="624" y="280" width="52" height="52" rx="12" fill="#475569" stroke="#94A3B8" stroke-width="1.4" stroke-dasharray="3,3"/>


### PR DESCRIPTION
## Summary

The Fleet architecture mermaid flowchart had many crossing/dotted edges and was hard to scan visually. Replaced it with a card-based SVG diagram matching the homepage's existing visual language (`docs/assets/images/pipeline-phases.svg`: colored header cards, drop shadows, rounded corners, consistent per-service colors).

The new diagram groups the same information into three readable bands:
1. **Management-cluster services** — Signal Entry (Thanos → Gateway), Orchestration (Remediation Orchestrator), and a roster of all 7 Fleet-dependent services as color-coded pills
2. **Scope Check + MCP Gateway + OAuth2 Provider** — the pluggable scope backend, the MCP Gateway as the prominent boundary, and the external OAuth2 identity provider
3. **Remote clusters** — per-cluster K8s MCP Server + remediation capability, plus a "+ up to 100s more" card to convey scale

Plus a footer banner restating that Fleet is opt-in and disabled by default.

The original mermaid diagram is preserved, collapsed under a `??? note` details block, for readers who want the exact edge-level call graph (every scope-check and MCP Gateway read/write edge individually).

## Test plan

- [x] `mkdocs build --strict` passes with no new warnings/errors
- [x] Rendered the SVG standalone via `rsvg-convert` at multiple resolutions to check for text overlap/collisions